### PR TITLE
Fixes mimicgeom / total mass issue with kinbody reader.

### DIFF
--- a/plugins/oderave/odephysics.h
+++ b/plugins/oderave/odephysics.h
@@ -359,7 +359,9 @@ The possible properties that can be set are: ";
         force = Vector(0,0,0);
         torque = Vector(0,0,0);
         if( body ) {
+            //Loop over all joints in the parent body
             FOREACHC(itjoint,plink->GetParent()->GetJoints()) {
+                //if this joint's parent or child body is the current body
                 if( (*itjoint)->GetHierarchyParentLink() == plink || (*itjoint)->GetHierarchyChildLink() == plink ) {
                     dJointID joint = _odespace->GetJoint(*itjoint);
                     dJointFeedback* feedback = dJointGetFeedback( joint );

--- a/src/libopenrave-core/ravep.h
+++ b/src/libopenrave-core/ravep.h
@@ -110,6 +110,7 @@ enum MassType
 {
     MT_None = 0,
     MT_MimicGeom,
+    MT_MimicGeomMass,
     MT_Box,
     MT_BoxMass,         // use total mass instead of density
     MT_Sphere,


### PR DESCRIPTION
The current version of the Kinbody XML reader assumes that when "mimicgeom" is specified as the mass type, the user has specified density (not total mass).  Setting a total mass has no effect because the fTotalMass property is not read in this mode.  My fix adds a new enum flag, which allows the code to correctly use either totalmass or density.

The method:
1.  Calculate each geom's mass assuming a dummy density (1000kg/m^3)
2.  Add all geom masses to find a total dummy mass
3.  Scale each geom's mass by the ratio of the assigned mass over the dummy mass.
4.  Sum and store the totalmass property.

It would likely be more elegant or simple to work directly with volume,
but this method was quick and easy given the existing code.  Hope this helps!

-Rob
