### PR TITLE
Small tweaks to simulation loop for pseudo-realtime

### DIFF
--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -2129,19 +2129,19 @@ protected:
                     //Hardcoded tolerance for now
                     const int tol=2;
                     if( _bRealTime ) {
-                        if(( sleeptime > deltasimtime/tol) &&( sleeptime > 2000) ) {
+                        if(( sleeptime > deltasimtime/tol) &&( sleeptime > 1000) ) {
                             lockenv.reset();
                             // sleep for less time since sleep isn't accurate at all and we have a 7ms buffer
-                            int actual_sleep=max((int)sleeptime,1000);
+                            int actual_sleep=max((int)sleeptime*6/8,1000);
                             boost::this_thread::sleep (boost::posix_time::microseconds(actual_sleep));
-                            RAVELOG_INFO("sleeptime ideal %d, actually slept: %d\n",(int)sleeptime,(int)actual_sleep);
+                            //RAVELOG_INFO("sleeptime ideal %d, actually slept: %d\n",(int)sleeptime,(int)actual_sleep);
                             nLastSleptTime = utils::GetMicroTime();
                             //Since already slept this cycle, wait till next time to sleep.
                             bNeedSleep = false;
                         }
-                        else if( sleeptime < -deltasimtime/tol ) {
+                        else if( sleeptime < -deltasimtime/tol && ( sleeptime < -1000) ) {
                             // simulation is getting late, so catch up (doesn't happen often in light loads)
-                            RAVELOG_INFO("sim catching up: %d\n",-(int)sleeptime);
+                            //RAVELOG_INFO("sim catching up: %d\n",-(int)sleeptime);
                             _nSimStartTime += -sleeptime;     //deltasimtime;
                         }
                     }
@@ -2149,7 +2149,7 @@ protected:
                         nLastSleptTime = utils::GetMicroTime();
                     }
 
-                    RAVELOG_INFOA("sim: %f, real: %f\n",_nCurSimTime*1e-6f,(utils::GetMicroTime()-_nSimStartTime)*1e-6f);
+                    //RAVELOG_INFOA("sim: %f, real: %f\n",_nCurSimTime*1e-6f,(utils::GetMicroTime()-_nSimStartTime)*1e-6f);
                 }
             }
 
@@ -2176,6 +2176,7 @@ protected:
                 }
             }
 
+            //TODO: Verify if this always has to happen even if thread slept in RT if statement above
             lockenv.reset(); // always release at the end of loop to give other threads time
             if( bNeedSleep ) {
                 boost::this_thread::sleep(boost::posix_time::milliseconds(1));


### PR DESCRIPTION
I made the sleep time corrections in the main simulation loop a little more aggressive, and removed a redundant sleep command. On linux with boost, the timing accuracy was much tighter on a non-RT system, with 99% of delta-T falling within 1-3% of the desired actual timestep.  Obviously the accuracy depends on CPU load and other threads, and I'm not sure how windows' coarse timing will handle it, but for ubuntu these small changes are a nice improvement.
