### PR TITLE
python init: catch AttributeError in loadstable

### DIFF
--- a/python/__init__.py.in
+++ b/python/__init__.py.in
@@ -31,7 +31,7 @@ if platform.startswith('win') or system().lower() == 'windows':
 else:
     try:
         openravepy_currentversion = loadstable(__openravepy_version__)
-    except NameError:
+    except (NameError, AttributeError):
         openravepy_currentversion = loadlatest()
 
 if openravepy_currentversion is not None:


### PR DESCRIPTION
This allows loading openrave if the version is removed from the library
name (i.e. the library name is _openravepy_ instead of _openravepy_0_9)

I'm currently working on a Fedora package for openrave. Since version numbers should be removed from the library names (as discussed at https://bugzilla.redhat.com/show_bug.cgi?id=674008 ), this patch is needed to make openrave.py work. If the version name is omitted, the current version of openrave.py throws an AttributeError because it tries to load _openravepy_0_9 instead of _openravepy_. Catching the error and using loadlatest() works as expected.
