### PR TITLE
IKFast compatibility with sympy-0.7.4

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 # ikfast component
 # install previous versions of ikfast also since don't know which sympy versino user will install
-install(FILES ikfast.py ikfast_sympy0_6.py ikfast_sympy0_7_4.py DESTINATION ${OPENRAVEPY_VER_INSTALL_DIR} PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ COMPONENT ${COMPONENT_PREFIX}ikfast)
+install(FILES ikfast.py ikfast_sympy0_6.py DESTINATION ${OPENRAVEPY_VER_INSTALL_DIR} PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ COMPONENT ${COMPONENT_PREFIX}ikfast)
 install(FILES ikfast.h ikfast_generator_cpp.py ikfast_generator_cpp_sympy0_6.py DESTINATION ${OPENRAVEPY_VER_INSTALL_DIR} COMPONENT ${COMPONENT_PREFIX}ikfast)
 if( NOT OPENRAVE_USE_LOCAL_SYMPY )
   set(IKFAST_USES python-sympy python-mpmath)


### PR DESCRIPTION
Related to https://github.com/rdiankov/openrave/issues/287

It works for us now, Fedora 20 with sympy-0.7.4, tested with katana-arm, both TranslationDirection5D and Tranform6D (model with a 6th dummy-link).

I couldn't figure out why the Pow._eval_subs method had to be modified for IKFast with sympy-0.7.1, the unmodified version of sympy-0.7.4 works fine. However, I guess you have better knowledge about that and can modify again if necessary.

This might also work with sympy-0.7.3 or sympy-0.7.2, haven't tested it yet.
