### PR TITLE
Switched to InstallSymlink for creating symlinks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ include(CheckCXXSourceCompiles)
 include(CheckCXXSourceRuns)
 include(CheckCXXCompilerFlag)
 include(CheckTypeSize)
+include(InstallSymlink)
 
 find_package(PkgConfig) # pkg_check_modules
 
@@ -788,7 +789,7 @@ endif()
 if( OPT_BUILD_PACKAGE_DEFAULT AND OPENRAVE_BIN_SUFFIX )
   # create all the directories ahead of time, or otherwise WORKING_DIRECTORY will not work
   install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory \${CMAKE_INSTALL_PREFIX}/bin COMMAND ${CMAKE_COMMAND} -E make_directory \${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig COMMAND ${CMAKE_COMMAND} -E make_directory \${CMAKE_INSTALL_PREFIX}/${BASH_COMPLETION_DIR})" COMPONENT openrave)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink openrave${OPENRAVE_BIN_SUFFIX}-config openrave-config WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/bin)" COMPONENT openrave)
+  InstallSymlink(${CMAKE_INSTALL_PREFIX}/bin/openrave${OPENRAVE_BIN_SUFFIX}-config ${CMAKE_INSTALL_PREFIX}/bin/openrave-config)
 endif()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/openrave-config.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/openrave-config.cmake" IMMEDIATE @ONLY)
@@ -804,13 +805,14 @@ if( UNIX OR CYGWIN)
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/openrave-core.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/openrave${OPENRAVE_BIN_SUFFIX}-core.pc" @ONLY IMMEDIATE)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/openrave${OPENRAVE_BIN_SUFFIX}-core.pc" DESTINATION lib${LIB_SUFFIX}/pkgconfig COMPONENT ${COMPONENT_PREFIX}dev)
   if( OPT_BUILD_PACKAGE_DEFAULT AND OPENRAVE_BIN_SUFFIX )
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink openrave${OPENRAVE_BIN_SUFFIX}.pc openrave.pc WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig)" COMPONENT openrave)
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink openrave${OPENRAVE_BIN_SUFFIX}-core.pc openrave-core.pc WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig)" COMPONENT openrave)
+    InstallSymlink(${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig/openrave${OPENRAVE_BIN_SUFFIX}.pc ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig/openrave.pc)
+    InstallSymlink(${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig/openrave${OPENRAVE_BIN_SUFFIX}-core.pc ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig/openrave-core.pc)
+
     if( BASH_COMPLETION_DIR )
-      install(CODE "get_filename_component(BASH_COMPLETION_ABSOLUTE_DIR \${CMAKE_INSTALL_PREFIX}/${BASH_COMPLETION_DIR} ABSOLUTE)" COMPONENT openrave)
-      install(CODE "get_filename_component(BASH_COMPLETION_SHARE_DIR \${CMAKE_INSTALL_PREFIX}/${OPENRAVE_SHARE_DIR} ABSOLUTE)" COMPONENT openrave)
-      install(CODE "file(RELATIVE_PATH BASH_COMPLETION_RELATIVE_DIR \${BASH_COMPLETION_ABSOLUTE_DIR} \${BASH_COMPLETION_SHARE_DIR})" COMPONENT openrave)
-      install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \${BASH_COMPLETION_RELATIVE_DIR}/openrave_completion.bash openrave_completion.bash WORKING_DIRECTORY \${BASH_COMPLETION_ABSOLUTE_DIR})" COMPONENT openrave)
+      get_filename_component(BASH_COMPLETION_ABSOLUTE_DIR ${CMAKE_INSTALL_PREFIX}/${BASH_COMPLETION_DIR} ABSOLUTE)
+      get_filename_component(BASH_COMPLETION_SHARE_DIR ${CMAKE_INSTALL_PREFIX}/${OPENRAVE_SHARE_DIR} ABSOLUTE)
+      file(RELATIVE_PATH BASH_COMPLETION_RELATIVE_DIR ${BASH_COMPLETION_ABSOLUTE_DIR} ${BASH_COMPLETION_SHARE_DIR})
+      InstallSymlink(${BASH_COMPLETION_RELATIVE_DIR}/openrave_completion.bash ${BASH_COMPLETION_ABSOLUTE_DIR}/openrave_completion.bash)
     endif()
   endif()
   # don't need symlinks

--- a/modules-cmake/InstallSymlink.cmake
+++ b/modules-cmake/InstallSymlink.cmake
@@ -1,0 +1,41 @@
+# This macro can be used to install symlinks, which turns out to be
+# non-trivial due to CMake version differences and limitations on how
+# files can be installed when building binary packages.
+#
+# The rule for binary packaging is that files (including symlinks) must
+# be installed with the standard CMake install() macro.
+#
+# The rule for non-binary packaging is that CMake 2.6 cannot install()
+# symlinks, but can create the symlink at install-time via scripting.
+# Though, we assume that CMake 2.6 isn't going to be used to generate
+# packages because versions later than 2.8.3 are superior for that purpose.
+#
+#   _filepath: the absolute path to the file to symlink
+#   _sympath: absolute path of the installed symlink
+
+macro(InstallSymlink _filepath _sympath)
+    get_filename_component(_symname ${_sympath} NAME)
+    get_filename_component(_installdir ${_sympath} PATH)
+
+    if (BINARY_PACKAGING_MODE)
+        execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink
+                        ${_filepath}
+                        ${CMAKE_CURRENT_BINARY_DIR}/${_symname})
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${_symname}
+                DESTINATION ${_installdir})
+    else ()
+        # scripting the symlink installation at install time should work
+        # for CMake 2.6.x and 2.8.x
+        install(CODE "
+            if (\"\$ENV{DESTDIR}\" STREQUAL \"\")
+                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+                                ${_filepath}
+                                ${_installdir}/${_symname})
+            else ()
+                execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+                                ${_filepath}
+                                \$ENV{DESTDIR}/${_installdir}/${_symname})
+            endif ()
+        ")
+    endif ()
+endmacro(InstallSymlink)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -37,10 +37,14 @@ set(CPACK_COMPONENT_${COMPONENT_PREFIX_UPPER}PYTHON_SUGGESTS ipython python-qt4 
 
 if( OPT_BUILD_PACKAGE_DEFAULT AND OPENRAVE_BIN_SUFFIX )
   install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory \${CMAKE_INSTALL_PREFIX}/${OPENRAVEPY_INSTALL_DIR})" COMPONENT openrave)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink openrave${OPENRAVE_BIN_SUFFIX}.py openrave.py WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/bin)" COMPONENT openrave)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink openrave${OPENRAVE_BIN_SUFFIX}-robot.py openrave-robot.py WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/bin)" COMPONENT openrave)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink openrave${OPENRAVE_BIN_SUFFIX}-createplugin.py openrave-createplugin.py WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/bin)" COMPONENT openrave)
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${OPENRAVEPY_VER_NAME} _openravepy_ WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/${OPENRAVEPY_INSTALL_DIR})" COMPONENT openrave)
+  InstallSymlink(${CMAKE_INSTALL_PREFIX}/bin/openrave${OPENRAVE_BIN_SUFFIX}.py
+                 ${CMAKE_INSTALL_PREFIX}/bin/openrave.py)
+  InstallSymlink(${CMAKE_INSTALL_PREFIX}/bin/openrave${OPENRAVE_BIN_SUFFIX}-robot.py
+                 ${CMAKE_INSTALL_PREFIX}/bin/openrave-robot.py)
+  InstallSymlink(${CMAKE_INSTALL_PREFIX}/bin/openrave${OPENRAVE_BIN_SUFFIX}-createplugin.py
+                 ${CMAKE_INSTALL_PREFIX}/bin/openrave-createplugin.py)
+  InstallSymlink(${CMAKE_INSTALL_PREFIX}/${OPENRAVEPY_INSTALL_DIR}/${OPENRAVEPY_VER_NAME}
+                 ${CMAKE_INSTALL_PREFIX}/${OPENRAVEPY_INSTALL_DIR}/_openravepy_)
 endif()
 
 # ikfast component

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,7 +93,7 @@ target_link_libraries (openrave ${Boost_DATE_TIME_LIBRARY} ${Boost_THREAD_LIBRAR
 
 install(TARGETS openrave DESTINATION bin COMPONENT ${COMPONENT_PREFIX}base)
 if( OPT_BUILD_PACKAGE_DEFAULT )
-  install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink openrave${OPENRAVE_BIN_SUFFIX} openrave WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/bin)" COMPONENT openrave)
+  InstallSymlink(${CMAKE_INSTALL_PREFIX}/bin/openrave${OPENRAVE_BIN_SUFFIX} ${CMAKE_INSTALL_PREFIX}/bin/openrave)
 endif()
 
 # always extract the models since we don't know when models.tgz has been changed

--- a/src/libopenrave/CMakeLists.txt
+++ b/src/libopenrave/CMakeLists.txt
@@ -35,11 +35,6 @@ if( MSVC )
 else()
   install(TARGETS libopenrave EXPORT openrave-targets DESTINATION lib${LIB_SUFFIX} COMPONENT ${COMPONENT_PREFIX}base)
 endif()
-#if( OPENRAVE_LIBRARY_SUFFIX AND NOT WIN32 )
-#  # create a symlink to the so for easier use..
-#  add_custom_command(TARGET libopenrave POST_BUILD COMMAND ${CMAKE_COMMAND} -E create_symlink $<TARGET_FILE_NAME:libopenrave0.3> $<TARGET_FILE_NAME:libopenrave> )
-#  install(FILES libopenrave.so DESTINATION lib${LIB_SUFFIX} COMPONENT ${COMPONENT_PREFIX}dev)
-#endif()
 
 if( OPT_CBINDINGS )
   add_library(libopenrave_c SHARED libopenrave_c.cpp)


### PR DESCRIPTION
OpenRAVE currently creates symlinks with an install(CODE ...) directive during the install step. Symlinks created in this way are not packaged correctly when debhelper to build a Debian package. I switched to the [InstallSymlink](https://github.com/bro/cmake/blob/master/InstallSymlink.cmake) macro which properly handles this case. This script is part of [Bro](http://www.bro.org/) and, thus, is is covered by a [3-clause BSD license](https://github.com/bro/bro/blob/master/COPYING).
