### PR TITLE
Added geometry groups to the KinBody XML

### DIFF
--- a/include/openrave/xmlreaders.h
+++ b/include/openrave/xmlreaders.h
@@ -108,12 +108,17 @@ public:
     inline bool IsOverwriteTransparency() const {
         return _bOverwriteTransparency;
     }
+
+    inline const std::string &GetGroupName() const {
+        return _sGroupName;
+    }
 protected:
     KinBody::GeometryInfoPtr _pgeom;
     std::stringstream _ss;
     BaseXMLReaderPtr _pcurreader;
 
     bool _bOverwriteDiffuse, _bOverwriteAmbient, _bOverwriteTransparency;
+    std::string _sGroupName;
 };
 
 typedef boost::shared_ptr<GeometryInfoReader> GeometryInfoReaderPtr;

--- a/src/libopenrave-core/xmlreaders-core.cpp
+++ b/src/libopenrave-core/xmlreaders-core.cpp
@@ -935,6 +935,15 @@ public:
                 xmlreaders::GeometryInfoReaderPtr geomreader = boost::dynamic_pointer_cast<xmlreaders::GeometryInfoReader>(_pcurreader);
                 if( !!geomreader ) {
                     KinBody::GeometryInfoPtr info = geomreader->GetGeometryInfo();
+
+                    // geometry is not in the default group, so we add it to the LinkInfo without instantiating it
+                    string groupname = geomreader->GetGroupName();
+                    if( groupname != "self" ) {
+                        _plink->_info._mapExtraGeometries[groupname].push_back(info);
+                        _pcurreader.reset();
+                        return false;
+                    }
+
                     TransformMatrix tm(info->_t); tm.trans = Vector();
                     TransformMatrix tminv = tm.inverse();
                     tm.m[0] *= _vScaleGeometry.x; tm.m[1] *= _vScaleGeometry.x; tm.m[2] *= _vScaleGeometry.x;

--- a/src/libopenrave/xmlreaders.cpp
+++ b/src/libopenrave/xmlreaders.cpp
@@ -179,6 +179,7 @@ void TrajectoryReader::characters(const std::string& ch)
 GeometryInfoReader::GeometryInfoReader(KinBody::GeometryInfoPtr pgeom, const AttributesList& atts) : _pgeom(pgeom)
 {
     _bOverwriteDiffuse = _bOverwriteAmbient = _bOverwriteTransparency = false;
+    _sGroupName = "self";
     string type;
     bool bVisible = true, bModifiable = true;
     FOREACHC(itatt,atts) {
@@ -191,6 +192,9 @@ GeometryInfoReader::GeometryInfoReader(KinBody::GeometryInfoPtr pgeom, const Att
         }
         else if( itatt->first == "modifiable" ) {
             bModifiable = !(_stricmp(itatt->second.c_str(), "false") == 0 || itatt->second=="0");
+        }
+        else if( itatt->first == "group" && !itatt->second.empty() ) {
+            _sGroupName = itatt->second;
         }
     }
 


### PR DESCRIPTION
There is now an optional "group" attribute that can be added to <Geom>
elements. If this tag is specified, the geometry is added to a separate
geometry group in the LinkInfo struct. This geometry can be queried or
applied at runtime just like any other geometry group.

The geometry is created as usual if the "group" attribute is omitted, is empty,
or has the value "self" (the name of the default geometry group)..

This relates to our discussion in #92 and #281.
