### PR TITLE
libopenrave-core: proper linking of libpcrecpp_LIBRARY_DIRS

### DIFF
--- a/src/libopenrave-core/CMakeLists.txt
+++ b/src/libopenrave-core/CMakeLists.txt
@@ -12,7 +12,7 @@ if( libpcrecpp_FOUND )
   set(LIBOPENRAVE_LINK_FLAGS "${LIBOPENRAVE_LINK_FLAGS} ${libpcrecpp_LDFLAGS_OTHER}")
   set(OPENRAVE_CORE_LIBRARIES ${OPENRAVE_CORE_LIBRARIES} ${libpcrecpp_LIBRARIES})
   include_directories(${libpcrecpp_INCLUDE_DIRS})
-  set(OPENRAVE_LINK_DIRS ${OPENRAVE_LINK_DIRS} libpcrecpp_LIBRARY_DIRS)
+  set(OPENRAVE_LINK_DIRS ${OPENRAVE_LINK_DIRS} ${libpcrecpp_LIBRARY_DIRS})
   add_definitions(-DHAVE_PCRECPP)
 endif()
 


### PR DESCRIPTION
Gets rid of the CMake warning on link_directories ("Policy CMP0015 is not set: ...")

It still worked fine for me, because pcre is installed system-wide, so libpcrecpp_LIBRARY_DIRS is either empty or "/usr/lib64" which is included anyway. It might be required for users with local installs of pcre to unconventional paths though.
