### PR TITLE
xmlreaders: Change default alpha value 0.0 -> 1.0

### DIFF
--- a/src/libopenrave/xmlreaders.cpp
+++ b/src/libopenrave/xmlreaders.cpp
@@ -334,10 +334,12 @@ bool GeometryInfoReader::endElement(const std::string& xmlname)
     else if( xmlname == "diffusecolor" ) {
         _bOverwriteDiffuse = true;
         _ss >> _pgeom->_vDiffuseColor.x >> _pgeom->_vDiffuseColor.y >> _pgeom->_vDiffuseColor.z;
+        _pgeom->_vDiffuseColor.w = 1;
     }
     else if( xmlname == "ambientcolor" ) {
         _bOverwriteAmbient = true;
         _ss >> _pgeom->_vAmbientColor.x >> _pgeom->_vAmbientColor.y >> _pgeom->_vAmbientColor.z;
+        _pgeom->_vAmbientColor.w = 1;
     }
     else if( xmlname == "transparency" ) {
         _bOverwriteTransparency = true;


### PR DESCRIPTION
Conversion from OpenRAVE XML to COLLADA makes fully transparent bodies (alpha=0.0).
