### PR TITLE
For tools run during build, use native optimizations. This allows ope…

### DIFF
--- a/3rdparty/crlibm-1.0beta4/CMakeLists.txt
+++ b/3rdparty/crlibm-1.0beta4/CMakeLists.txt
@@ -121,3 +121,6 @@ set(crlibm_SOURCES ${crlibm_SOURCES}
 
 add_library(crlibm STATIC ${crlibm_SOURCES})
 set_target_properties(crlibm PROPERTIES COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS}")
+
+add_library(crlibm-native STATIC ${crlibm_SOURCES})
+set_target_properties(crlibm-native PROPERTIES COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} ${NATIVE_COMPILE_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,6 +377,8 @@ else()
   set(EXTRA_COMPILE_FLAGS "")
 endif()
 
+set(NATIVE_COMPILE_FLAGS "-march=native -mtune=native")
+
 # generate the md5 sum for all OpenRAVE interfaces
 add_subdirectory(cpp-gen-md5)
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/cpp-gen-md5")
@@ -452,6 +454,9 @@ if( OPT_ACCURATEMATH AND NOT MSVC )
     message(STATUS "Using local crlibm")
     add_subdirectory(3rdparty/crlibm-1.0beta4)
     set(CRLIBM_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/crlibm-1.0beta4")
+    set(NATIVE_CRLIBM_LIBRARY crlibm-native)
+  else()
+    set(NATIVE_CRLIBM_LIBRARY crlibm)
   endif()
   set(CRLIBM_FOUND 1)
   set(CRLIBM_LIBRARY crlibm)

--- a/cpp-gen-md5/CMakeLists.txt
+++ b/cpp-gen-md5/CMakeLists.txt
@@ -2,10 +2,14 @@
 add_library(openrave-md5 STATIC md5.c)
 set_target_properties(openrave-md5 PROPERTIES COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS}")
 
+add_library(openrave-md5-native STATIC md5.c)
+set_target_properties(openrave-md5-native PROPERTIES COMPILE_FLAGS "${EXTRA_COMPILE_FLAGS} ${NATIVE_COMPILE_FLAGS}")
+
 add_executable(cpp-gen-md5 cpp_lexer.cpp cpp_lexer_token.cpp md5.c cpp-gen-md5.cpp)
-target_link_libraries(cpp-gen-md5 openrave-md5 ${STDC_LIBRARY})
-add_dependencies(cpp-gen-md5 openrave-md5)
+set_target_properties(cpp-gen-md5 PROPERTIES COMPILE_FLAGS "${NATIVE_COMPILE_FLAGS}")
+target_link_libraries(cpp-gen-md5 openrave-md5-native ${STDC_LIBRARY})
+add_dependencies(cpp-gen-md5 openrave-md5-native)
 
 if( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX )
-  set_target_properties(cpp-gen-md5 PROPERTIES COMPILE_FLAGS "-trigraphs -ftemplate-depth-500")
+  set_target_properties(cpp-gen-md5 PROPERTIES COMPILE_FLAGS "-trigraphs -ftemplate-depth-500 ${NATIVE_COMPILE_FLAGS}")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,8 @@ if( CRLIBM_FOUND )
 
   # check the accuracy of the current math library with crlibm
   add_executable(check_libm_accuracy check_libm_accuracy_main.cpp)
-  target_link_libraries(check_libm_accuracy ${CRLIBM_LIBRARY} ${STDC_LIBRARY})
+  set_target_properties(check_libm_accuracy PROPERTIES COMPILE_FLAGS "${NATIVE_COMPILE_FLAGS}")
+  target_link_libraries(check_libm_accuracy ${NATIVE_CRLIBM_LIBRARY} ${STDC_LIBRARY})
   set(libm_accuracy_results_h "${CMAKE_CURRENT_BINARY_DIR}/libm_accuracy_results.h")
   add_custom_command(TARGET check_libm_accuracy POST_BUILD
     COMMAND check_libm_accuracy ARGS ${libm_accuracy_results_h}


### PR DESCRIPTION
…nrave to be cross compiled.