### PR TITLE
added missing else in openravepy_collisionchecker.cpp and package.xml for catkin workspace

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package>
+  <name>OpenRAVE</name>
+  <version>0.9.0</version>
+  <description>The openrave package</description>
+
+  <maintainer email="todo@todo.todo">todo</maintainer>
+
+  <license>LGPLv3</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/python/bindings/openravepy_collisionchecker.cpp
+++ b/python/bindings/openravepy_collisionchecker.cpp
@@ -289,7 +289,7 @@ public:
                 }
             }
         }
-        {
+        else {
             KinBodyConstPtr pbody = openravepy::GetKinBody(o1);
             if( !!pbody ) {
                 KinBody::LinkConstPtr plink2 = openravepy::GetKinBodyLinkConst(o2);


### PR DESCRIPTION
There was a bug in openravepy_collisionchecker.cpp that caused CheckCollision(link1, link2, report) to crash (exception thrown).

I've also added package.xml so the OpenRAVE can be compiled as a catkin package (isolated).