### PR TITLE
Use -O3 -g3 -DNODEBUG for RelWithDebInfo builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ set(OPENRAVE_EXPORT_CXXFLAGS)
 if( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG)
   set(CMAKE_CXX_FLAGS_OPTIMIZED "-O3 -DNDEBUG -DBOOST_DISABLE_ASSERTS -D_SECURE_SCL=0") # this practically removes all checks making it a very dangerous options to play with
   set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g3 -O3 -DNDEBUG")
   set(CMAKE_CXX_FLAGS_DEBUG "-g3 -D_DEBUG")
 
   # the _GLIBCXX_DEBUG flag is very helpful in bounds checking for vector[] and iterators, however it requires all


### PR DESCRIPTION
OpenRAVE benchmark results shows that -O3 -g3 seems to be safe performance wise, and -DNODEBUG should be used for RelWithDebInfo anyway because it is a release build (just one with symbols).

```
-O3 -DNDEBUG -g3
0.09839437529 0.101434553 0.08361791261   0.08563291468   0.08399659209   0.08559477516
AVG: 0.08977852048

-O3 -DNDEBUG -g
0.09927962162 0.1012524385    0.09756402299   0.09853888489   0.09853888489   0.1054291613
AVG: 0.1001005024

-O3 -DNDEBUG
0.09447302297 0.09964400157   0.1018797029    0.09464305267   0.1002974138    0.1010313388
AVG: 0.09866142211

-O2 -DNDEBUG -g3
0.08984194137 0.09937638789   0.09404396079   0.09296278842   0.09484822676   0.0942838192
AVG: 0.09422618741

-O2 -DNDEBUG -g
0.09823156334 0.09728751704   0.1004633531    0.09419155866   0.09695095196   0.09316166304
AVG: 0.09671443452
```