### PR TITLE
alternative workaround for QTBUG-22829

### DIFF
--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -64,6 +64,9 @@
 #include <fstream>
 #include <sstream>
 
+// QTBUG-22829 alternative workaround
+#ifndef Q_MOC_RUN
+
 #include <boost/version.hpp>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
@@ -79,6 +82,8 @@
 #include <boost/array.hpp>
 #include <boost/multi_array.hpp>
 //#include <boost/cstdint.hpp>
+
+#endif
 
 #if defined(__GNUC__)
 #define RAVE_DEPRECATED __attribute__((deprecated))

--- a/plugins/qtcoinrave/CMakeLists.txt
+++ b/plugins/qtcoinrave/CMakeLists.txt
@@ -18,8 +18,7 @@ if (QT_FOUND AND QT_QTCORE_FOUND AND QT_QTGUI_FOUND AND SOQT_LIBRARY_FOUND AND C
   link_directories(${OPENRAVE_LINK_DIRS} ${SOQT_LINK_DIRS} ${COIN_LINK_DIRS})
 
   # generate rules for building source files from the resources
-  # BOOST_TT_HAS_OPERATOR_HPP_INCLUDED: https://bugreports.qt-project.org/browse/QTBUG-22829
-  set(QTCOIN_MOCS qtcoinviewer.h OPTIONS -DBOOST_TT_HAS_OPERATOR_HPP_INCLUDED)
+  set(QTCOIN_MOCS qtcoinviewer.h)
   include(${QT_USE_FILE})
   qt4_wrap_cpp(MOC_OUTPUT_FILES ${QTCOIN_MOCS})
 

--- a/plugins/qtcoinrave/qtcoin.h
+++ b/plugins/qtcoinrave/qtcoin.h
@@ -22,12 +22,15 @@
 
 // include boost for vc++ only (to get typeof working)
 #ifdef _MSC_VER
+// QTBUG-22829 alternative workaround
+#ifndef Q_MOC_RUN
 #include <boost/typeof/std/string.hpp>
 #include <boost/typeof/std/vector.hpp>
 #include <boost/typeof/std/list.hpp>
 #include <boost/typeof/std/map.hpp>
 #include <boost/typeof/std/set.hpp>
 #include <boost/typeof/std/string.hpp>
+#endif
 
 #define FOREACH(it, v) for(BOOST_TYPEOF(v) ::iterator it = (v).begin(); it != (v).end(); (it)++)
 #define FOREACH_NOINC(it, v) for(BOOST_TYPEOF(v) ::iterator it = (v).begin(); it != (v).end(); )
@@ -58,6 +61,9 @@
 #include <iostream>
 #include <sstream>
 
+// QTBUG-22829 alternative workaround
+#ifndef Q_MOC_RUN
+
 #include <boost/bind.hpp>
 #include <boost/assert.hpp>
 #include <boost/thread/condition.hpp>
@@ -65,6 +71,8 @@
 #include <boost/array.hpp>
 #include <boost/function.hpp>
 #include <boost/algorithm/string.hpp>
+
+#endif
 
 using namespace OpenRAVE;
 using namespace std;


### PR DESCRIPTION
alternative workaround for QTBUG-22829
The old one no longer works with boost 1.57