### PR TITLE
Enable Doxygen tagfile generation

### DIFF
--- a/docs/Doxyfile.html
+++ b/docs/Doxyfile.html
@@ -203,7 +203,7 @@ SKIP_FUNCTION_MACROS   = YES
 # Configuration::additions related to external references   
 #---------------------------------------------------------------------------
 TAGFILES               = 
-GENERATE_TAGFILE       = 
+GENERATE_TAGFILE       = coreapi.tag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 PERL_PATH              = /usr/bin/perl


### PR DESCRIPTION
I'm working on an external project (a planner) which depends on OpenRAVE, and I'm creating documentation for it using Doxygen. Doxygen supports linking to external projects using [tag files](http://www.stack.nl/~dimitri/doxygen/manual/external.html). A tag file is an XML file which lists the files/classes/members documented by the project. It would be really sweet if OpenRAVE could generate its tag file when the documentation is built (using the `GENERATE_TAGFILE =` Doxygen config option as in this pull request), and the resulting file hosted somewhere alongside the documentation (perhaps at http://openrave.org/docs/latest_stable/coreapi.tag or something?). This would allow my documentation to link directly to the documentation of OpenRAVE's classes.

I realize that the current documentation hosted at http://openrave.org/docs/latest_stable/coreapihtml/ hasn't been updated very recently, but hopefully with this change, the tag file will be generated as well whenever it's updated.