### PR TITLE
Problem with drawarrow -- wrong color / segfault

### DIFF
--- a/plugins/qtcoinrave/qtcoinviewer.cpp
+++ b/plugins/qtcoinrave/qtcoinviewer.cpp
@@ -1811,6 +1811,13 @@ void* QtCoinViewer::_drawarrow(SoSwitch* handle, const RaveVector<float>& p1, co
         RAVELOG_WARN("QtCoinViewer::drawarrow - Error: End points are the same.\n");
         return handle;
     }
+    //compute color material
+    SoMaterial* mtrl = new SoMaterial;
+    mtrl->diffuseColor = SbColor(color[0],color[1],color[2]);
+    mtrl->ambientColor = SbColor(color[0],color[1],color[2]);
+    mtrl->transparency = (1.0-color[3]);
+    mtrl->setOverride(true);
+    pparent->addChild(mtrl);
 
     //rotate to face point
     RaveVector<float> qrot = quatRotateDirection(RaveVector<dReal>(0,1,0),RaveVector<dReal>(direction));
@@ -1830,9 +1837,6 @@ void* QtCoinViewer::_drawarrow(SoSwitch* handle, const RaveVector<float>& p1, co
 
     psep->addChild(ptrans);
     pparent->addChild(psep);
-
-    // set a diffuse color
-    _SetMaterial(pparent, color);
 
     SoCylinder* c = new SoCylinder();
     c->radius = fwidth;


### PR DESCRIPTION
I ran into some problems with the drawarrow method when called from the openravepy interface.

(1) choosing an alpha value different from 1.0 lead to a segfault
(2) color of cylinder of arrow and cone of arrow did not match up. in particular, the color of the cylinder remained gray, instead of having the specified color, only the cone did change the color

I fixed both issues inside of the qtcoin interface by computing a color material (SoMaterial), and then setting it to the parent node. Color of the cylinder and cone are now consistent, and i can choose different alpha values without segfault. 
