### PR TITLE
Fixed pointer bug

### DIFF
--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -1284,7 +1284,7 @@ void RobotBase::CalculateActiveAngularVelocityJacobian(int index, std::vector<dR
         std::vector<dReal> vjacobianjoints;
         ComputeJacobianAxisAngle(index, vjacobianjoints, _vActiveDOFIndices);
         for(size_t i = 0; i < 3; ++i) {
-            std::copy(vjacobianjoints.begin()+i*_vActiveDOFIndices.size(),vjacobianjoints.begin()+(i+1)*_vActiveDOFIndices.size(),vjacobianjoints.begin()+i*dofstride);
+            std::copy(vjacobianjoints.begin()+i*_vActiveDOFIndices.size(),vjacobianjoints.begin()+(i+1)*_vActiveDOFIndices.size(),vjacobian.begin()+i*dofstride);
         }
     }
 


### PR DESCRIPTION
CalculateActiveAngularVelocityJacobian now correctly copies to vjacobian.