### PR TITLE
Fix GCC6 errors

### DIFF
--- a/3rdparty/convexdecomposition/NvHashMap.h
+++ b/3rdparty/convexdecomposition/NvHashMap.h
@@ -684,7 +684,7 @@ namespace CONVEX_DECOMPOSITION
 				copy(mData,t.mData,t.mSize);
 				mSize = t.mSize;
 
-				return;
+				return *this;
 			}
 			else
 			{
@@ -1505,7 +1505,7 @@ namespace CONVEX_DECOMPOSITION
 			NX_INLINE const Entry* find(const Key& k) const
 			{
 				if(!mHash.size())
-					return false;
+					return NULL;
 
 				NxU32 h = hash(k);
 				NxU32 index = mHash[h];

--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -52,10 +52,6 @@ public:
         return false;
     }
 
-    virtual void accept(osgGA::GUIEventHandlerVisitor& v)   {
-        v.visit(*this);
-    }
-
 private:
     boost::function<bool(int)> _onKeyDown; ///< called when key is pressed
 };

--- a/python/bindings/openravepy_global.cpp
+++ b/python/bindings/openravepy_global.cpp
@@ -139,7 +139,7 @@ bool ExtractRay(object o, RAY& ray)
 class Ray_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getinitargs(const PyRay& r)
+    static boost::python::tuple getinitargs(const PyRay& r)
     {
         return boost::python::make_tuple(toPyVector3(r.r.pos),toPyVector3(r.r.dir));
     }
@@ -185,7 +185,7 @@ object toPyAABB(const AABB& ab)
 class AABB_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getinitargs(const PyAABB& ab)
+    static boost::python::tuple getinitargs(const PyAABB& ab)
     {
         return boost::python::make_tuple(toPyVector3(ab.ab.pos),toPyVector3(ab.ab.extents));
     }
@@ -266,7 +266,7 @@ object toPyTriMesh(const TriMesh& mesh)
 class TriMesh_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getinitargs(const PyTriMesh& r)
+    static boost::python::tuple getinitargs(const PyTriMesh& r)
     {
         return boost::python::make_tuple(r.vertices,r.indices);
     }
@@ -553,7 +553,7 @@ public:
 class ConfigurationSpecification_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getinitargs(const PyConfigurationSpecification& pyspec)
+    static boost::python::tuple getinitargs(const PyConfigurationSpecification& pyspec)
     {
         std::stringstream ss;
         ss << pyspec._spec;

--- a/python/bindings/openravepy_ikparameterization.cpp
+++ b/python/bindings/openravepy_ikparameterization.cpp
@@ -345,11 +345,11 @@ object toPyIkParameterization(const std::string& serializeddata)
 class IkParameterization_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getinitargs(const PyIkParameterization &r)
+    static boost::python::tuple getinitargs(const PyIkParameterization &r)
     {
         std::stringstream ss; ss << std::setprecision(std::numeric_limits<dReal>::digits10+1);
         ss << r._param;
-        return make_tuple(ss.str());
+        return boost::python::make_tuple(ss.str());
     }
 };
 

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -1336,7 +1336,7 @@ public:
     bool SetViewer(const string &viewername, bool showviewer=true)
     {
         ViewerBasePtr pviewer = GetViewerManager()->AddViewer(_penv, viewername, showviewer, true);
-        return pviewer;
+        return !(pviewer == NULL);
     }
 
     /// \brief sets the default viewer

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -2619,7 +2619,7 @@ PyKinBodyPtr RaveCreateKinBody(PyEnvironmentBasePtr pyenv, const std::string& na
 class GeometryInfo_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getstate(const PyGeometryInfo& r)
+    static boost::python::tuple getstate(const PyGeometryInfo& r)
     {
         return boost::python::make_tuple(r._t, boost::make_tuple(r._vGeomData, r._vGeomData2, r._vGeomData3), r._vDiffuseColor, r._vAmbientColor, r._meshcollision, r._type, r._filenamerender, r._filenamecollision, r._vRenderScale, r._vCollisionScale, r._fTransparency, r._bVisible, r._bModifiable, r._mapExtraGeometries);
     }
@@ -2647,7 +2647,7 @@ public:
 class LinkInfo_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getstate(const PyLinkInfo& r)
+    static boost::python::tuple getstate(const PyLinkInfo& r)
     {
         return boost::python::make_tuple(r._vgeometryinfos, r._name, r._t, r._tMassFrame, r._mass, r._vinertiamoments, r._mapFloatParameters, r._mapIntParameters, r._vForcedAdjacentLinks, r._bStatic, r._bIsEnabled, r._mapStringParameters);
     }
@@ -2672,7 +2672,7 @@ public:
 class ElectricMotorActuatorInfo_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getstate(const PyElectricMotorActuatorInfo& r)
+    static boost::python::tuple getstate(const PyElectricMotorActuatorInfo& r)
     {
         return boost::python::make_tuple(r.gear_ratio, r.assigned_power_rating, r.max_speed, r.no_load_speed, boost::python::make_tuple(r.stall_torque, r.max_instantaneous_torque), boost::python::make_tuple(r.nominal_speed_torque_points, r.max_speed_torque_points), r.nominal_torque, r.rotor_inertia, r.torque_constant, r.nominal_voltage, r.speed_constant, r.starting_current, r.terminal_resistance, boost::python::make_tuple(r.coloumb_friction, r.viscous_friction));
     }
@@ -2700,7 +2700,7 @@ public:
 class JointInfo_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getstate(const PyJointInfo& r)
+    static boost::python::tuple getstate(const PyJointInfo& r)
     {
         return boost::python::make_tuple(boost::python::make_tuple(r._type, r._name, r._linkname0, r._linkname1, r._vanchor, r._vaxes, r._vcurrentvalues), boost::python::make_tuple(r._vresolution, r._vmaxvel, r._vhardmaxvel, r._vmaxaccel, r._vmaxtorque, r._vweights, r._voffsets, r._vlowerlimit, r._vupperlimit), boost::python::make_tuple(r._trajfollow, r._vmimic, r._mapFloatParameters, r._mapIntParameters, r._bIsCircular, r._bIsActive, r._mapStringParameters, r._infoElectricMotor, r._vmaxinertia));
     }

--- a/python/bindings/openravepy_planningutils.cpp
+++ b/python/bindings/openravepy_planningutils.cpp
@@ -318,7 +318,7 @@ object toPyDHParameter(const OpenRAVE::planningutils::DHParameter& p, PyEnvironm
 class DHParameter_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getinitargs(const PyDHParameter& p)
+    static boost::python::tuple getinitargs(const PyDHParameter& p)
     {
         return boost::python::make_tuple(object(), p.parentindex, p.transform, p.d, p.a, p.theta, p.alpha);
     }

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -1371,7 +1371,7 @@ public:
 class ManipulatorInfo_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getstate(const PyRobotBase::PyManipulatorInfo& r)
+    static boost::python::tuple getstate(const PyRobotBase::PyManipulatorInfo& r)
     {
         return boost::python::make_tuple(r._name, r._sBaseLinkName, r._sEffectorLinkName, r._tLocalTool, r._vChuckingDirection, r._vdirection, r._sIkSolverXMLId, r._vGripperJointNames);
     }
@@ -1390,7 +1390,7 @@ public:
 class GrabbedInfo_pickle_suite : public pickle_suite
 {
 public:
-    static tuple getstate(const PyRobotBase::PyGrabbedInfo& r)
+    static boost::python::tuple getstate(const PyRobotBase::PyGrabbedInfo& r)
     {
         return boost::python::make_tuple(r._grabbedname, r._robotlinkname, r._trelative, r._setRobotLinksToIgnore);
     }

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -3845,8 +3845,8 @@ void KinBody::_ComputeInternalInformation()
             _vClosedLoops.back().reserve(itclosedloop->size());
             // fill the links
             FOREACH(itlinkindex,*itclosedloop) {
-                _vClosedLoopIndices.back().push_back(make_pair<int16_t,int16_t>(*itlinkindex,0));
-                _vClosedLoops.back().push_back(make_pair<LinkPtr,JointPtr>(_veclinks.at(*itlinkindex),JointPtr()));
+                _vClosedLoopIndices.back().push_back(make_pair(*itlinkindex,0));
+                _vClosedLoops.back().push_back(make_pair(_veclinks.at(*itlinkindex),JointPtr()));
             }
             // fill the joints
             for(size_t i = 0; i < _vClosedLoopIndices.back().size(); ++i) {


### PR DESCRIPTION
With the 6.1 release, GCC switched to compile with `-std=c++11` as default. This caused several errors:
* functions with a non-void return type must return a value
* implicit conversion from pointer to bool is not allowed anymore
* ambiguous type declarations (e.g. `tuple` instead `std::tuple` or `boost::python::tuple`) are not allowed anymore
* template argument deduction is stricter (see [this StackOverflow answer](http://stackoverflow.com/a/9642232/2785041) for more details)

This pull request fixes all issues with GCC6.1. Additionally, it removes an unused function from the OSGViewerWidget, which did not compile with recent versions of OSG.