### PR TITLE
Fix undefined symbol errors

### DIFF
--- a/plugins/configurationcache/configurationcachetree.cpp
+++ b/plugins/configurationcache/configurationcachetree.cpp
@@ -1268,6 +1268,11 @@ int ConfigurationCache::UpdateCollisionConfigurations(KinBodyPtr pbody)
     return _cachetree.UpdateCollisionConfigurations(pbody);
 }
 
+int ConfigurationCache::UpdateFreeConfigurations(KinBodyPtr pbody)
+{
+    return _cachetree.UpdateFreeConfigurations(pbody);
+}
+
 int ConfigurationCache::RemoveFreeConfigurations()
 {
     return _cachetree.RemoveFreeConfigurations();

--- a/plugins/rplanners/ParabolicPathSmooth/DynamicPath.cpp
+++ b/plugins/rplanners/ParabolicPathSmooth/DynamicPath.cpp
@@ -434,7 +434,7 @@ struct RampSection
 };
 
 
-int CheckRamp(const ParabolicRampND& ramp,FeasibilityCheckerBase* feas,DistanceCheckerBase* distance,int maxiters)
+int CheckRamp(const ParabolicRampND& ramp,FeasibilityCheckerBase* feas,DistanceCheckerBase* distance,int maxiters, __attribute__((unused)) int options)
 {
     ramp.constraintchecked = 1;
     int ret0 = feas->ConfigFeasible(ramp.x0, ramp.dx0);

--- a/plugins/rplanners/rplanners.cpp
+++ b/plugins/rplanners/rplanners.cpp
@@ -26,7 +26,6 @@ PlannerBasePtr CreateWorkspaceTrajectoryTracker(EnvironmentBasePtr penv, std::is
 PlannerBasePtr CreateLinearTrajectoryRetimer(EnvironmentBasePtr penv, std::istream& sinput);
 PlannerBasePtr CreateParabolicTrajectoryRetimer(EnvironmentBasePtr penv, std::istream& sinput);
 PlannerBasePtr CreateCubicTrajectoryRetimer(EnvironmentBasePtr penv, std::istream& sinput);
-PlannerBasePtr CreateSubParabolicSmoother(EnvironmentBasePtr penv, std::istream& sinput);
 PlannerBasePtr CreateLinearSmoother(EnvironmentBasePtr penv, std::istream& sinput);
 PlannerBasePtr CreateConstraintParabolicSmoother(EnvironmentBasePtr penv, std::istream& sinput);
 
@@ -78,9 +77,6 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
         else if( interfacename == "parabolicsmoother" ) {
             return rplanners::CreateParabolicSmoother(penv,sinput);
         }
-        else if( interfacename == "subparabolicsmoother" ) {
-            return CreateSubParabolicSmoother(penv,sinput);
-        }
         else if( interfacename == "constraintparabolicsmoother" ) {
             return CreateConstraintParabolicSmoother(penv,sinput);
         }
@@ -105,7 +101,6 @@ void GetPluginAttributesValidated(PLUGININFO& info)
     info.interfacenames[PT_Planner].push_back("WorkspaceTrajectoryTracker");
     info.interfacenames[PT_Planner].push_back("LinearSmoother");
     info.interfacenames[PT_Planner].push_back("ParabolicSmoother");
-    info.interfacenames[PT_Planner].push_back("SubParabolicSmoother");
     info.interfacenames[PT_Planner].push_back("ConstraintParabolicSmoother");
 }
 


### PR DESCRIPTION
This fixes three undefined symbol errors that occurred during startup of openrave:
* In rplanners, fix the signature of `CheckRamp` to match the declaration in the header file
* In `ConfigurationCache`, add a missing definition for `UpdateFreeConfigurations`. This function was declared but never defined. I implemented the function similar to the other update functions, please check if this makes sense.
* Remove the `SubParabolicSmoother`. It looks like it was never used, its implementation is not part of the library (it was removed in 524ecc83). Looking at the code, it seems like it was not possible to use it at all (the implementation was missing). Remove it to fix an undefined symbol error.

It looks like the undefined symbol errors only occurred sometimes; depending on the compiler flags. In fact, my local version has all those symbols defined, but when I build with Fedora's `%optflags%`, the symbols are not defined. I didn't check which flags caused the errors because those fixes work everywhere.

I also tried adding the `SubParabolicSmoother` back to the library, but it gave multiple compiler errors.