### PR TITLE
Only create symlink for the openrave binary if a bin suffix is given

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 target_link_libraries (openrave ${Boost_DATE_TIME_LIBRARY} ${Boost_THREAD_LIBRARY} ${SOCKET_LIBS} libopenrave libopenrave-core)
 
 install(TARGETS openrave DESTINATION bin COMPONENT ${COMPONENT_PREFIX}base)
-if( OPT_BUILD_PACKAGE_DEFAULT )
+if( OPT_BUILD_PACKAGE_DEFAULT AND OPENRAVE_BIN_SUFFIX )
   InstallSymlink(${CMAKE_INSTALL_PREFIX}/bin/openrave${OPENRAVE_BIN_SUFFIX} ${CMAKE_INSTALL_PREFIX}/bin/openrave)
 endif()
 


### PR DESCRIPTION
If the bin suffix is empty, do not create the symlink, because then the
symlink points to itself (e.g. /usr/bin/openrave -> /usr/bin/openrave)
and the binary is deleted.