### PR TITLE
Look for fparser version 4.5 instead of 4.4.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -706,7 +706,7 @@ endif()
 #endif()
 
 # function expression parser library
-find_package(FPARSER 4.4.3)
+find_package(FPARSER 4.5 QUIET)
 if( NOT FPARSER_FOUND )
   if( PKG_CONFIG_FOUND )
     pkg_search_module(FPARSER fparser)


### PR DESCRIPTION
Seems reasonable, as the provided fparser version is 4.5 as well.
I added `QUIET` because subsequent checks are made, so an error at an earlier phase seems redundant.
