### PR TITLE
Increase working precision for polyroots (fix ikfast compatibility with mpmath-0.19)

### DIFF
--- a/python/ikfast.py
+++ b/python/ikfast.py
@@ -8151,7 +8151,7 @@ class IKFastSolver(AutoReloader):
                 break            
             realsolution = pfinal.gens[0].subs(subs).subs(self.globalsymbols).subs(testconsistentvalue).evalf()
             # need to convert to float64 first, X.evalf() is still a sympy object
-            roots = mpmath.polyroots(numpy.array(numpy.array(coeffs),numpy.float64))
+            roots = mpmath.polyroots(numpy.array(numpy.array(coeffs),numpy.float64),extraprec=20)
             for root in roots:
                 if Abs(float(root.imag)) < 10.0**-self.precision and Abs(float(root.real)-realsolution) < 10.0**-(self.precision-2):
                     found = True


### PR DESCRIPTION
Since the tolerance calculation has been fixed and become more precise in mpmath-v0.19, higher working precision is required to avoid a NoConvergence error.
See https://github.com/fredrik-johansson/mpmath/commit/a2e7c3aeff03c7d68ff9446691dd7a2e94c2b59f for the commit in mpmath.

I tried a few values for `extraprec` and 18-20 seemed to work (maybe there is a "proper" way to find the right precision?). Adjusting `maxsteps` didn't help.

Since those arguments seemed to be ineffective in prior verisions of mpmath, this commit should be "downward compatible".