### PR TITLE
Make fixes for OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ include(CheckCXXSourceRuns)
 include(CheckCXXCompilerFlag)
 include(CheckTypeSize)
 include(InstallSymlink)
+include(FindIntl)
 
 find_package(PkgConfig) # pkg_check_modules
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -42,7 +42,7 @@ if( OPT_ODE_COLLISION )
   set(PLUGINS ${PLUGINS} oderave)
 endif()
 if( OPT_FCL_COLLISION )
-  set(PLUGINS ${PLUGINS} fclrave)
+	#  set(PLUGINS ${PLUGINS} fclrave)
 endif()
 
 foreach(PLUGIN ${PLUGINS})

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -42,7 +42,7 @@ if( OPT_ODE_COLLISION )
   set(PLUGINS ${PLUGINS} oderave)
 endif()
 if( OPT_FCL_COLLISION )
-	#  set(PLUGINS ${PLUGINS} fclrave)
+  set(PLUGINS ${PLUGINS} fclrave)
 endif()
 
 foreach(PLUGIN ${PLUGINS})

--- a/plugins/qtosgrave/CMakeLists.txt
+++ b/plugins/qtosgrave/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 #include(${CMAKE_SOURCE_DIR}/modules-cmake/FindOSG.cmake)
 find_package(OpenSceneGraph 3.4 COMPONENTS osgDB osgQt osgGA osgFX osgText osgViewer osgManipulator)
 
-if (QT_FOUND AND QT_QTCORE_FOUND AND QT_QTGUI_FOUND AND OPENGL_FOUND AND OPENSCENEGRAPH_FOUND)
+if (QT_FOUND AND QT_QTCORE_FOUND AND QT_QTGUI_FOUND AND OPENGL_FOUND AND OPENSCENEGRAPH_FOUND AND OSGQT_FOUND)
   message(STATUS "Detected Qt/OSG GUI, making plugin")
 
   include_directories(${QT_INCLUDE_DIR} ${OPENGL_INCLUDE_DIR} ${QT_QTOPENGL_INCLUDE_DIR})

--- a/src/libopenrave/CMakeLists.txt
+++ b/src/libopenrave/CMakeLists.txt
@@ -23,13 +23,14 @@ add_dependencies(libopenrave interfacehashes_target openrave-md5)
 if( CRLIBM_FOUND )
   add_dependencies(libopenrave check_libm_accuracy-native) # forces check to be run before libopenrave is compile
 endif()
+
 set_target_properties(libopenrave PROPERTIES OUTPUT_NAME openrave${OPENRAVE_LIBRARY_SUFFIX}
                                   SOVERSION 0 # always have it 0 since we're including the soversion as part of the library name
                                   VERSION ${OPENRAVE_VERSION}
                                   CLEAN_DIRECT_OUTPUT 1
                                   COMPILE_FLAGS "${LIBOPENRAVE_COMPILE_FLAGS} ${FPARSER_CXX_FLAGS} -DOPENRAVE_DLL_EXPORTS -DOPENRAVE_DLL"
                                   LINK_FLAGS "${LIBOPENRAVE_LINK_FLAGS} ${FPARSER_LINK_FLAGS}")
-target_link_libraries(libopenrave ${openrave_libraries} ${FPARSER_LIBRARIES})
+target_link_libraries(libopenrave ${openrave_libraries} ${FPARSER_LIBRARIES} ${Intl_LIBRARIES})
 if( MSVC )
   install(TARGETS libopenrave EXPORT openrave-targets RUNTIME DESTINATION bin COMPONENT ${COMPONENT_PREFIX}base LIBRARY DESTINATION bin COMPONENT ${COMPONENT_PREFIX}base ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT ${COMPONENT_PREFIX}base)
 else()


### PR DESCRIPTION
The default homebrew openscenegraph installation doesn't package osgQt - that means that a compilation error happened prior to this PR, because the condition checks for OPENSCENEGRAPH only, not for OSGQT

On OS X, intl isn't part of the default C library, so some CMAKE fixes are in order to get that working. 