### PR TITLE
Set libpcrecpp_FOUND when using local pcre

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,6 +588,8 @@ if( NOT libpcrecpp_FOUND )
   message(STATUS "System pcre not found, using local from sources")
   # include the local pcre
   add_subdirectory(3rdparty/pcre-8.02)
+
+  set(libpcrecpp_FOUND 1)
 endif()
 
 if( OPT_COLLADA )


### PR DESCRIPTION
This pull request is related to an issue [#296](https://github.com/rdiankov/openrave/issues/296).

A problem here is that when local libpcre is loaded in `openrave/CMakelits.txt`, a variable `libpcrecpp_FOUND` is still unset.
And if `libpcrecpp_FOUND` is unset, a include directory of `libpcre` is not passed to the compiler.
However, `openrave/src/libopenrave-core/environment-core.h` always includes `<pcrecpp.h>` ignoring `libpcrecpp_FOUND`.

In this pull request, I set the variable to `1` when local libpcre is used.