### PR TITLE
Undefined behaviour when creating a shared_ptr from a naked pointer inheriting from enable_shared_from_this

### DIFF
--- a/plugins/rplanners/rrt.h
+++ b/plugins/rplanners/rrt.h
@@ -67,6 +67,7 @@ Uses the Rapidly-Exploring Random Trees Algorithm.\n\
 
         _vecInitialNodes.resize(0);
         _sampleConfig.resize(params->GetDOF());
+        // TODO perhaps distmetricfn should take into number of revolutions of circular joints
         _treeForward.Init(shared_planner(), params->GetDOF(), params->_distmetricfn, params->_fStepLength, params->_distmetricfn(params->_vConfigLowerLimit, params->_vConfigUpperLimit));
         std::vector<dReal> vinitialconfig(params->GetDOF());
         for(size_t index = 0; index < params->vinitialconfig.size(); index += params->GetDOF()) {
@@ -307,6 +308,7 @@ Some python code to display data::\n\
         PlannerParameters::StateSaver savestate(_parameters);
         CollisionOptionsStateSaver optionstate(GetEnv()->GetCollisionChecker(),GetEnv()->GetCollisionChecker()->GetCollisionOptions()|CO_ActiveDOFs,false);
 
+        // TODO perhaps distmetricfn should take into number of revolutions of circular joints
         _treeBackward.Init(shared_planner(), _parameters->GetDOF(), _parameters->_distmetricfn, _parameters->_fStepLength, _parameters->_distmetricfn(_parameters->_vConfigLowerLimit, _parameters->_vConfigUpperLimit));
 
         //read in all goals

--- a/src/libopenrave/planner.cpp
+++ b/src/libopenrave/planner.cpp
@@ -41,7 +41,11 @@ std::istream& operator>>(std::istream& I, PlannerBase::PlannerParameters& pp)
             throw OPENRAVE_EXCEPTION_FORMAT(_("error, failed to find </PlannerParameters> in %s"),buf.str(),ORE_InvalidArguments);
         }
         pp._plannerparametersdepth = 0;
-        LocalXML::ParseXMLData(PlannerBase::PlannerParametersPtr(&pp,utils::null_deleter()), pbuf.c_str(), ppsize);
+        try {
+            LocalXML::ParseXMLData(pp.shared_from_this(), pbuf.c_str(), ppsize);
+        } catch(boost::bad_weak_ptr& e) {
+            LocalXML::ParseXMLData(PlannerBase::PlannerParametersPtr(&pp, utils::null_deleter()), pbuf.c_str(), ppsize);
+        }
     }
 
     return I;
@@ -827,7 +831,7 @@ void PlannerBase::PlannerParameters::Validate() const
                 RAVELOG_DEBUG_FORMAT("unequal states: %s",ss.str());
             }
         }
-        
+
         OPENRAVE_ASSERT_OP(dist,<=,1000*g_fEpsilon);
     }
     if( !!_diffstatefn && vstate.size() > 0 ) {
@@ -895,7 +899,7 @@ PlannerStatus PlannerBase::_ProcessPostPlanners(RobotBasePtr probot, TrajectoryB
             }
         }
     }
-        
+
     // transfer the callbacks?
     list<UserDataPtr> listhandles;
     FOREACHC(it,__listRegisteredCallbacks) {


### PR DESCRIPTION
This seems to be currently fine with boost::shared_ptr (but it is specified as an UB in the documentation), and it is definitively not fine with std::shared_ptr from c++11.
