### PR TITLE
Fixcheckmanipconstraints

### DIFF
--- a/plugins/rplanners/manipconstraints.h
+++ b/plugins/rplanners/manipconstraints.h
@@ -507,7 +507,7 @@ public:
         }
 
         std::vector<ParabolicRampInternal::ParabolicRampND>::const_iterator itramp2 = --outramps.end();
-        if (itramp2 != itramp1) {
+        if (itramp2 != itramp1 || itramp1->endTime > g_fEpsilonLinear) {
             FOREACHC(itmanipinfo, _listCheckManips) {
                 KinBodyPtr probot = itmanipinfo->plink->GetParent();
 


### PR DESCRIPTION
In `CheckManipConstraints`, we should skip checking  in the later part only when there is only one  ramp and the ramp is too short.