### PR TITLE
When writing to collada, write cylinder as cylinderz such that we don't have to rotate axis.

### DIFF
--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -2705,6 +2705,23 @@ public:
                                 }
                             }
                         }
+                        else if( name == "cylinderz" ) {
+                            daeElementRef pradius = children[i]->getChild("radius");
+                            daeElementRef pheight = children[i]->getChild("height");
+                            if( !!pradius && !!pheight ) {
+                                Vector vGeomData;
+                                stringstream ss(pradius->getCharData());
+                                ss >> vGeomData.x;
+                                stringstream ss2(pheight->getCharData());
+                                ss2 >> vGeomData.y;
+                                if( (ss.eof() || !!ss) && (ss2.eof() || !!ss2) ) {
+                                    geominfo._type = GT_Cylinder;
+                                    geominfo._vGeomData = vGeomData;
+                                    geominfo._t = tlocalgeom;
+                                    bfoundgeom = true;
+                                }
+                            }
+                        }
                         else if( name == "container" ) {
                             daeElementRef pouter_extents = children[i]->getChild("outer_extents");
                             if( !!pouter_extents ) {

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -1704,13 +1704,10 @@ private:
                 ptec->add("sphere")->add("radius")->setCharData(ss.str());
                 break;
             case GT_Cylinder: {
-                daeElementRef pcylinder = ptec->add("cylinder");
+                daeElementRef pcylinder = ptec->add("cylinderz");
                 ss << geom->GetCylinderRadius() << " " << geom->GetCylinderRadius();
                 pcylinder->add("radius")->setCharData(ss.str());
                 pcylinder->add("height")->setCharData(boost::lexical_cast<std::string>(geom->GetCylinderHeight()));
-                // collada cylinder is oriented toward y-axis while openrave is toward z-axis
-                Transform trot(quatRotateDirection(Vector(0,1,0),Vector(0,0,1)),Vector());
-                tlocalgeom = tlocalgeom * trot;
                 break;
             }
             case GT_None:


### PR DESCRIPTION
After this change, when reading dae file, we will respect both <cylinder> and <cylinderz>. When writing, we will only write <cylinderz>.