### PR TITLE
Clean C API

### DIFF
--- a/include/openrave_c/openrave_c.h
+++ b/include/openrave_c/openrave_c.h
@@ -65,7 +65,7 @@ enum DebugLevel {
 OPENRAVE_C_API void ORCSetDebugLevel(int level);
 
 /// \brief Calls \ref RaveInitialize
-OPENRAVE_C_API void ORCInitialize(bool bLoadAllPlugins=true, int level=Level_Info);
+OPENRAVE_C_API void ORCInitialize(int bLoadAllPlugins, int level);
 
 /// \brief Calls \ref RaveDestroy
 OPENRAVE_C_API void ORCDestroy();
@@ -89,7 +89,7 @@ OPENRAVE_C_API void ORCTriMeshDestroy(void* trimesh);
 /// \brief Calls \ref EnvironmentBase::Destroy
 OPENRAVE_C_API void ORCEnvironmentDestroy(void* env);
 
-OPENRAVE_C_API bool ORCEnvironmentLoad(void* env, const char* filename);
+OPENRAVE_C_API int ORCEnvironmentLoad(void* env, const char* filename);
 
 /// \brief Calls \ref EnvironmentBase::GetKinBody
 OPENRAVE_C_API void* ORCEnvironmentGetKinBody(void* env, const char* name);
@@ -137,7 +137,7 @@ OPENRAVE_C_API void ORCEnvironmentLock(void* env);
 OPENRAVE_C_API void ORCEnvironmentUnlock(void* env);
 
 /// \brief Starts a viewer thread for the current environment
-OPENRAVE_C_API bool ORCEnvironmentSetViewer(void* env, const char* viewername);
+OPENRAVE_C_API int ORCEnvironmentSetViewer(void* env, const char* viewername);
 
 //@}
 
@@ -209,7 +209,7 @@ OPENRAVE_C_API void ORCBodyGetTransformMatrix(void* body, OpenRAVEReal* matrix);
 /// \brief Calls \ref KinBody::InitFromTrimesh
 ///
 /// \param trimesh returned from ORCTriMeshCreate()
-OPENRAVE_C_API bool ORCBodyInitFromTrimesh(void* body, void* trimesh, bool visible);
+OPENRAVE_C_API int ORCBodyInitFromTrimesh(void* body, void* trimesh, int visible);
 
 //@}
 

--- a/src/cexamples/CMakeLists.txt
+++ b/src/cexamples/CMakeLists.txt
@@ -14,10 +14,10 @@ link_directories(${OpenRAVE_LIBRARY_DIRS})
 message(STATUS "lib ${OpenRAVE_CORE_C_LIBRARIES}")
 
 macro(build_openrave_executable name)
-  add_executable(${name} ${name}.cpp)
+  add_executable(${name} ${name}.c)
   set_target_properties(${name} PROPERTIES COMPILE_FLAGS "${OpenRAVE_CXX_FLAGS} -DOPENRAVE_C_DLL -DOPENRAVE_C_CORE_DLL")
   set_target_properties(${name} PROPERTIES LINK_FLAGS "${OpenRAVE_LINK_FLAGS}")
-  target_link_libraries(${name} ${OpenRAVE_CORE_C_LIBRARIES})
+  target_link_libraries(${name} ${OpenRAVE_CORE_C_LIBRARIES} -lm)
   install(TARGETS ${name} DESTINATION . )
 endmacro(build_openrave_executable)
 

--- a/src/cexamples/orc_bodyfunctions.c
+++ b/src/cexamples/orc_bodyfunctions.c
@@ -1,0 +1,87 @@
+/** @example orc_bodyfunctions.cpp
+    @author Rosen Diankov
+
+    Shows how to change body transforms, remove bodies, and get link information and change geometry properties.
+ */
+#include <openrave-core_c.h>
+#include <stdio.h>
+#include <malloc.h>
+#include <math.h>
+
+int main(int argc, char ** argv)
+{
+    ORCInitialize(1, 1);
+    void* env = ORCEnvironmentCreate();
+    ORCEnvironmentLoad(env, "data/lab1.env.xml");
+    ORCEnvironmentSetViewer(env,"qtcoin");
+
+    ORCSetDebugLevel(4); // set to debug
+
+    int pole2added = 1;
+    void* bodypole2 = ORCEnvironmentGetKinBody(env, "pole2");
+    void* bodypole3 = ORCEnvironmentGetKinBody(env, "pole3");
+
+    int numlinks = ORCBodyGetLinks(bodypole3, NULL);
+    void** links = NULL;
+    links = (void**)malloc(sizeof(void*)*numlinks);
+    ORCBodyGetLinks(bodypole3, links);
+
+    // get the geometries of the first link
+    int numgeometries = ORCBodyLinkGetGeometries(links[0], NULL);
+    void** geometries = NULL;
+    geometries = (void**)malloc(sizeof(void*)*numgeometries);
+    ORCBodyLinkGetGeometries(links[0], geometries);
+
+    OpenRAVEReal pose[7];
+    ORCBodyGetTransform(bodypole3, pose);
+    unsigned long long startsimtime = ORCEnvironmentGetSimulationTime(env);
+
+    int i;
+    for( i = 0; i < 10000; ++i) {
+        // lock the environment when doing operations
+        ORCEnvironmentLock(env);
+
+        unsigned long long newsimtime = ORCEnvironmentGetSimulationTime(env);
+        OpenRAVEReal deltatime = (newsimtime-startsimtime)*1e-6;
+        OpenRAVEReal fanim = fmod(deltatime,1.0);
+        // animate around X axis
+        pose[4] = 1 + fanim;
+        ORCBodySetTransform(bodypole3,pose);
+
+        // set the color
+        ORCBodyGeometrySetDiffuseColor(geometries[0], 1,0,fanim);
+
+        if( fanim > 0.5 && pole2added ) {
+            // remove the pole
+            ORCEnvironmentRemove(env, bodypole2);
+            pole2added = 0;
+        }
+        else if( fanim < 0.5 && (pole2added == 0) ) {
+            ORCEnvironmentAdd(env, bodypole2);
+            pole2added = 1;
+        }
+
+        // unlock
+        ORCEnvironmentUnlock(env);
+
+        // wait until sim time changes
+        while(newsimtime == ORCEnvironmentGetSimulationTime(env)) {
+            // sleep?
+        }
+    }
+
+    // release all resources
+    for( i = 0; i < numgeometries; ++i) {
+        ORCBodyLinkRelease(geometries[i]);
+    }
+    free(geometries);
+    for( i = 0; i < numlinks; ++i) {
+        ORCBodyLinkRelease(links[i]);
+    }
+    free(links);
+    ORCInterfaceRelease(bodypole2);
+    ORCInterfaceRelease(bodypole3);
+    ORCEnvironmentDestroy(env);
+    ORCEnvironmentRelease(env);
+    ORCDestroy();
+};

--- a/src/cexamples/orc_customgeometry.c
+++ b/src/cexamples/orc_customgeometry.c
@@ -1,0 +1,66 @@
+/** @example orc_customgeometry.cpp
+    @author Rosen Diankov
+
+    Shows how to create custom geometry dynamically and rotate it. This geometry is now part of the collision detection.
+ */
+#include <openrave-core_c.h>
+#include <stdio.h>
+#include <malloc.h>
+#include <math.h>
+
+int main(int argc, char ** argv)
+{
+    ORCInitialize(1, 1);
+    void* env = ORCEnvironmentCreate();
+    //ORCEnvironmentLoad(env, "data/lab1.env.xml");
+    ORCSetDebugLevel(4); // set to debug
+
+    // create a simple triangle
+    OpenRAVEReal vertices[9]={1,0,0, 0,1,0,  0,0,1 };
+    int numvertices=3;
+    OpenRAVEReal indices[3]={0,1,2};
+    int numtriangles=1;
+    void* trimesh = ORCCreateTriMesh(vertices, numvertices, indices, numtriangles);
+
+    // create a body to encompass the triangle
+    void* body = ORCCreateKinBody(env, "");
+    ORCBodyInitFromTrimesh(body, trimesh, 1);
+    ORCBodySetName(body, "mytriangle");
+    ORCEnvironmentAdd(env,body);
+
+    // attach the viewer
+    ORCEnvironmentSetViewer(env,"qtcoin");
+
+    // animate along Z axis
+    OpenRAVEReal pose[7] = {1,0,0,0,0,0,0};
+    unsigned long long startsimtime = ORCEnvironmentGetSimulationTime(env);
+
+    int i;
+    for( i = 0; i < 10000; ++i) {
+        // lock the environment when doing operations
+        ORCEnvironmentLock(env);
+
+        unsigned long long newsimtime = ORCEnvironmentGetSimulationTime(env);
+        OpenRAVEReal deltatime = (newsimtime-startsimtime)*1e-6;
+        //OpenRAVEReal fanim = fmod(deltatime,1.0);
+
+        pose[0] = sin(deltatime);
+        pose[3] = cos(deltatime);
+        ORCBodySetTransform(body,pose);
+
+        // unlock
+        ORCEnvironmentUnlock(env);
+
+        // wait until sim time changes
+        while(newsimtime == ORCEnvironmentGetSimulationTime(env)) {
+            // sleep?
+        }
+    }
+
+    ORCTriMeshDestroy(trimesh);
+    ORCInterfaceRelease(body);
+    ORCEnvironmentDestroy(env);
+    ORCEnvironmentRelease(env);
+    ORCDestroy();
+    return 0;
+};

--- a/src/cexamples/orc_rrtplanning.c
+++ b/src/cexamples/orc_rrtplanning.c
@@ -1,0 +1,43 @@
+/** @example orc_rrtplanning.cpp
+    @author Rosen Diankov
+
+    Shows how to start a planning with the OpenRAVE C bindings.
+ */
+#include <openrave-core_c.h>
+#include <stdio.h>
+#include <malloc.h>
+
+int main(int argc, char ** argv)
+{
+    ORCInitialize(1, 1);
+    void* env = ORCEnvironmentCreate();
+    ORCEnvironmentLoad(env, "data/lab1.env.xml");
+
+    ORCSetDebugLevel(4); // set to debug
+
+    int numrobots = ORCEnvironmentGetRobots(env, NULL);
+    void** robots = NULL;
+    robots = (void**)malloc(sizeof(void*)*numrobots);
+    ORCEnvironmentGetRobots(env, robots);
+
+    const char* robotname = ORCRobotGetName(robots[0]);
+    printf("robot name is: %s\n", robotname);
+
+    void* basemanip = ORCModuleCreate(env, "BaseManipulation");
+    ORCEnvironmentAddModule(env, basemanip, robotname);
+    char* output = ORCInterfaceSendCommand(basemanip, "MoveManipulator goal -0.75 1.24 -0.064 2.33 -1.16 -1.548 1.19 outputtraj execute 0");
+    printf("rrt output is: %s", output);
+
+    // release all resources
+    free(output);
+    ORCInterfaceRelease(basemanip);
+    int i;
+    for( i = 0; i < numrobots; ++i) {
+        ORCInterfaceRelease(robots[i]);
+    }
+    free(robots);
+    ORCEnvironmentDestroy(env);
+    ORCEnvironmentRelease(env);
+    ORCDestroy();
+    return 0;
+};

--- a/src/csharpbindings_c/OpenRAVE/Body.cs
+++ b/src/csharpbindings_c/OpenRAVE/Body.cs
@@ -6,280 +6,286 @@ using System.Text;
 
 namespace OpenRAVE
 {
-	/// <summary>
-	/// The BodyGeometry class provides access to geometry data of the
-	/// body.
-	/// </summary>
-	public class BodyGeometry : Base
-	{
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern void ORCBodyLinkRelease(IntPtr link);
+/// <summary>
+/// The BodyGeometry class provides access to geometry data of the
+/// body.
+/// </summary>
+public class BodyGeometry : Base
+{
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern void ORCBodyLinkRelease(IntPtr link);
 
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern void ORCBodyGeometrySetDiffuseColor(IntPtr geometry, float red, float green, float blue);
-		
-		internal BodyGeometry(IntPtr ptr) : base(ptr) {}
-		
-		protected override void Destroy()
-		{
-			// This is implied by the orcbodyfunctions.cpp example so we'll
-			// maintain this assumption here.
-			ORCBodyLinkRelease(ptr);
-		}
-				
-		public void SetDiffuseColor(float red, float green, float blue)
-		{
-			ORCBodyGeometrySetDiffuseColor(ptr, red, green, blue);
-		}
-	}
-	
-	/// <summary>
-	/// The BodyLink class provides access to the link information which
-	/// joins elements the various geometrys of the model.
-	/// </summary>
-	public class BodyLink : Base
-	{
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern void ORCBodyLinkRelease(IntPtr link);
-		
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern int ORCBodyLinkGetGeometries(IntPtr link, IntPtr[] geometries);
-		
-		internal BodyLink(IntPtr ptr) : base(ptr) {}
-		
-		protected override void Destroy()
-		{
-			ORCBodyLinkRelease(ptr);
-		}
-		
-		public int GeometryCount
-		{
-			get
-			{
-				return ORCBodyLinkGetGeometries(ptr, null);
-			}
-		}
-		
-		public DisposableList<BodyGeometry> Geometries
-		{
-			get
-			{
-				IntPtr[] v = new IntPtr[GeometryCount];
-				ORCBodyLinkGetGeometries(ptr, v);
-				DisposableList<BodyGeometry> l = new DisposableList<BodyGeometry>();
-				foreach(IntPtr p in v)
-					l.Add(new BodyGeometry(p));
-				return l;
-			}
-		}
-	}
-	
-	/// <summary>
-	/// The Body class provides a broad range of support for the overall body
-	/// data of a model.
-	/// </summary>
-	public class Body : InterfaceBase
-	{
-		[DllImport("libopenrave0.9_c")]
-		private static extern IntPtr ORCBodyGetName(IntPtr body);
-		
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern void ORCBodySetName(IntPtr body, string name);
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern void ORCBodyGeometrySetDiffuseColor(IntPtr geometry, float red, float green, float blue);
 
-		[DllImport("libopenrave0.9_c")]
-		private static extern int ORCBodyGetDOF(IntPtr body);
+    internal BodyGeometry(IntPtr ptr) : base(ptr) {
+    }
 
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodyGetDOFValues(IntPtr body, float[] values);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodyGetDOFValues(IntPtr body, double[] values);
+    protected override void Destroy()
+    {
+        // This is implied by the orcbodyfunctions.cpp example so we'll
+        // maintain this assumption here.
+        ORCBodyLinkRelease(ptr);
+    }
 
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodySetDOFValues(IntPtr body, float[] values);
+    public void SetDiffuseColor(float red, float green, float blue)
+    {
+        ORCBodyGeometrySetDiffuseColor(ptr, red, green, blue);
+    }
+}
 
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodySetDOFValues(IntPtr body, double[] values);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern int ORCBodyGetLinks(IntPtr body, IntPtr[] links);
+/// <summary>
+/// The BodyLink class provides access to the link information which
+/// joins elements the various geometrys of the model.
+/// </summary>
+public class BodyLink : Base
+{
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern void ORCBodyLinkRelease(IntPtr link);
 
-		/// \param[in] pose 7 values of the quaternion (4) and translation (3) of the world pose of the transform.
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodySetTransform(IntPtr body, float[] pose);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodySetTransform(IntPtr body, double[] pose);
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern int ORCBodyLinkGetGeometries(IntPtr link, IntPtr[] geometries);
 
-		/// \param[in] matrix column-order, row-major 3x4 matrix of the body world transform
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodySetTransformMatrix(IntPtr body, float[] matrix);
+    internal BodyLink(IntPtr ptr) : base(ptr) {
+    }
 
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodySetTransformMatrix(IntPtr body, double[] matrix);
-		
-		/// \param[out] pose 7 values of the quaternion (4) and translation (3) of the world pose of the transform.
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodyGetTransform(IntPtr body, float[] pose);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodyGetTransform(IntPtr body, double[] pose);
+    protected override void Destroy()
+    {
+        ORCBodyLinkRelease(ptr);
+    }
 
-		/// \param[out] matrix column-order, row-major 3x4 matrix of the body world transform
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodyGetTransformMatrix(IntPtr body, float[] matrix);
+    public int GeometryCount
+    {
+        get
+        {
+            return ORCBodyLinkGetGeometries(ptr, null);
+        }
+    }
 
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCBodyGetTransformMatrix(IntPtr body, double[] matrix);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern bool ORCBodyInitFromTrimesh(IntPtr body, IntPtr trimesh, bool visible);
-				
-		internal Body(IntPtr ptr) : base(ptr) {}
-		
-		public string Name
-		{
-			get
-			{
-				return Marshal.PtrToStringAnsi(ORCBodyGetName(ptr));
-			}
-			set
-			{
-				ORCBodySetName(ptr, value);
-			}
-		}
-		
-		public int DOF
-		{
-			get
-			{
-				return ORCBodyGetDOF(ptr);
-			}
-		}
-		
-		public float[] DOFValuesF
-		{
-			get
-			{
-				float[] v = new float[DOF];
-				ORCBodyGetDOFValues(ptr, v);
-				return v;
-			}
-			set
-			{
-				ORCBodySetDOFValues(ptr, value);
-			}
-		}
+    public DisposableList<BodyGeometry> Geometries
+    {
+        get
+        {
+            IntPtr[] v = new IntPtr[GeometryCount];
+            ORCBodyLinkGetGeometries(ptr, v);
+            DisposableList<BodyGeometry> l = new DisposableList<BodyGeometry>();
+            foreach(IntPtr p in v)
+                l.Add(new BodyGeometry(p));
+            return l;
+        }
+    }
+}
 
-		public double[] DOFValuesD
-		{
-			get
-			{
-				double[] v = new double[DOF];
-				ORCBodyGetDOFValues(ptr, v);
-				return v;
-			}
-			set
-			{
-				ORCBodySetDOFValues(ptr, value);
-			}
-		}
-		
-		public int LinkCount
-		{
-			get
-			{
-				return ORCBodyGetLinks(ptr, null);
-			}
-		}
-		
-		public DisposableList<BodyLink> Links
-		{
-			get
-			{
-				IntPtr[] v = new IntPtr[LinkCount];
-				ORCBodyGetLinks(ptr, v);
-				DisposableList<BodyLink> l = new DisposableList<BodyLink>();
-				foreach(IntPtr p in v)
-					l.Add(new BodyLink(p));
-				return l;
-			}
-		}
-		
-		public float[] TransformF
-		{
-			get
-			{
-				float[] f = new float[7];
-				ORCBodyGetTransform(ptr, f);
-				return f;
-			}
-			set
-			{
-				if(value.Length != 7)
-					return;
-				ORCBodySetTransform(ptr, value);
-			}
-		}
+/// <summary>
+/// The Body class provides a broad range of support for the overall body
+/// data of a model.
+/// </summary>
+public class Body : InterfaceBase
+{
+    [DllImport("libopenrave0.9_c")]
+    private static extern IntPtr ORCBodyGetName(IntPtr body);
 
-		public double[] TransformD
-		{
-			get
-			{
-				double[] f = new double[7];
-				ORCBodyGetTransform(ptr, f);
-				return f;
-			}
-			set
-			{
-				if(value.Length != 7)
-					return;
-				ORCBodySetTransform(ptr, value);
-			}
-		}
-		
-		public float[] TransformMatrixF
-		{
-			get
-			{
-				float[] f = new float[12];
-				ORCBodyGetTransformMatrix(ptr, f);
-				return f;
-			}
-			set
-			{
-				if(value.Length != 12)
-					return;
-				ORCBodySetTransformMatrix(ptr, value);
-			}
-		}
-		
-		public double[] TransformMatrixD
-		{
-			get
-			{
-				double[] f = new double[12];
-				ORCBodyGetTransformMatrix(ptr, f);
-				return f;
-			}
-			set
-			{
-				if(value.Length != 12)
-					return;
-				ORCBodySetTransformMatrix(ptr, value);
-			}
-		}
-		
-		public bool InitFromTriMesh(TriMesh trimesh, bool visible)
-		{
-			return ORCBodyInitFromTrimesh(ptr, trimesh.Ptr, visible);
-		}
-		
-		protected override void Destroy()
-		{
-			// How??
-		}
-	}
-	
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern void ORCBodySetName(IntPtr body, string name);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern int ORCBodyGetDOF(IntPtr body);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodyGetDOFValues(IntPtr body, float[] values);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodyGetDOFValues(IntPtr body, double[] values);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodySetDOFValues(IntPtr body, float[] values);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodySetDOFValues(IntPtr body, double[] values);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern int ORCBodyGetLinks(IntPtr body, IntPtr[] links);
+
+    /// \param[in] pose 7 values of the quaternion (4) and translation (3) of the world pose of the transform.
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodySetTransform(IntPtr body, float[] pose);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodySetTransform(IntPtr body, double[] pose);
+
+    /// \param[in] matrix column-order, row-major 3x4 matrix of the body world transform
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodySetTransformMatrix(IntPtr body, float[] matrix);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodySetTransformMatrix(IntPtr body, double[] matrix);
+
+    /// \param[out] pose 7 values of the quaternion (4) and translation (3) of the world pose of the transform.
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodyGetTransform(IntPtr body, float[] pose);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodyGetTransform(IntPtr body, double[] pose);
+
+    /// \param[out] matrix column-order, row-major 3x4 matrix of the body world transform
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodyGetTransformMatrix(IntPtr body, float[] matrix);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCBodyGetTransformMatrix(IntPtr body, double[] matrix);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern int ORCBodyInitFromTrimesh(IntPtr body, IntPtr trimesh, uint visible);
+
+    internal Body(IntPtr ptr) : base(ptr) {
+    }
+
+    public string Name
+    {
+        get
+        {
+            return Marshal.PtrToStringAnsi(ORCBodyGetName(ptr));
+        }
+        set
+        {
+            ORCBodySetName(ptr, value);
+        }
+    }
+
+    public int DOF
+    {
+        get
+        {
+            return ORCBodyGetDOF(ptr);
+        }
+    }
+
+    public float[] DOFValuesF
+    {
+        get
+        {
+            float[] v = new float[DOF];
+            ORCBodyGetDOFValues(ptr, v);
+            return v;
+        }
+        set
+        {
+            ORCBodySetDOFValues(ptr, value);
+        }
+    }
+
+    public double[] DOFValuesD
+    {
+        get
+        {
+            double[] v = new double[DOF];
+            ORCBodyGetDOFValues(ptr, v);
+            return v;
+        }
+        set
+        {
+            ORCBodySetDOFValues(ptr, value);
+        }
+    }
+
+    public int LinkCount
+    {
+        get
+        {
+            return ORCBodyGetLinks(ptr, null);
+        }
+    }
+
+    public DisposableList<BodyLink> Links
+    {
+        get
+        {
+            IntPtr[] v = new IntPtr[LinkCount];
+            ORCBodyGetLinks(ptr, v);
+            DisposableList<BodyLink> l = new DisposableList<BodyLink>();
+            foreach(IntPtr p in v)
+                l.Add(new BodyLink(p));
+            return l;
+        }
+    }
+
+    public float[] TransformF
+    {
+        get
+        {
+            float[] f = new float[7];
+            ORCBodyGetTransform(ptr, f);
+            return f;
+        }
+        set
+        {
+            if(value.Length != 7)
+                return;
+            ORCBodySetTransform(ptr, value);
+        }
+    }
+
+    public double[] TransformD
+    {
+        get
+        {
+            double[] f = new double[7];
+            ORCBodyGetTransform(ptr, f);
+            return f;
+        }
+        set
+        {
+            if(value.Length != 7)
+                return;
+            ORCBodySetTransform(ptr, value);
+        }
+    }
+
+    public float[] TransformMatrixF
+    {
+        get
+        {
+            float[] f = new float[12];
+            ORCBodyGetTransformMatrix(ptr, f);
+            return f;
+        }
+        set
+        {
+            if(value.Length != 12)
+                return;
+            ORCBodySetTransformMatrix(ptr, value);
+        }
+    }
+
+    public double[] TransformMatrixD
+    {
+        get
+        {
+            double[] f = new double[12];
+            ORCBodyGetTransformMatrix(ptr, f);
+            return f;
+        }
+        set
+        {
+            if(value.Length != 12)
+                return;
+            ORCBodySetTransformMatrix(ptr, value);
+        }
+    }
+
+    public bool InitFromTriMesh(TriMesh trimesh, bool visible)
+    {
+        if (visible)
+            return ORCBodyInitFromTrimesh(ptr, trimesh.Ptr, 1);
+        else
+            return ORCBodyInitFromTrimesh(ptr, trimesh.Ptr, 0);
+    }
+
+    protected override void Destroy()
+    {
+        // How??
+    }
+}
+
 }
 

--- a/src/csharpbindings_c/OpenRAVE/Context.cs
+++ b/src/csharpbindings_c/OpenRAVE/Context.cs
@@ -6,79 +6,79 @@ using System.Text;
 
 namespace OpenRAVE
 {
-	/// <summary>
-	/// The DebugLevel enum provides a means of specifying the level to which
-	/// debug information should be reported by OpenRAVE.
-	/// </summary>
-	public enum DebugLevel : uint {
-		Fatal 		= 0,
-		Error 		= 1,
-		Warn 		= 2,
-		Info 		= 3,
-		Debug 		= 4,
-		Verbose 	= 5,
-		OutputMask	= 0xf,
-		VerifyPlans = 0x80000000, ///< if set, should verify every plan returned. the verification is left up to the planners or the modules calling the planners. See \ref planningutils::ValidateTrajectory
-	};
+/// <summary>
+/// The DebugLevel enum provides a means of specifying the level to which
+/// debug information should be reported by OpenRAVE.
+/// </summary>
+public enum DebugLevel : uint {
+    Fatal       = 0,
+    Error       = 1,
+    Warn        = 2,
+    Info        = 3,
+    Debug       = 4,
+    Verbose     = 5,
+    OutputMask  = 0xf,
+    VerifyPlans = 0x80000000, ///< if set, should verify every plan returned. the verification is left up to the planners or the modules calling the planners. See \ref planningutils::ValidateTrajectory
+};
 
-	/// <summary>
-	/// The Context class provides the main point of initialisation of the OpenRAVE
-	/// environment using a Singleton design pattern to restrict the a single
-	/// initialisation. I believe this is correct?
-	/// </summary>
-	public class Context : Base
-	{
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCSetDebugLevel(uint level);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCInitialize(bool bLoadAllPlugins, uint level);
+/// <summary>
+/// The Context class provides the main point of initialisation of the OpenRAVE
+/// environment using a Singleton design pattern to restrict the a single
+/// initialisation. I believe this is correct?
+/// </summary>
+public class Context : Base
+{
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCSetDebugLevel(uint level);
 
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCDestroy();
-		
-		private static Context thisContext = null;
-		private DebugLevel debugLevel;
-		public DebugLevel DebugLevel
-		{
-			get
-			{
-				return debugLevel;
-			}
-			set
-			{
-				debugLevel = value;
-				ORCSetDebugLevel((uint)value);
-			}
-		}
-		
-		private Context(DebugLevel level) : base((IntPtr)1)
-		{
-			debugLevel = level;
-			ORCInitialize(true, (uint)level);
-		}
-		
-		public static Context Create()
-		{
-			return Create(DebugLevel.Info);
-		}
-		
-		public static Context Create(DebugLevel level)
-		{
-			if(thisContext == null) thisContext = new Context(level);
-			return thisContext;
-		}
-		
-		protected override void Destroy()
-		{
-			ORCDestroy();
-			thisContext = null;
-		}
-		
-		public Environment CreateEnvironment()
-		{
-			return new Environment();
-		}
-	}
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCInitialize(uint bLoadAllPlugins, uint level);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCDestroy();
+
+    private static Context thisContext = null;
+    private DebugLevel debugLevel;
+    public DebugLevel DebugLevel
+    {
+        get
+        {
+            return debugLevel;
+        }
+        set
+        {
+            debugLevel = value;
+            ORCSetDebugLevel((uint)value);
+        }
+    }
+
+    private Context(DebugLevel level) : base((IntPtr)1)
+    {
+        debugLevel = level;
+        ORCInitialize( 1, (uint)level);
+    }
+
+    public static Context Create()
+    {
+        return Create(DebugLevel.Info);
+    }
+
+    public static Context Create(DebugLevel level)
+    {
+        if(thisContext == null) thisContext = new Context(level);
+        return thisContext;
+    }
+
+    protected override void Destroy()
+    {
+        ORCDestroy();
+        thisContext = null;
+    }
+
+    public Environment CreateEnvironment()
+    {
+        return new Environment();
+    }
+}
 }
 

--- a/src/csharpbindings_c/OpenRAVE/Environment.cs
+++ b/src/csharpbindings_c/OpenRAVE/Environment.cs
@@ -6,167 +6,174 @@ using System.Text;
 
 namespace OpenRAVE
 {
-	/// <summary>
-	/// The Environment class provides a wrapper around the various Environment
-	/// related functions. An object itself must be created from the Context object.
-	/// </summary>
-	public class Environment : Base
-	{
-		[DllImport("libopenrave0.9-core_c")]
-		private static extern IntPtr ORCEnvironmentCreate();
+/// <summary>
+/// The Environment class provides a wrapper around the various Environment
+/// related functions. An object itself must be created from the Context object.
+/// </summary>
+public class Environment : Base
+{
+    [DllImport("libopenrave0.9-core_c")]
+    private static extern IntPtr ORCEnvironmentCreate();
 
-		[DllImport("libopenrave0.9-core_c")]
-		private static extern void ORCEnvironmentRelease(IntPtr pObj);
+    [DllImport("libopenrave0.9-core_c")]
+    private static extern void ORCEnvironmentRelease(IntPtr pObj);
 
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern bool ORCEnvironmentLoad(IntPtr env, string filename);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCEnvironmentDestroy(IntPtr env);
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern int ORCEnvironmentLoad(IntPtr env, string filename);
 
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern IntPtr ORCCreateKinBody(IntPtr env, string name);
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCEnvironmentDestroy(IntPtr env);
 
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern IntPtr ORCEnvironmentGetKinBody(IntPtr env, string name);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern int ORCEnvironmentGetBodies(IntPtr env, IntPtr[] bodies);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern int ORCEnvironmentGetRobots(IntPtr env, IntPtr[] robots);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCEnvironmentAdd(IntPtr env, IntPtr pinterface);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCEnvironmentRemove(IntPtr env, IntPtr pinterface);
-		
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern int ORCEnvironmentAddModule(IntPtr env, IntPtr module, string args);
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern IntPtr ORCCreateKinBody(IntPtr env, string name);
 
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern IntPtr ORCModuleCreate(IntPtr env, string modulename);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern ulong ORCEnvironmentGetSimulationTime(IntPtr env);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCEnvironmentLock(IntPtr env);
-		
-		[DllImport("libopenrave0.9_c")]
-		private static extern void ORCEnvironmentUnlock(IntPtr env);
-		
-		[DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
-		private static extern bool ORCEnvironmentSetViewer(IntPtr env, string viewername);
-		
-		internal Environment() : base(ORCEnvironmentCreate()) {}
-		
-		protected override void Destroy()
-		{
-			ORCEnvironmentDestroy(ptr);
-			ORCEnvironmentRelease(ptr);
-		}
-		
-		public bool Load(string filename)
-		{
-			return ORCEnvironmentLoad(ptr, filename);
-		}
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern IntPtr ORCEnvironmentGetKinBody(IntPtr env, string name);
 
-		public Body CreateBody(string name)
-		{
-			return new Body(ORCCreateKinBody(ptr, name));
-		}
+    [DllImport("libopenrave0.9_c")]
+    private static extern int ORCEnvironmentGetBodies(IntPtr env, IntPtr[] bodies);
 
-		public Body GetBody(string name)
-		{
-			return new Body(ORCEnvironmentGetKinBody(ptr, name));
-		}		
-		
-		public int BodyCount
-		{
-			get
-			{
-				return ORCEnvironmentGetBodies(ptr, null);
-			}
-		}
-		
-		public DisposableList<Body> Bodies
-		{
-			get
-			{
-				IntPtr[] ptrs = new IntPtr[BodyCount];
-				ORCEnvironmentGetBodies(ptr, ptrs);
-				DisposableList<Body> l = new DisposableList<Body>();
-				foreach(IntPtr p in ptrs)
-					l.Add(new Body(p));
-				return l;
-			}
-		}
-		
-		public int RobotCount
-		{
-			get
-			{
-				return ORCEnvironmentGetRobots(ptr, null);
-			}
-		}
+    [DllImport("libopenrave0.9_c")]
+    private static extern int ORCEnvironmentGetRobots(IntPtr env, IntPtr[] robots);
 
-		public DisposableList<Robot> Robots
-		{
-			get
-			{
-				IntPtr[] ptrs = new IntPtr[RobotCount];
-				ORCEnvironmentGetBodies(ptr, ptrs);
-				DisposableList<Robot> l = new DisposableList<Robot>();
-				foreach(IntPtr p in ptrs)
-					l.Add(new Robot(p));
-				return l;
-			}
-		}
-		
-		public void Add(InterfaceBase item)
-		{
-			ORCEnvironmentAdd(ptr, item.Ptr);
-		}
-		
-		public void Remove(InterfaceBase item)
-		{
-			ORCEnvironmentRemove(ptr, item.Ptr);
-		}
-		
-		public int AddModule(Module module, string args)
-		{
-			return ORCEnvironmentAddModule(ptr, module.Ptr, args);
-		}
-		
-		public Module CreateModule(string name)
-		{
-			return new Module(ORCModuleCreate(ptr, name));
-		}
-		
-		public ulong SimulationTime
-		{
-			get
-			{
-				return ORCEnvironmentGetSimulationTime(ptr);
-			}
-		}
-		
-		public void Lock()
-		{
-			ORCEnvironmentLock(ptr);
-		}
-		
-		public void Unlock()
-		{
-			ORCEnvironmentUnlock(ptr);
-		}
-		
-		public bool SetViewer(string viewername)
-		{
-			return ORCEnvironmentSetViewer(ptr, viewername);
-		}
-	}
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCEnvironmentAdd(IntPtr env, IntPtr pinterface);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCEnvironmentRemove(IntPtr env, IntPtr pinterface);
+
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern int ORCEnvironmentAddModule(IntPtr env, IntPtr module, string args);
+
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern IntPtr ORCModuleCreate(IntPtr env, string modulename);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern ulong ORCEnvironmentGetSimulationTime(IntPtr env);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCEnvironmentLock(IntPtr env);
+
+    [DllImport("libopenrave0.9_c")]
+    private static extern void ORCEnvironmentUnlock(IntPtr env);
+
+    [DllImport("libopenrave0.9_c", CharSet = CharSet.Ansi)]
+    private static extern int ORCEnvironmentSetViewer(IntPtr env, string viewername);
+
+    internal Environment() : base(ORCEnvironmentCreate()) {
+    }
+
+    protected override void Destroy()
+    {
+        ORCEnvironmentDestroy(ptr);
+        ORCEnvironmentRelease(ptr);
+    }
+
+    public bool Load(string filename)
+    {
+        if (ORCEnvironmentLoad(ptr, filename)==1)
+            return true;
+        else
+            return false;
+    }
+
+    public Body CreateBody(string name)
+    {
+        return new Body(ORCCreateKinBody(ptr, name));
+    }
+
+    public Body GetBody(string name)
+    {
+        return new Body(ORCEnvironmentGetKinBody(ptr, name));
+    }
+
+    public int BodyCount
+    {
+        get
+        {
+            return ORCEnvironmentGetBodies(ptr, null);
+        }
+    }
+
+    public DisposableList<Body> Bodies
+    {
+        get
+        {
+            IntPtr[] ptrs = new IntPtr[BodyCount];
+            ORCEnvironmentGetBodies(ptr, ptrs);
+            DisposableList<Body> l = new DisposableList<Body>();
+            foreach(IntPtr p in ptrs)
+                l.Add(new Body(p));
+            return l;
+        }
+    }
+
+    public int RobotCount
+    {
+        get
+        {
+            return ORCEnvironmentGetRobots(ptr, null);
+        }
+    }
+
+    public DisposableList<Robot> Robots
+    {
+        get
+        {
+            IntPtr[] ptrs = new IntPtr[RobotCount];
+            ORCEnvironmentGetBodies(ptr, ptrs);
+            DisposableList<Robot> l = new DisposableList<Robot>();
+            foreach(IntPtr p in ptrs)
+                l.Add(new Robot(p));
+            return l;
+        }
+    }
+
+    public void Add(InterfaceBase item)
+    {
+        ORCEnvironmentAdd(ptr, item.Ptr);
+    }
+
+    public void Remove(InterfaceBase item)
+    {
+        ORCEnvironmentRemove(ptr, item.Ptr);
+    }
+
+    public int AddModule(Module module, string args)
+    {
+        return ORCEnvironmentAddModule(ptr, module.Ptr, args);
+    }
+
+    public Module CreateModule(string name)
+    {
+        return new Module(ORCModuleCreate(ptr, name));
+    }
+
+    public ulong SimulationTime
+    {
+        get
+        {
+            return ORCEnvironmentGetSimulationTime(ptr);
+        }
+    }
+
+    public void Lock()
+    {
+        ORCEnvironmentLock(ptr);
+    }
+
+    public void Unlock()
+    {
+        ORCEnvironmentUnlock(ptr);
+    }
+
+    public bool SetViewer(string viewername)
+    {
+        if(ORCEnvironmentSetViewer(ptr, viewername)==1)
+            return true;
+        else
+            return false;
+    }
+}
 }
 


### PR DESCRIPTION
Cleaned C API to be compiled with gcc.  

Functions ( signatures) changed:  
OPENRAVE_C_API void ORCInitialize(bool bLoadAllPlugins=true, int level=Level_Info) -->
OPENRAVE_C_API void ORCInitialize(int bLoadAllPlugins, int level)

OPENRAVE_C_API bool ORCBodyInitFromTrimesh(void* body, void* trimesh, bool visible) -->
OPENRAVE_C_API int ORCBodyInitFromTrimesh(void* body, void* trimesh, int visible)

OPENRAVE_C_API bool ORCEnvironmentLoad(void* env, const char* filename) -->
OPENRAVE_C_API int ORCEnvironmentLoad(void* env, const char* filename)

OPENRAVE_C_API bool ORCEnvironmentSetViewer(void* env, const char* viewername) -->
OPENRAVE_C_API int ORCEnvironmentSetViewer(void* env, const char* viewername)   


The main  motivation for this cleanup was the desire to use OpenRAVE API within real time components upon https://github.com/machinekit/machinekit . 
The first tests look promising:  
calculating Angular Jacobian for a 5 DOF robot takes less than 15 microseconds,  inversion of a 3x3 jacobian matrix takes less than 35 microseconds in the worst case. Tests were run on Intel(R) Celeron(R) CPU  N2930  @ 1.83GHz  with the develop branch of OpenBLAS.  


*.cpp and *.c files have been uncrustify'ed.