### PR TITLE
GrasperModule QHull wrapper empty points check

### DIFF
--- a/plugins/grasper/graspermodule.cpp
+++ b/plugins/grasper/graspermodule.cpp
@@ -535,6 +535,11 @@ public:
             }
         }
 
+        if ( vpoints.empty() ) {
+            RAVELOG_ERROR("no points are provided");
+            return false;
+        }
+
         vector<double> vconvexplanes;
         boost::shared_ptr< vector<int> > vconvexfaces;
         if( bReturnFaces || bReturnTriangles ) {


### PR DESCRIPTION
Check if vpoints is empty. If empty vpoints are provided to QHull, it will crash