### PR TITLE
Shared pointer optimization

### DIFF
--- a/include/openrave/robot.h
+++ b/include/openrave/robot.h
@@ -24,6 +24,9 @@
 
 namespace OpenRAVE {
 
+class Grabbed;
+typedef boost::shared_ptr<Grabbed> GrabbedPtr;
+
 /** \brief <b>[interface]</b> A robot is a kinematic body that has attached manipulators, sensors, and controllers. <b>If not specified, method is not multi-thread safe.</b> See \ref arch_robot.
     \ingroup interfaces
  */
@@ -562,7 +565,7 @@ protected:
         int affinedofs;
         Vector rotationaxis;
         ManipulatorPtr _pManipActive;
-        std::vector<UserDataPtr> _vGrabbedBodies;
+        std::vector<GrabbedPtr> _vGrabbedBodies;
         Transform _tActiveManipLocalTool;
         Vector _vActiveManipLocalDirection;
         IkSolverBasePtr _pActiveManipIkSolver;
@@ -1010,7 +1013,7 @@ protected:
     }
 
     /// \brief **internal use only** Releases and grabs the body inside the grabbed structure from _vGrabbedBodies.
-    virtual void _Regrab(UserDataPtr pgrabbed);
+    virtual void _Regrab(GrabbedPtr pgrabbed);
 
     /// \brief Proprocess the manipulators and sensors and build the specific robot hashes.
     virtual void _ComputeInternalInformation();
@@ -1020,7 +1023,7 @@ protected:
     /// This function in calls every registers calledback that is tracking the changes.
     virtual void _PostprocessChangedParameters(uint32_t parameters);
 
-    std::vector<UserDataPtr> _vGrabbedBodies; ///< vector of grabbed bodies
+    std::vector<GrabbedPtr> _vGrabbedBodies; ///< vector of grabbed bodies
     virtual void _UpdateGrabbedBodies();
     virtual void _UpdateAttachedSensors();
     std::vector<ManipulatorPtr> _vecManipulators; ///< \see GetManipulators

--- a/plugins/basecontrollers/idealcontroller.cpp
+++ b/plugins/basecontrollers/idealcontroller.cpp
@@ -415,10 +415,10 @@ private:
     }
 
     inline boost::shared_ptr<IdealController> shared_controller() {
-        return boost::dynamic_pointer_cast<IdealController>(shared_from_this());
+        return boost::static_pointer_cast<IdealController>(shared_from_this());
     }
     inline boost::shared_ptr<IdealController const> shared_controller_const() const {
-        return boost::dynamic_pointer_cast<IdealController const>(shared_from_this());
+        return boost::static_pointer_cast<IdealController const>(shared_from_this());
     }
     inline boost::weak_ptr<IdealController> weak_controller() {
         return shared_controller();

--- a/plugins/basecontrollers/idealcontroller.cpp
+++ b/plugins/basecontrollers/idealcontroller.cpp
@@ -71,7 +71,7 @@ If SetDesired is called, only joint values will be set at every timestep leaving
             _SetJointLimits();
 
             if( _dofindices.size() > 0 ) {
-                _gjointvalues.reset(new ConfigurationSpecification::Group());
+                _gjointvalues = boost::make_shared<ConfigurationSpecification::Group>();
                 _gjointvalues->offset = 0;
                 _gjointvalues->dof = _dofindices.size();
                 stringstream ss;
@@ -82,7 +82,7 @@ If SetDesired is called, only joint values will be set at every timestep leaving
                 _gjointvalues->name = ss.str();
             }
             if( nControlTransformation ) {
-                _gtransform.reset(new ConfigurationSpecification::Group());
+                _gtransform = boost::make_shared<ConfigurationSpecification::Group>();
                 _gtransform->offset = robot->GetDOF();
                 _gtransform->dof = RaveGetAffineDOF(DOF_Transform);
                 _gtransform->name = str(boost::format("affine_transform %s %d")%robot->GetName()%DOF_Transform);
@@ -205,7 +205,7 @@ If SetDesired is called, only joint values will be set at every timestep leaving
                                     trelativepose.trans[0] = boost::lexical_cast<dReal>(tokens[8]);
                                     trelativepose.trans[1] = boost::lexical_cast<dReal>(tokens[9]);
                                     trelativepose.trans[2] = boost::lexical_cast<dReal>(tokens[10]);
-                                    _vgrabbodylinks.back().trelativepose.reset(new Transform(trelativepose));
+                                    _vgrabbodylinks.back().trelativepose = boost::make_shared<Transform>(trelativepose);
                                 }
                             }
                             dof += _samplespec._vgroups.back().dof;

--- a/plugins/basecontrollers/idealcontroller.cpp
+++ b/plugins/basecontrollers/idealcontroller.cpp
@@ -17,6 +17,7 @@
 
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 
 class IdealController : public ControllerBase
 {
@@ -558,5 +559,5 @@ private:
 
 ControllerBasePtr CreateIdealController(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return ControllerBasePtr(new IdealController(penv,sinput));
+    return boost::make_shared<IdealController>(penv, boost::ref(sinput));
 }

--- a/plugins/basecontrollers/idealvelocitycontroller.cpp
+++ b/plugins/basecontrollers/idealvelocitycontroller.cpp
@@ -17,6 +17,7 @@
 
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 
 class IdealVelocityController : public ControllerBase
 {
@@ -107,5 +108,5 @@ protected:
 
 ControllerBasePtr CreateIdealVelocityController(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return ControllerBasePtr(new IdealVelocityController(penv,sinput));
+    return boost::make_shared<IdealVelocityController>(penv, boost::ref(sinput));
 }

--- a/plugins/basecontrollers/redirectcontroller.cpp
+++ b/plugins/basecontrollers/redirectcontroller.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "plugindefs.h"
 
+#include <boost/make_shared.hpp>
+
 class RedirectController : public ControllerBase
 {
 public:
@@ -156,5 +158,5 @@ private:
 
 ControllerBasePtr CreateRedirectController(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return ControllerBasePtr(new RedirectController(penv,sinput));
+    return boost::make_shared<RedirectController>(penv, boost::ref(sinput));
 }

--- a/plugins/baserobots/collisionmaprobot.cpp
+++ b/plugins/baserobots/collisionmaprobot.cpp
@@ -271,7 +271,7 @@ protected:
 
 RobotBasePtr CreateCollisionMapRobot(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return RobotBasePtr(new CollisionMapRobot(penv,sinput));
+    return boost::make_shared<CollisionMapRobot>(penv, boost::ref(sinput));
 }
 
 void RegisterCollisionMapRobotReaders(std::list< UserDataPtr >& listRegisteredReaders)

--- a/plugins/baserobots/collisionmaprobot.cpp
+++ b/plugins/baserobots/collisionmaprobot.cpp
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "plugindefs.h"
 
+#include <boost/make_shared.hpp>
+
 class CollisionMapRobot : public RobotBase
 {
 public:
@@ -123,7 +125,7 @@ protected:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
         // ptr is the robot interface that this reader is being created for
-        return BaseXMLReaderPtr(new CollisionMapXMLReader(boost::shared_ptr<XMLData>(),atts));
+        return boost::make_shared<CollisionMapXMLReader>(boost::shared_ptr<XMLData>(),atts);
     }
 
     CollisionMapRobot(EnvironmentBasePtr penv, std::istream& sinput) : RobotBase(penv) {

--- a/plugins/baserobots/conveyor.cpp
+++ b/plugins/baserobots/conveyor.cpp
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "plugindefs.h"
+#include <boost/make_shared.hpp>
 #include <openrave/xmlreaders.h>
 
 class Conveyor : public RobotBase
@@ -269,7 +270,7 @@ protected:
 
 RobotBasePtr CreateConveyorRobot(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return RobotBasePtr(new Conveyor(penv,sinput));
+    return boost::make_shared<Conveyor>(penv, boost::ref(sinput));
 }
 
 void RegisterConveyorReaders(std::list< UserDataPtr >& listRegisteredReaders)

--- a/plugins/baserobots/conveyor.cpp
+++ b/plugins/baserobots/conveyor.cpp
@@ -187,7 +187,7 @@ protected:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
         // ptr is the robot interface that this reader is being created for
-        return BaseXMLReaderPtr(new ConveyorXMLReader(ConveyorInfoPtr(),RaveInterfaceCast<RobotBase>(ptr), atts));
+        return boost::make_shared<ConveyorXMLReader>(ConveyorInfoPtr(),RaveInterfaceCast<RobotBase>(ptr), atts);
     }
 
     Conveyor(EnvironmentBasePtr penv, std::istream& is) : RobotBase(penv) {

--- a/plugins/basesamplers/basesamplers.cpp
+++ b/plugins/basesamplers/basesamplers.cpp
@@ -14,6 +14,7 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#include <boost/make_shared.hpp>
 #include <openrave/plugin.h>
 #include "mt19937ar.h"
 #include "halton.h"
@@ -25,16 +26,16 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
     switch(type) {
     case PT_SpaceSampler:
         if( interfacename == "mt19937") {
-            return InterfaceBasePtr(new MT19937Sampler(penv,sinput));
+            return boost::make_shared<MT19937Sampler>(penv, boost::ref(sinput));
         }
         else if( interfacename == "halton" ) {
-            return InterfaceBasePtr(new HaltonSampler(penv,sinput));
+            return boost::make_shared<HaltonSampler>(penv, boost::ref(sinput));
         }
         else if( interfacename == "robotconfiguration" ) {
-            return InterfaceBasePtr(new RobotConfigurationSampler(penv,sinput));
+            return boost::make_shared<RobotConfigurationSampler>(penv, boost::ref(sinput));
         }
         else if( interfacename == "bodyconfiguration" ) {
-            return InterfaceBasePtr(new BodyConfigurationSampler(penv,sinput));
+            return boost::make_shared<BodyConfigurationSampler>(penv, boost::ref(sinput));
         }
         break;
     default:

--- a/plugins/basesensors/basecamera.h
+++ b/plugins/basesensors/basecamera.h
@@ -300,7 +300,7 @@ public:
     virtual SensorDataPtr CreateSensorData(SensorType type)
     {
         if(( type == ST_Invalid) ||( type == ST_Camera) ) {
-            return SensorDataPtr(boost::shared_ptr<CameraSensorData>(new CameraSensorData()));
+            return boost::make_shared<CameraSensorData>();
         }
         return SensorDataPtr();
     }

--- a/plugins/basesensors/basecamera.h
+++ b/plugins/basesensors/basecamera.h
@@ -16,6 +16,7 @@
 #ifndef OPENRAVE_BASECAMERA_H
 #define OPENRAVE_BASECAMERA_H
 
+#include <boost/make_shared.hpp>
 #include <boost/lexical_cast.hpp>
 
 class BaseCameraSensor : public SensorBase
@@ -167,7 +168,7 @@ protected:
 public:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-        return BaseXMLReaderPtr(new BaseCameraXMLReader(boost::dynamic_pointer_cast<BaseCameraSensor>(ptr)));
+        return boost::make_shared<BaseCameraXMLReader>(boost::dynamic_pointer_cast<BaseCameraSensor>(ptr));
     }
 
     BaseCameraSensor(EnvironmentBasePtr penv) : SensorBase(penv) {

--- a/plugins/basesensors/baseflashlidar3d.h
+++ b/plugins/basesensors/baseflashlidar3d.h
@@ -16,6 +16,8 @@
 #ifndef OPENRAVE_BASEFLASHLIDAR_H
 #define OPENRAVE_BASEFLASHLIDAR_H
 
+#include <boost/make_shared.hpp>
+
 /// Flash LIDAR - sends laser points given a camera projection matrix
 class BaseFlashLidar3DSensor : public SensorBase
 {
@@ -123,7 +125,7 @@ public:
 public:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-        return BaseXMLReaderPtr(new BaseFlashLidar3DXMLReader(boost::dynamic_pointer_cast<BaseFlashLidar3DSensor>(ptr)));
+        return boost::make_shared<BaseFlashLidar3DXMLReader>(boost::dynamic_pointer_cast<BaseFlashLidar3DSensor>(ptr));
     }
 
     BaseFlashLidar3DSensor(EnvironmentBasePtr penv) : SensorBase(penv)
@@ -313,7 +315,7 @@ public:
     virtual SensorDataPtr CreateSensorData(SensorType type)
     {
         if(( type == ST_Invalid) ||( type == ST_Laser) ) {
-            return SensorDataPtr(new LaserSensorData());
+            return boost::make_shared<LaserSensorData>();
         }
         return SensorDataPtr();
     }

--- a/plugins/basesensors/baselaser.h
+++ b/plugins/basesensors/baselaser.h
@@ -16,6 +16,8 @@
 #ifndef OPENRAVE_BASELASER_H
 #define OPENRAVE_BASELASER_H
 
+#include <boost/make_shared.hpp>
+
 /// Laser rotates around the zaxis and it's 0 angle is pointed toward the xaxis.
 class BaseLaser2DSensor : public SensorBase
 {
@@ -120,7 +122,7 @@ protected:
 public:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-        return BaseXMLReaderPtr(new BaseLaser2DXMLReader(boost::dynamic_pointer_cast<BaseLaser2DSensor>(ptr)));
+        return boost::make_shared<BaseLaser2DXMLReader>(boost::dynamic_pointer_cast<BaseLaser2DSensor>(ptr));
     }
 
     BaseLaser2DSensor(EnvironmentBasePtr penv) : SensorBase(penv) {
@@ -299,7 +301,7 @@ public:
     virtual SensorDataPtr CreateSensorData(SensorType type)
     {
         if(( type == ST_Invalid) ||( type == ST_Laser) ) {
-            return SensorDataPtr(new LaserSensorData());
+            return boost::make_shared<LaserSensorData>();
         }
         return SensorDataPtr();
     }
@@ -512,7 +514,7 @@ public:
 public:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-        return BaseXMLReaderPtr(new BaseSpinningLaser2DXMLReader(boost::dynamic_pointer_cast<BaseSpinningLaser2DSensor>(ptr)));
+        return boost::make_shared<BaseSpinningLaser2DXMLReader>(boost::dynamic_pointer_cast<BaseSpinningLaser2DSensor>(ptr));
     }
 
     BaseSpinningLaser2DSensor(EnvironmentBasePtr penv) : BaseLaser2DSensor(penv) {

--- a/plugins/basesensors/basesensors.cpp
+++ b/plugins/basesensors/basesensors.cpp
@@ -34,16 +34,16 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
     switch(type) {
     case PT_Sensor:
         if((interfacename == "baselaser2d")||(interfacename == "base_laser2d")) {
-            return InterfaceBasePtr(new BaseLaser2DSensor(penv));
+            return boost::make_shared<BaseLaser2DSensor>(penv);
         }
         else if( interfacename == "basespinninglaser2d" ) {
-            return InterfaceBasePtr(new BaseSpinningLaser2DSensor(penv));
+            return  boost::make_shared<BaseSpinningLaser2DSensor>(penv);
         }
         else if((interfacename == "baseflashlidar3d")||(interfacename == "base_laser3d")) {
-            return InterfaceBasePtr(new BaseFlashLidar3DSensor(penv));
+            return  boost::make_shared<BaseFlashLidar3DSensor>(penv);
         }
         else if((interfacename == "basecamera")||(interfacename == "base_pinhole_camera")) {
-            return InterfaceBasePtr(new BaseCameraSensor(penv));
+            return  boost::make_shared<BaseCameraSensor>(penv);
         }
         break;
     default:

--- a/plugins/bulletrave/bulletcollision.h
+++ b/plugins/bulletrave/bulletcollision.h
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "bulletspace.h"
 
+#include <boost/make_shared.hpp>
+
 class BulletCollisionChecker : public CollisionCheckerBase
 {
 private:
@@ -811,5 +813,5 @@ private:
 
 CollisionCheckerBasePtr CreateBulletCollisionChecker(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return CollisionCheckerBasePtr(new BulletCollisionChecker(penv,sinput));
+    return boost::make_shared<BulletCollisionChecker>(penv, boost::ref(sinput));
 }

--- a/plugins/bulletrave/bulletphysics.h
+++ b/plugins/bulletrave/bulletphysics.h
@@ -16,6 +16,8 @@
 // 2013 Modifications: Theodoros Stouraitis and Praveen Ramanujam
 #include "bulletspace.h"
 
+#include <boost/make_shared.hpp>
+
 class BulletPhysicsEngine : public PhysicsEngineBase
 {
     class PhysicsFilterCallback : public OpenRAVEFilterCallback
@@ -184,7 +186,7 @@ public:
     
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-    	return BaseXMLReaderPtr(new PhysicsPropertiesXMLReader(boost::dynamic_pointer_cast<BulletPhysicsEngine>(ptr),atts));
+    	return boost::make_shared<PhysicsPropertiesXMLReader>(boost::dynamic_pointer_cast<BulletPhysicsEngine>(ptr),atts);
     }
 
     BulletPhysicsEngine(EnvironmentBasePtr penv, std::istream& sinput) : PhysicsEngineBase(penv), _space(new BulletSpace(penv, GetPhysicsInfo, true))
@@ -725,5 +727,5 @@ private:
 
 PhysicsEngineBasePtr CreateBulletPhysicsEngine(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PhysicsEngineBasePtr(new BulletPhysicsEngine(penv,sinput));
+    return boost::make_shared<BulletPhysicsEngine>(penv, boost::ref(sinput));
 }

--- a/plugins/bulletrave/bulletphysics.h
+++ b/plugins/bulletrave/bulletphysics.h
@@ -71,10 +71,10 @@ public:
     };
 
     inline boost::shared_ptr<BulletPhysicsEngine> shared_physics() {
-        return boost::dynamic_pointer_cast<BulletPhysicsEngine>(shared_from_this());
+        return boost::static_pointer_cast<BulletPhysicsEngine>(shared_from_this());
     }
     inline boost::shared_ptr<BulletPhysicsEngine const> shared_physics_const() const {
-        return boost::dynamic_pointer_cast<BulletPhysicsEngine const>(shared_from_this());
+        return boost::static_pointer_cast<BulletPhysicsEngine const>(shared_from_this());
     }
 
 class PhysicsPropertiesXMLReader : public BaseXMLReader

--- a/plugins/configurationcache/cachechecker.cpp
+++ b/plugins/configurationcache/cachechecker.cpp
@@ -14,6 +14,8 @@
 #include "openraveplugindefs.h"
 #include "configurationcachetree.h"
 
+#include <boost/make_shared.hpp>
+
 namespace configurationcache
 {
 
@@ -690,7 +692,7 @@ protected:
 
 CollisionCheckerBasePtr CreateCacheCollisionChecker(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return CollisionCheckerBasePtr(new CacheCollisionChecker(penv, sinput));
+    return boost::make_shared<CacheCollisionChecker>(penv, boost::ref(sinput));
 }
 
 };

--- a/plugins/configurationcache/configurationjitterer.cpp
+++ b/plugins/configurationcache/configurationjitterer.cpp
@@ -911,7 +911,7 @@ protected:
 
 SpaceSamplerBasePtr CreateConfigurationJitterer(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return boost::make_shared<ConfigurationJitterer>(penv, sinput);
+    return boost::make_shared<ConfigurationJitterer>(penv, boost::ref(sinput));
 }
 
 }

--- a/plugins/configurationcache/configurationjitterer.cpp
+++ b/plugins/configurationcache/configurationjitterer.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 #include <openraveplugindefs.h>
 
+#include <boost/make_shared.hpp>
+
 #ifdef OPENRAVE_HAS_LAPACK
 // for jacobians
 #include <boost/numeric/ublas/vector.hpp>
@@ -909,7 +911,7 @@ protected:
 
 SpaceSamplerBasePtr CreateConfigurationJitterer(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return SpaceSamplerBasePtr(new ConfigurationJitterer(penv, sinput));
+    return boost::make_shared<ConfigurationJitterer>(penv, sinput);
 }
 
 }

--- a/plugins/dualmanipulation/dualmanipulation.cpp
+++ b/plugins/dualmanipulation/dualmanipulation.cpp
@@ -15,13 +15,14 @@
 #include "plugindefs.h"
 #include "dualmanipulation.h"
 #include <openrave/plugin.h>
+#include <boost/make_shared.hpp>
 
 InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string& interfacename, std::istream& sinput, EnvironmentBasePtr penv)
 {
     switch(type) {
     case PT_Module:
         if( interfacename == "dualmanipulation")
-            return InterfaceBasePtr(new DualManipulation(penv));
+            return boost::make_shared<DualManipulation>(penv);
         break;
     default:
         break;

--- a/plugins/dualmanipulation/dualmanipulation.h
+++ b/plugins/dualmanipulation/dualmanipulation.h
@@ -94,10 +94,10 @@ public:
 protected:
 
     inline boost::shared_ptr<DualManipulation> shared_problem() {
-        return boost::dynamic_pointer_cast<DualManipulation>(shared_from_this());
+        return boost::static_pointer_cast<DualManipulation>(shared_from_this());
     }
     inline boost::shared_ptr<DualManipulation const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<DualManipulation const>(shared_from_this());
+        return boost::static_pointer_cast<DualManipulation const>(shared_from_this());
     }
 
     bool SetActiveManip(ostream& sout, istream& sinput)

--- a/plugins/fclrave/fclcollision.h
+++ b/plugins/fclrave/fclcollision.h
@@ -63,7 +63,7 @@ public:
         {
             _bHasCallbacks = _pchecker->GetEnv()->HasRegisteredCollisionCallbacks();
             if( _bHasCallbacks && !_report ) {
-                _report.reset(new CollisionReport());
+                _report = boost::make_shared<CollisionReport>();
             }
 
             // TODO : What happens if we have CO_AllGeometryContacts set and not CO_Contacts ?
@@ -112,7 +112,7 @@ public:
         : OpenRAVE::CollisionCheckerBase(penv), _broadPhaseCollisionManagerAlgorithm("DynamicAABBTree2"), _bIsSelfCollisionChecker(true) // DynamicAABBTree2 should be slightly faster than Naive
     {
         _userdatakey = std::string("fclcollision") + boost::lexical_cast<std::string>(this);
-        _fclspace.reset(new FCLSpace(penv, _userdatakey));
+        _fclspace = boost::make_shared<FCLSpace>(penv, _userdatakey);
         _options = 0;
         // TODO : Should we put a more reasonable arbitrary value ?
         _numMaxContacts = std::numeric_limits<int>::max();
@@ -684,7 +684,7 @@ public:
 
 private:
     inline boost::shared_ptr<FCLCollisionChecker> shared_checker() {
-        return boost::dynamic_pointer_cast<FCLCollisionChecker>(shared_from_this());
+        return boost::static_pointer_cast<FCLCollisionChecker>(shared_from_this());
     }
 
     static bool CheckNarrowPhaseCollision(fcl::CollisionObject *o1, fcl::CollisionObject *o2, void *data) {
@@ -890,7 +890,7 @@ private:
     {
         BODYMANAGERSMAP::iterator it = _bodymanagers.find(std::make_pair(pbody, (int)bactiveDOFs));
         if( it == _bodymanagers.end() ) {
-            FCLCollisionManagerInstancePtr p(new FCLCollisionManagerInstance(*_fclspace, _CreateManager()));
+            FCLCollisionManagerInstancePtr p = boost::make_shared<FCLCollisionManagerInstance>(*_fclspace, _CreateManager());
             p->InitBodyManager(pbody, bactiveDOFs);
             it = _bodymanagers.insert(BODYMANAGERSMAP::value_type(std::make_pair(pbody, (int)bactiveDOFs), p)).first;
         }
@@ -924,7 +924,7 @@ private:
 
         std::map<std::set<int>, FCLCollisionManagerInstancePtr>::iterator it = _envmanagers.find(setExcludeBodyIds);
         if( it == _envmanagers.end() ) {
-            FCLCollisionManagerInstancePtr p(new FCLCollisionManagerInstance(*_fclspace, _CreateManager()));
+            FCLCollisionManagerInstancePtr p = boost::make_shared<FCLCollisionManagerInstance>(*_fclspace, _CreateManager());
             p->InitEnvironment(excludedbodies);
             it = _envmanagers.insert(std::map<std::set<int>, FCLCollisionManagerInstancePtr>::value_type(setExcludeBodyIds, p)).first;
         }

--- a/plugins/fclrave/fclrave.cpp
+++ b/plugins/fclrave/fclrave.cpp
@@ -17,13 +17,14 @@
 
 #include "fclcollision.h"
 
+#include <boost/make_shared.hpp>
 #include <openrave/plugin.h>
 
 InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string& interfacename, std::istream& sinput, EnvironmentBasePtr penv)
 {
 
     if( type == OpenRAVE::PT_CollisionChecker && interfacename == "fcl_" ) {
-        return InterfaceBasePtr(new fclrave::FCLCollisionChecker(penv, sinput));
+        return boost::make_shared<fclrave::FCLCollisionChecker>(penv, boost::ref(sinput));
     }
 
     return InterfaceBasePtr();

--- a/plugins/fclrave/fclspace.h
+++ b/plugins/fclrave/fclspace.h
@@ -204,7 +204,7 @@ public:
         pinfo->vlinks.reserve(pbody->GetLinks().size());
         FOREACHC(itlink, pbody->GetLinks()) {
 
-            boost::shared_ptr<KinBodyInfo::LINK> link(new KinBodyInfo::LINK(*itlink));
+            boost::shared_ptr<KinBodyInfo::LINK> link = boost::make_shared<KinBodyInfo::LINK>(*itlink);
 
 
             typedef boost::range_detail::any_iterator<KinBody::GeometryInfo, boost::forward_traversal_tag, KinBody::GeometryInfo const&, std::ptrdiff_t> GeometryInfoIterator;

--- a/plugins/grasper/graspermodule.cpp
+++ b/plugins/grasper/graspermodule.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "plugindefs.h"
 
+#include <boost/make_shared.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
 
@@ -1704,5 +1705,5 @@ protected:
 
 ModuleBasePtr CreateGrasperModule(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return ModuleBasePtr(new GrasperModule(penv,sinput));
+    return boost::make_shared<GrasperModule>(penv, boost::ref(sinput));
 }

--- a/plugins/grasper/grasperplanner.cpp
+++ b/plugins/grasper/grasperplanner.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "plugindefs.h"
 
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
 
 class GrasperPlanner :  public PlannerBase
@@ -694,5 +695,5 @@ protected:
 
 PlannerBasePtr CreateGrasperPlanner(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PlannerBasePtr(new GrasperPlanner(penv,sinput));
+    return boost::make_shared<GrasperPlanner>(penv, boost::ref(sinput));
 }

--- a/plugins/ikfastsolvers/ikfastmodule.cpp
+++ b/plugins/ikfastsolvers/ikfastmodule.cpp
@@ -16,6 +16,7 @@
 #include "plugindefs.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 
 #ifdef Boost_IOSTREAMS_FOUND
 #include <boost/iostreams/device/file_descriptor.hpp>
@@ -1436,7 +1437,7 @@ public:
 
 ModuleBasePtr CreateIkFastModule(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return ModuleBasePtr(new IkFastModule(penv,sinput));
+    return boost::make_shared<IkFastModule>(penv, boost::ref(sinput));
 }
 
 void DestroyIkFastLibraries() {

--- a/plugins/ikfastsolvers/ikfastmodule.cpp
+++ b/plugins/ikfastsolvers/ikfastmodule.cpp
@@ -305,10 +305,10 @@ private:
     };
 
     inline boost::shared_ptr<IkFastModule> shared_problem() {
-        return boost::dynamic_pointer_cast<IkFastModule>(shared_from_this());
+        return boost::static_pointer_cast<IkFastModule>(shared_from_this());
     }
     inline boost::shared_ptr<IkFastModule const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<IkFastModule const>(shared_from_this());
+        return boost::static_pointer_cast<IkFastModule const>(shared_from_this());
     }
 
 public:

--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -18,6 +18,7 @@
 #include <boost/bind.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 
 #ifdef OPENRAVE_HAS_LAPACK
 #include "jacobianinverse.h"
@@ -2012,11 +2013,11 @@ protected:
 IkSolverBasePtr CreateIkFastSolver(EnvironmentBasePtr penv, std::istream& sinput, boost::shared_ptr<ikfast::IkFastFunctions<float> > ikfunctions, const vector<dReal>& vfreeinc)
 
 {
-    return IkSolverBasePtr(new IkFastSolver<float>(penv,sinput,ikfunctions,vfreeinc));
+    return boost::make_shared<IkFastSolver<float> >(penv,sinput,ikfunctions,vfreeinc);
 }
 #endif
 
 IkSolverBasePtr CreateIkFastSolver(EnvironmentBasePtr penv, std::istream& sinput, boost::shared_ptr<ikfast::IkFastFunctions<double> > ikfunctions, const vector<dReal>& vfreeinc)
 {
-    return IkSolverBasePtr(new IkFastSolver<double>(penv,sinput,ikfunctions,vfreeinc));
+    return boost::make_shared<IkFastSolver<double> >(penv,sinput,ikfunctions,vfreeinc);
 }

--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -2013,11 +2013,11 @@ protected:
 IkSolverBasePtr CreateIkFastSolver(EnvironmentBasePtr penv, std::istream& sinput, boost::shared_ptr<ikfast::IkFastFunctions<float> > ikfunctions, const vector<dReal>& vfreeinc)
 
 {
-    return boost::make_shared<IkFastSolver<float> >(penv,sinput,ikfunctions,vfreeinc);
+    return boost::make_shared<IkFastSolver<float> >(penv, boost::ref(sinput),ikfunctions,vfreeinc);
 }
 #endif
 
 IkSolverBasePtr CreateIkFastSolver(EnvironmentBasePtr penv, std::istream& sinput, boost::shared_ptr<ikfast::IkFastFunctions<double> > ikfunctions, const vector<dReal>& vfreeinc)
 {
-    return boost::make_shared<IkFastSolver<double> >(penv,sinput,ikfunctions,vfreeinc);
+    return boost::make_shared<IkFastSolver<double> >(penv, boost::ref(sinput),ikfunctions,vfreeinc);
 }

--- a/plugins/logging/viewerrecorder.cpp
+++ b/plugins/logging/viewerrecorder.cpp
@@ -81,10 +81,10 @@ static boost::shared_ptr<VideoGlobalState> s_pVideoGlobalState;
 class ViewerRecorder : public ModuleBase
 {
     inline boost::shared_ptr<ViewerRecorder> shared_module() {
-        return boost::dynamic_pointer_cast<ViewerRecorder>(shared_from_this());
+        return boost::static_pointer_cast<ViewerRecorder>(shared_from_this());
     }
     inline boost::shared_ptr<ViewerRecorder const> shared_module_const() const {
-        return boost::dynamic_pointer_cast<ViewerRecorder const>(shared_from_this());
+        return boost::static_pointer_cast<ViewerRecorder const>(shared_from_this());
     }
     struct VideoFrame
     {

--- a/plugins/logging/viewerrecorder.cpp
+++ b/plugins/logging/viewerrecorder.cpp
@@ -16,11 +16,11 @@
 #define __STDC_CONSTANT_MACROS
 #include "plugindefs.h"
 
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
-#include <boost/version.hpp>
-
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/version.hpp>
 
 #ifdef _WIN32
 
@@ -902,7 +902,7 @@ protected:
 };
 
 ModuleBasePtr CreateViewerRecorder(EnvironmentBasePtr penv, std::istream& sinput) {
-    return ModuleBasePtr(new ViewerRecorder(penv,sinput));
+    return boost::make_shared<ViewerRecorder>(penv, boost::ref(sinput));
 }
 void DestroyViewerRecordingStaticResources()
 {

--- a/plugins/mobyrave/mobycontroller.h
+++ b/plugins/mobyrave/mobycontroller.h
@@ -794,12 +794,12 @@ private:
 
     inline boost::shared_ptr<MobyController> shared_controller()
     {
-        return boost::dynamic_pointer_cast<MobyController>(shared_from_this());
+        return boost::static_pointer_cast<MobyController>(shared_from_this());
     }
 
     inline boost::shared_ptr<MobyController const> shared_controller_const() const
     {
-        return boost::dynamic_pointer_cast<MobyController const>(shared_from_this());
+        return boost::static_pointer_cast<MobyController const>(shared_from_this());
     }
 
     inline boost::weak_ptr<MobyController> weak_controller()

--- a/plugins/mobyrave/mobycontroller.h
+++ b/plugins/mobyrave/mobycontroller.h
@@ -17,6 +17,7 @@
 
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 
 class MobyController : public ControllerBase
 {
@@ -111,7 +112,7 @@ protected:
 public:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-    	return BaseXMLReaderPtr(new ControllerPropertiesXMLReader(boost::dynamic_pointer_cast<MobyController>(ptr),atts));
+    	return boost::make_shared<ControllerPropertiesXMLReader>(boost::dynamic_pointer_cast<MobyController>(ptr),atts);
     }
 
     MobyController(EnvironmentBasePtr penv, std::istream& sinput) : ControllerBase(penv), cmdid(0), _bPause(false), _bIsDone(true), _bCheckCollision(false), _bThrowExceptions(false), _bEnableLogging(false), _bEnableTuningLogging(false), _bSteadyState(false)    {
@@ -1003,5 +1004,5 @@ private:
 
 ControllerBasePtr CreateMobyController(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return ControllerBasePtr(new MobyController(penv,sinput));
+    return boost::make_shared<MobyController>(penv, boost::ref(sinput));
 }

--- a/plugins/mobyrave/mobyphysics.h
+++ b/plugins/mobyrave/mobyphysics.h
@@ -27,11 +27,11 @@ class MobyPhysics : public PhysicsEngineBase
 {
 
     inline boost::shared_ptr<MobyPhysics> shared_physics() {
-        return boost::dynamic_pointer_cast<MobyPhysics>(shared_from_this());
+        return boost::static_pointer_cast<MobyPhysics>(shared_from_this());
     }
 
     inline boost::shared_ptr<MobyPhysics const> shared_physics_const() const {
-        return boost::dynamic_pointer_cast<MobyPhysics const>(shared_from_this());
+        return boost::static_pointer_cast<MobyPhysics const>(shared_from_this());
     }
 
     class PhysicsPropertiesXMLReader : public BaseXMLReader

--- a/plugins/mobyrave/mobyphysics.h
+++ b/plugins/mobyrave/mobyphysics.h
@@ -18,6 +18,7 @@
 
 #include "mobyspace.h"
 
+#include <boost/make_shared.hpp>
 #include <Moby/TimeSteppingSimulator.h>
 #include <Moby/EulerIntegrator.h>
 #include <Moby/GravityForce.h>
@@ -116,7 +117,7 @@ public:
 
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-    	return BaseXMLReaderPtr(new PhysicsPropertiesXMLReader(boost::dynamic_pointer_cast<MobyPhysics>(ptr),atts));
+    	return boost::make_shared<PhysicsPropertiesXMLReader>(boost::dynamic_pointer_cast<MobyPhysics>(ptr),atts);
     }
 
     MobyPhysics(EnvironmentBasePtr penv, istream& sinput) : PhysicsEngineBase(penv), _StepSize(0.001), _space(new MobySpace(penv, GetPhysicsInfo, true)) 

--- a/plugins/mobyrave/mobyrave.cpp
+++ b/plugins/mobyrave/mobyrave.cpp
@@ -22,7 +22,7 @@ using namespace OpenRAVE;
 // create moby physics shared pointer
 PhysicsEngineBasePtr CreateMobyPhysics(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PhysicsEngineBasePtr(new MobyPhysics(penv,sinput));
+    return boost::make_shared<MobyPhysics>(penv, boost::ref(sinput));
 }
 
 static std::list< OpenRAVE::UserDataPtr >* s_listRegisteredReaders = NULL; ///< have to make it a pointer in order to prevent static object
@@ -46,10 +46,10 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
         break;
     case OpenRAVE::PT_Controller:
         if( interfacename == "moby") {
-            return InterfaceBasePtr(new MobyController(penv,sinput));
+            return boost::make_shared<MobyController>(penv, boost::ref(sinput));
         }
         else if( interfacename == "mobyreplay") {
-            return InterfaceBasePtr(new MobyReplayController(penv,sinput));
+            return boost::make_shared<MobyReplayController>(penv, boost::ref(sinput));
         }
         break;
     default:

--- a/plugins/mobyrave/mobyreplaycontroller.h
+++ b/plugins/mobyrave/mobyreplaycontroller.h
@@ -818,12 +818,12 @@ private:
 
     inline boost::shared_ptr<MobyReplayController> shared_controller()
     {
-        return boost::dynamic_pointer_cast<MobyReplayController>(shared_from_this());
+        return boost::static_pointer_cast<MobyReplayController>(shared_from_this());
     }
 
     inline boost::shared_ptr<MobyReplayController const> shared_controller_const() const
     {
-        return boost::dynamic_pointer_cast<MobyReplayController const>(shared_from_this());
+        return boost::static_pointer_cast<MobyReplayController const>(shared_from_this());
     }
 
     inline boost::weak_ptr<MobyReplayController> weak_controller()

--- a/plugins/mobyrave/mobyreplaycontroller.h
+++ b/plugins/mobyrave/mobyreplaycontroller.h
@@ -17,6 +17,7 @@
 
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 
 class MRDFile {
 private:
@@ -282,7 +283,7 @@ protected:
 public:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-    	return BaseXMLReaderPtr(new ControllerPropertiesXMLReader(boost::dynamic_pointer_cast<MobyReplayController>(ptr),atts));
+    	return boost::make_shared<ControllerPropertiesXMLReader>(boost::dynamic_pointer_cast<MobyReplayController>(ptr),atts);
     }
 
     MobyReplayController(EnvironmentBasePtr penv, std::istream& sinput) : ControllerBase(penv), cmdid(0), _bPause(false), _bIsDone(true), _bCheckCollision(false), _bThrowExceptions(false), _bEnableLogging(false), _mrdfilename(""), _firstAction(true) {
@@ -991,5 +992,5 @@ private:
 
 ControllerBasePtr CreateMobyReplayController(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return ControllerBasePtr(new MobyReplayController(penv,sinput));
+    return boost::make_shared<MobyReplayController>(penv, boost::ref(sinput));
 }

--- a/plugins/mobyrave/mobyspace.h
+++ b/plugins/mobyrave/mobyspace.h
@@ -29,6 +29,8 @@
 #include <Moby/SphericalJoint.h>
 #include <Moby/GravityForce.h>
 
+#include <boost/make_shared.hpp>
+
 typedef void (*ControllerCallbackFn)(boost::shared_ptr<Moby::DynamicBody>,double,void*);
 
 // manages a space of Moby objects
@@ -132,7 +134,7 @@ private:
 
         // compute a box to approximate link inertial properties
         AABB bb = plink->ComputeLocalAABB();
-        link->_primitive = Moby::PrimitivePtr(new Moby::BoxPrimitive(bb.extents.x*2,bb.extents.y*2,bb.extents.z*2));
+        link->_primitive = boost::make_shared<Moby::BoxPrimitive>(bb.extents.x*2,bb.extents.y*2,bb.extents.z*2);
         link->_primitive->set_mass(plink->GetMass());
 
         // assign link parameters

--- a/plugins/oderave/odecollision.h
+++ b/plugins/oderave/odecollision.h
@@ -104,10 +104,10 @@ private:
     };
 
     inline boost::shared_ptr<ODECollisionChecker> shared_checker() {
-        return boost::dynamic_pointer_cast<ODECollisionChecker>(shared_from_this());
+        return boost::static_pointer_cast<ODECollisionChecker>(shared_from_this());
     }
     inline boost::shared_ptr<ODECollisionChecker const> shared_checker_const() const {
-        return boost::dynamic_pointer_cast<ODECollisionChecker const>(shared_from_this());
+        return boost::static_pointer_cast<ODECollisionChecker const>(shared_from_this());
     }
 
 public:

--- a/plugins/oderave/odephysics.h
+++ b/plugins/oderave/odephysics.h
@@ -18,6 +18,8 @@
 
 #include "odespace.h"
 
+#include <boost/make_shared.hpp>
+
 class ODEPhysicsEngine : public OpenRAVE::PhysicsEngineBase
 {
     // ODE joint helper fns
@@ -184,7 +186,7 @@ protected:
 public:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
-        return BaseXMLReaderPtr(new PhysicsPropertiesXMLReader(boost::dynamic_pointer_cast<ODEPhysicsEngine>(ptr),atts));
+        return boost::make_shared<PhysicsPropertiesXMLReader>(boost::dynamic_pointer_cast<ODEPhysicsEngine>(ptr),atts);
     }
 
     ODEPhysicsEngine(OpenRAVE::EnvironmentBasePtr penv) : OpenRAVE::PhysicsEngineBase(penv), _odespace(new ODESpace(penv, "odephysics", true)) {

--- a/plugins/oderave/odephysics.h
+++ b/plugins/oderave/odephysics.h
@@ -61,10 +61,10 @@ class ODEPhysicsEngine : public OpenRAVE::PhysicsEngineBase
     }
 
     inline boost::shared_ptr<ODEPhysicsEngine> shared_physics() {
-        return boost::dynamic_pointer_cast<ODEPhysicsEngine>(shared_from_this());
+        return boost::static_pointer_cast<ODEPhysicsEngine>(shared_from_this());
     }
     inline boost::shared_ptr<ODEPhysicsEngine const> shared_physics_const() const {
-        return boost::dynamic_pointer_cast<ODEPhysicsEngine const>(shared_from_this());
+        return boost::static_pointer_cast<ODEPhysicsEngine const>(shared_from_this());
     }
 
     class PhysicsPropertiesXMLReader : public BaseXMLReader

--- a/plugins/oderave/oderave.cpp
+++ b/plugins/oderave/oderave.cpp
@@ -18,6 +18,7 @@
 #include "odephysics.h"
 #include "odecontroller.h"
 
+#include <boost/make_shared.hpp>
 #include <openrave/plugin.h>
 
 static std::list< OpenRAVE::UserDataPtr >* s_listRegisteredReaders = NULL; ///< have to make it a pointer in order to prevent static object destruction from taking precedence
@@ -31,15 +32,15 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
     switch(type) {
     case OpenRAVE::PT_CollisionChecker:
         if( interfacename == "ode")
-            return InterfaceBasePtr(new ODECollisionChecker(penv));
+            return boost::make_shared<ODECollisionChecker>(penv);
         break;
     case OpenRAVE::PT_PhysicsEngine:
         if( interfacename == "ode" )
-            return InterfaceBasePtr(new ODEPhysicsEngine(penv));
+            return boost::make_shared<ODEPhysicsEngine>(penv);
         break;
     case OpenRAVE::PT_Controller:
         if( interfacename == "odevelocity")
-            return InterfaceBasePtr(new ODEVelocityController(penv));
+            return boost::make_shared<ODEVelocityController>(penv);
         break;
     default:
         break;

--- a/plugins/pqprave/pqprave.cpp
+++ b/plugins/pqprave/pqprave.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "plugindefs.h"
 #include "collisionPQP.h"
+#include <boost/make_shared.hpp>
 #include <openrave/plugin.h>
 
 InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string& interfacename, std::istream& sinput, EnvironmentBasePtr penv)
@@ -21,7 +22,7 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
     switch(type) {
     case OpenRAVE::PT_CollisionChecker:
         if( interfacename == "pqp")
-            return InterfaceBasePtr(new CollisionCheckerPQP(penv));
+            return boost::make_shared<CollisionCheckerPQP>(penv);
         break;
     default:
         break;

--- a/plugins/qtcoinrave/item.h
+++ b/plugins/qtcoinrave/item.h
@@ -126,7 +126,7 @@ protected:
     };
 
     inline boost::shared_ptr<KinBodyItem> shared_kinbody() {
-        return boost::dynamic_pointer_cast<KinBodyItem>(shared_from_this());
+        return boost::static_pointer_cast<KinBodyItem>(shared_from_this());
     }
     inline boost::weak_ptr<KinBodyItem> weak_kinbody() {
         return shared_kinbody();

--- a/plugins/qtcoinrave/ivmodelloader.cpp
+++ b/plugins/qtcoinrave/ivmodelloader.cpp
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "qtcoin.h"
 #include <boost/algorithm/string.hpp>
-
+#include <boost/make_shared.hpp>
 #include <Inventor/SoDB.h>
 #include <Inventor/SoInput.h>
 #include <Inventor/nodes/SoMaterial.h>
@@ -235,5 +235,5 @@ public:
 };
 
 ModuleBasePtr CreateIvModelLoader(EnvironmentBasePtr penv) {
-    return ModuleBasePtr(new IvModelLoader(penv));
+    return boost::make_shared<IvModelLoader>(penv);
 }

--- a/plugins/qtcoinrave/qtcoinrave.cpp
+++ b/plugins/qtcoinrave/qtcoinrave.cpp
@@ -18,6 +18,7 @@
 #if defined(HAVE_X11_XLIB_H) && defined(Q_WS_X11)
 #include <X11/Xlib.h>
 #endif
+#include <boost/make_shared.hpp>
 
 #include <QApplication>
 
@@ -50,10 +51,10 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
             boost::mutex::scoped_lock lock(g_mutexsoqt);
             EnsureSoQtInit();
             //SoDBWriteLock dblock;
-            return InterfaceBasePtr(new QtCoinViewer(penv, sinput));
+            return boost::make_shared<QtCoinViewer>(penv, boost::ref(sinput));
         }
         else if( interfacename == "qtcameraviewer" ) {
-            return InterfaceBasePtr(new QtCameraViewer(penv,sinput));
+            return boost::make_shared<QtCameraViewer>(penv, boost::ref(sinput));
         }
         break;
     case PT_Module:

--- a/plugins/qtcoinrave/qtcoinviewer.cpp
+++ b/plugins/qtcoinrave/qtcoinviewer.cpp
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "qtcoin.h"
-
+#include <boost/make_shared.hpp>
 #include <Inventor/elements/SoGLCacheContextElement.h>
 #include <Inventor/actions/SoToVRML2Action.h>
 #include <Inventor/actions/SoWriteAction.h>
@@ -879,49 +879,49 @@ SoSwitch* QtCoinViewer::_createhandle()
 GraphHandlePtr QtCoinViewer::plot3(const float* ppoints, int numPoints, int stride, float fPointSize, const RaveVector<float>& color, int drawstyle)
 {
     SoSwitch* handle = _createhandle();
-    EnvMessagePtr pmsg(new DrawMessage(shared_viewer(), handle, ppoints, numPoints, stride, fPointSize, color, drawstyle ? DrawMessage::DT_Sphere : DrawMessage::DT_Point));
+    EnvMessagePtr pmsg = boost::make_shared<DrawMessage>(shared_viewer(), handle, ppoints, numPoints, stride, fPointSize, color, drawstyle ? DrawMessage::DT_Sphere : DrawMessage::DT_Point);
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtCoinViewer::plot3(const float* ppoints, int numPoints, int stride, float fPointSize, const float* colors, int drawstyle, bool bhasalpha)
 {
     SoSwitch* handle = _createhandle();
-    EnvMessagePtr pmsg(new DrawMessage(shared_viewer(), handle, ppoints, numPoints, stride, fPointSize, colors, drawstyle ? DrawMessage::DT_Sphere : DrawMessage::DT_Point, bhasalpha));
+    EnvMessagePtr pmsg = boost::make_shared<DrawMessage>(shared_viewer(), handle, ppoints, numPoints, stride, fPointSize, colors, drawstyle ? DrawMessage::DT_Sphere : DrawMessage::DT_Point, bhasalpha);
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtCoinViewer::drawlinestrip(const float* ppoints, int numPoints, int stride, float fwidth, const RaveVector<float>& color)
 {
     SoSwitch* handle = _createhandle();
-    EnvMessagePtr pmsg(new DrawMessage(shared_viewer(), handle, ppoints, numPoints, stride, fwidth, color,DrawMessage::DT_LineStrip));
+    EnvMessagePtr pmsg = boost::make_shared<DrawMessage>(shared_viewer(), handle, ppoints, numPoints, stride, fwidth, color,DrawMessage::DT_LineStrip);
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtCoinViewer::drawlinestrip(const float* ppoints, int numPoints, int stride, float fwidth, const float* colors)
 {
     SoSwitch* handle = _createhandle();
-    EnvMessagePtr pmsg(new DrawMessage(shared_viewer(), handle, ppoints, numPoints, stride, fwidth, colors, DrawMessage::DT_LineStrip,false));
+    EnvMessagePtr pmsg = boost::make_shared<DrawMessage>(shared_viewer(), handle, ppoints, numPoints, stride, fwidth, colors, DrawMessage::DT_LineStrip,false);
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtCoinViewer::drawlinelist(const float* ppoints, int numPoints, int stride, float fwidth, const RaveVector<float>& color)
 {
     SoSwitch* handle = _createhandle();
-    EnvMessagePtr pmsg(new DrawMessage(shared_viewer(), handle, ppoints, numPoints, stride, fwidth, color, DrawMessage::DT_LineList));
+    EnvMessagePtr pmsg = boost::make_shared<DrawMessage>(shared_viewer(), handle, ppoints, numPoints, stride, fwidth, color, DrawMessage::DT_LineList);
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtCoinViewer::drawlinelist(const float* ppoints, int numPoints, int stride, float fwidth, const float* colors)
 {
     SoSwitch* handle = _createhandle();
-    EnvMessagePtr pmsg(new DrawMessage(shared_viewer(), handle, ppoints, numPoints, stride, fwidth, colors, DrawMessage::DT_LineList,false));
+    EnvMessagePtr pmsg = boost::make_shared<DrawMessage>(shared_viewer(), handle, ppoints, numPoints, stride, fwidth, colors, DrawMessage::DT_LineList,false);
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 class DrawArrowMessage : public QtCoinViewer::EnvMessage
@@ -953,7 +953,7 @@ GraphHandlePtr QtCoinViewer::drawarrow(const RaveVector<float>& p1, const RaveVe
     SoSwitch* handle = _createhandle();
     EnvMessagePtr pmsg(new DrawArrowMessage(shared_viewer(), handle, p1, p2, fwidth, color));
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 class DrawBoxMessage : public QtCoinViewer::EnvMessage
@@ -984,7 +984,7 @@ GraphHandlePtr QtCoinViewer::drawbox(const RaveVector<float>& vpos, const RaveVe
     SoSwitch* handle = _createhandle();
     EnvMessagePtr pmsg(new DrawBoxMessage(shared_viewer(), handle, vpos, vextents));
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 class DrawPlaneMessage : public QtCoinViewer::EnvMessage
@@ -1017,7 +1017,7 @@ GraphHandlePtr QtCoinViewer::drawplane(const RaveTransform<float>& tplane, const
     SoSwitch* handle = _createhandle();
     EnvMessagePtr pmsg(new DrawPlaneMessage(shared_viewer(), handle, tplane,vextents,vtexture));
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 class DrawTriMeshMessage : public QtCoinViewer::EnvMessage
@@ -1108,7 +1108,7 @@ GraphHandlePtr QtCoinViewer::drawtrimesh(const float* ppoints, int stride, const
     SoSwitch* handle = _createhandle();
     EnvMessagePtr pmsg(new DrawTriMeshMessage(shared_viewer(), handle, ppoints, stride, pIndices, numTriangles, color));
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtCoinViewer::drawtrimesh(const float* ppoints, int stride, const int* pIndices, int numTriangles, const boost::multi_array<float,2>& colors)
@@ -1116,7 +1116,7 @@ GraphHandlePtr QtCoinViewer::drawtrimesh(const float* ppoints, int stride, const
     SoSwitch* handle = _createhandle();
     EnvMessagePtr pmsg(new DrawTriMeshColorMessage(shared_viewer(), handle, ppoints, stride, pIndices, numTriangles, colors));
     pmsg->callerexecute(false);
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 class CloseGraphMessage : public QtCoinViewer::EnvMessage

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -14,6 +14,7 @@
 #include "qtosgviewer.h"
 
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 #include <iostream>
 
 #include <osg/ArgumentParser>
@@ -1416,7 +1417,7 @@ GraphHandlePtr QtOSGViewer::plot3(const float* ppoints, int numPoints, int strid
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
     _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::POINTS, new osg::Point(fPointSize),color.w<1)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtOSGViewer::plot3(const float* ppoints, int numPoints, int stride, float fPointSize, const float* colors, int drawstyle, bool bhasalpha)
@@ -1437,7 +1438,7 @@ GraphHandlePtr QtOSGViewer::plot3(const float* ppoints, int numPoints, int strid
     }
 
     _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::POINTS, osg::ref_ptr<osg::Point>(new osg::Point(fPointSize)), bhasalpha)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, int stride, float fwidth, const RaveVector<float>& color)
@@ -1452,7 +1453,7 @@ GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, i
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
     _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, int stride, float fwidth, const float* colors)
 {
@@ -1467,7 +1468,7 @@ GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, i
     }
 
     _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, int stride, float fwidth, const RaveVector<float>& color)
@@ -1481,7 +1482,7 @@ GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, in
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
     _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, int stride, float fwidth, const float* colors)
 {
@@ -1496,7 +1497,7 @@ GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, in
     }
 
     _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtOSGViewer::drawarrow(const RaveVector<float>& p1, const RaveVector<float>& p2, float fwidth, const RaveVector<float>& color)
@@ -1612,7 +1613,7 @@ GraphHandlePtr QtOSGViewer::drawplane(const RaveTransform<float>& tplane, const 
 {
     OSGSwitchPtr handle = _CreateGraphHandle();
     _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawPlane, this, handle, tplane, vextents, vtexture)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 void QtOSGViewer::_DrawTriMesh(OSGSwitchPtr handle, osg::ref_ptr<osg::Vec3Array> vertices, osg::ref_ptr<osg::Vec4Array> colors, osg::ref_ptr<osg::DrawElementsUInt> osgindices, bool bUsingTransparency)
@@ -1677,7 +1678,7 @@ GraphHandlePtr QtOSGViewer::drawtrimesh(const float* ppoints, int stride, const 
     (*osgcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
 
     _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, handle, osgvertices, osgcolors, osgindices, color.w<1)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 GraphHandlePtr QtOSGViewer::drawtrimesh(const float* ppoints, int stride, const int* pIndices, int numTriangles, const boost::multi_array<float,2>& colors)
@@ -1712,7 +1713,7 @@ GraphHandlePtr QtOSGViewer::drawtrimesh(const float* ppoints, int stride, const 
 
     OSGSwitchPtr handle = _CreateGraphHandle();
     _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, handle, osgvertices, osgcolors, osgindices, bhasalpha)); // copies ref counts
-    return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
+    return boost::make_shared<PrivateGraphHandle>(shared_viewer(), handle);
 }
 
 void QtOSGViewer::_Deselect()
@@ -2083,21 +2084,21 @@ void QtOSGViewer::_SetGraphShow(OSGSwitchPtr handle, bool bShow)
 
 UserDataPtr QtOSGViewer::RegisterItemSelectionCallback(const ItemSelectionCallbackFn& fncallback)
 {
-    ItemSelectionCallbackDataPtr pdata(new ItemSelectionCallbackData(fncallback,shared_viewer()));
+    ItemSelectionCallbackDataPtr pdata = boost::make_shared<ItemSelectionCallbackData>(fncallback,shared_viewer());
     pdata->_iterator = _listRegisteredItemSelectionCallbacks.insert(_listRegisteredItemSelectionCallbacks.end(),pdata);
     return pdata;
 }
 
 UserDataPtr QtOSGViewer::RegisterViewerThreadCallback(const ViewerThreadCallbackFn& fncallback)
 {
-    ViewerThreadCallbackDataPtr pdata(new ViewerThreadCallbackData(fncallback,shared_viewer()));
+    ViewerThreadCallbackDataPtr pdata = boost::make_shared<ViewerThreadCallbackData>(fncallback,shared_viewer());
     pdata->_iterator = _listRegisteredViewerThreadCallbacks.insert(_listRegisteredViewerThreadCallbacks.end(),pdata);
     return pdata;
 }
 
 ViewerBasePtr CreateQtOSGViewer(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return ViewerBasePtr(new QtOSGViewer(penv, sinput));
+    return boost::make_shared<QtOSGViewer>(penv, boost::ref(sinput));
 }
 
 } // end namespace qtosgviewer

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1935,9 +1935,9 @@ boost::shared_ptr<EnvironmentMutex::scoped_try_lock> QtOSGViewer::LockEnvironmen
 {
     // try to acquire the lock
 #if BOOST_VERSION >= 103500
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetEnv()->GetMutex(),boost::defer_lock_t()));
+    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = boost::make_shared<EnvironmentMutex::scoped_try_lock>(boost::ref(GetEnv()->GetMutex()), boost::defer_lock_t());
 #else
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetEnv()->GetMutex(),false));
+    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = boost::make_shared<EnvironmentMutex::scoped_try_lock>(boost::ref(GetEnv()->GetMutex()), false);
 #endif
     uint64_t basetime = utils::GetMicroTime();
     while(utils::GetMicroTime()-basetime<timeout ) {

--- a/plugins/rmanipulation/basemanipulation.cpp
+++ b/plugins/rmanipulation/basemanipulation.cpp
@@ -16,6 +16,7 @@
 #include "commonmanipulation.h"
 
 #include <boost/algorithm/string.hpp>
+#include <boost/make_shared.hpp>
 
 class BaseManipulation : public ModuleBase
 {
@@ -1122,5 +1123,5 @@ protected:
 };
 
 ModuleBasePtr CreateBaseManipulation(EnvironmentBasePtr penv) {
-    return ModuleBasePtr(new BaseManipulation(penv));
+    return boost::make_shared<BaseManipulation>(penv);
 }

--- a/plugins/rmanipulation/basemanipulation.cpp
+++ b/plugins/rmanipulation/basemanipulation.cpp
@@ -132,10 +132,10 @@ Method wraps the WorkspaceTrajectoryTracker planner. For more details on paramet
 protected:
 
     inline boost::shared_ptr<BaseManipulation> shared_problem() {
-        return boost::dynamic_pointer_cast<BaseManipulation>(shared_from_this());
+        return boost::static_pointer_cast<BaseManipulation>(shared_from_this());
     }
     inline boost::shared_ptr<BaseManipulation const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<BaseManipulation const>(shared_from_this());
+        return boost::static_pointer_cast<BaseManipulation const>(shared_from_this());
     }
 
     bool Traj(ostream& sout, istream& sinput)

--- a/plugins/rmanipulation/taskcaging.cpp
+++ b/plugins/rmanipulation/taskcaging.cpp
@@ -746,10 +746,10 @@ private:
     };
 
     inline boost::shared_ptr<TaskCaging> shared_problem() {
-        return boost::dynamic_pointer_cast<TaskCaging>(shared_from_this());
+        return boost::static_pointer_cast<TaskCaging>(shared_from_this());
     }
     inline boost::shared_ptr<TaskCaging const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<TaskCaging const>(shared_from_this());
+        return boost::static_pointer_cast<TaskCaging const>(shared_from_this());
     }
 
 public:

--- a/plugins/rmanipulation/taskcaging.cpp
+++ b/plugins/rmanipulation/taskcaging.cpp
@@ -19,6 +19,8 @@
 // Manipulation Planning with Caging Grasps. IEEE-RAS Intl. Conf. on Humanoid Robots, December 2008.
 #include "commonmanipulation.h"
 
+#include <boost/make_shared.hpp>
+
 class TaskCaging : public ModuleBase
 {
 public:
@@ -1932,5 +1934,5 @@ BOOST_TYPEOF_REGISTER_TYPE(TaskCaging::ConstrainedTaskData::FINDGRASPDATA)
 #endif
 
 ModuleBasePtr CreateTaskCaging(EnvironmentBasePtr penv) {
-    return ModuleBasePtr(new TaskCaging(penv));
+    return boost::make_shared<TaskCaging>(penv);
 }

--- a/plugins/rmanipulation/taskmanipulation.cpp
+++ b/plugins/rmanipulation/taskmanipulation.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "commonmanipulation.h"
 
+#include <boost/make_shared.hpp>
+
 #define GRASPTHRESH2 dReal(0.002f)
 
 struct GRASPGOAL
@@ -1847,5 +1849,5 @@ protected:
 };
 
 ModuleBasePtr CreateTaskManipulation(EnvironmentBasePtr penv) {
-    return ModuleBasePtr(new TaskManipulation(penv));
+    return boost::make_shared<TaskManipulation>(penv);
 }

--- a/plugins/rmanipulation/taskmanipulation.cpp
+++ b/plugins/rmanipulation/taskmanipulation.cpp
@@ -102,7 +102,7 @@ Task-based manipulation planning involving target objects. A lot of the algorith
                         "Sets the robot.");
         _fMaxVelMult=1;
         _minimumgoalpaths=1;
-        _report.reset(new CollisionReport());
+        _report = boost::make_shared<CollisionReport>();
     }
     virtual ~TaskManipulation()
     {
@@ -362,7 +362,7 @@ protected:
         RobotBase::ManipulatorConstPtr pmanip = _robot->GetActiveManipulator();
 
         vector<dReal> vgrasps;
-        boost::shared_ptr<GraspParameters> graspparams(new GraspParameters(GetEnv()));
+        boost::shared_ptr<GraspParameters> graspparams = boost::make_shared<GraspParameters>(GetEnv());
 
         KinBodyPtr ptarget;
         int nNumGrasps=0, nGraspDim=0;
@@ -390,7 +390,7 @@ protected:
         int iGraspTransformNoCol = -1;
         int iStartCountdown = 40;
         string cmd;
-        CollisionReportPtr report(new CollisionReport);
+        CollisionReportPtr report = boost::make_shared<CollisionReport>();
         Vector vLocalGraspTranslationOffset;
 
         while(!sinput.eof()) {
@@ -593,7 +593,7 @@ protected:
             mapPreshapeTrajectories[vCurHandValues] = pstarttraj;
         }
 
-        IkReturnPtr ikreturn(new IkReturn(IKRA_Success));
+        IkReturnPtr ikreturn = boost::make_shared<IkReturn>(IKRA_Success);
         TrajectoryBasePtr ptraj;
         GRASPGOAL goalFound;
         int iCountdown = 0;
@@ -1114,7 +1114,7 @@ protected:
         boost::shared_ptr<ostream> pOutputTrajStream;
         Vector direction;
         RobotBase::ManipulatorConstPtr pmanip = _robot->GetActiveManipulator();
-        boost::shared_ptr<GraspParameters> graspparams(new GraspParameters(GetEnv()));
+        boost::shared_ptr<GraspParameters> graspparams = boost::make_shared<GraspParameters>(GetEnv());
         graspparams->vgoalconfig = pmanip->GetChuckingDirection();
 
         vector<dReal> voffset;
@@ -1234,7 +1234,7 @@ protected:
         Vector direction;
         KinBodyPtr ptarget;
         RobotBase::ManipulatorConstPtr pmanip = _robot->GetActiveManipulator();
-        boost::shared_ptr<GraspParameters> graspparams(new GraspParameters(GetEnv()));
+        boost::shared_ptr<GraspParameters> graspparams = boost::make_shared<GraspParameters>(GetEnv());
         graspparams->vgoalconfig = pmanip->GetChuckingDirection();
         FOREACH(it,graspparams->vgoalconfig) {
             *it = -*it;
@@ -1375,7 +1375,7 @@ protected:
         bool bExecute = true, bOutputFinal = false;
         string strtrajfilename;
         boost::shared_ptr<ostream> pOutputTrajStream;
-        boost::shared_ptr<GraspParameters> graspparams(new GraspParameters(GetEnv()));
+        boost::shared_ptr<GraspParameters> graspparams = boost::make_shared<GraspParameters>(GetEnv());
 
         // initialize the moving direction as the opposite of the chucking direction defined in the manipulators
         vector<dReal> vchuckingsign_full(_robot->GetDOF(), 0);
@@ -1510,10 +1510,10 @@ protected:
 
 protected:
     inline boost::shared_ptr<TaskManipulation> shared_problem() {
-        return boost::dynamic_pointer_cast<TaskManipulation>(shared_from_this());
+        return boost::static_pointer_cast<TaskManipulation>(shared_from_this());
     }
     inline boost::shared_ptr<TaskManipulation const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<TaskManipulation const>(shared_from_this());
+        return boost::static_pointer_cast<TaskManipulation const>(shared_from_this());
     }
 
     /// \brief grasps using the list of grasp goals. Removes all the goals that the planner planned with
@@ -1654,7 +1654,7 @@ protected:
         if( GetEnv()->CheckCollision(KinBodyConstPtr(_robot)) )
             RAVELOG_WARN("Hand in collision\n");
 
-        RRTParametersPtr params(new RRTParameters());
+        RRTParametersPtr params = boost::make_shared<RRTParameters>();
         params->_minimumgoalpaths = _minimumgoalpaths;
         if( _sPostProcessingParameters.size() > 0 ) {
             params->_sPostProcessingParameters = _sPostProcessingParameters;
@@ -1794,7 +1794,7 @@ protected:
                 _phandtraj = RaveCreateTrajectory(GetEnv(),"");
             }
 
-            GraspParametersPtr graspparams(new GraspParameters(GetEnv()));
+            GraspParametersPtr graspparams = boost::make_shared<GraspParameters>(GetEnv());
             graspparams->targetbody = ptarget;
             graspparams->btransformrobot = false;
             graspparams->breturntrajectory = false;

--- a/plugins/rmanipulation/visualfeedback.cpp
+++ b/plugins/rmanipulation/visualfeedback.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "commonmanipulation.h"
 
+#include <boost/make_shared.hpp>
+
 /// samples rays from the projected OBB and returns true if the test function returns true
 /// for all the rays. Otherwise, returns false
 /// allowableoutliers - specifies the % of allowable outliying rays
@@ -1432,5 +1434,5 @@ protected:
 };
 
 ModuleBasePtr CreateVisualFeedback(EnvironmentBasePtr penv) {
-    return ModuleBasePtr(new VisualFeedback(penv));
+    return boost::make_shared<VisualFeedback>(penv);
 }

--- a/plugins/rmanipulation/visualfeedback.cpp
+++ b/plugins/rmanipulation/visualfeedback.cpp
@@ -139,10 +139,10 @@ class VisualFeedback : public ModuleBase
 {
 public:
     inline boost::shared_ptr<VisualFeedback> shared_problem() {
-        return boost::dynamic_pointer_cast<VisualFeedback>(shared_from_this());
+        return boost::static_pointer_cast<VisualFeedback>(shared_from_this());
     }
     inline boost::shared_ptr<VisualFeedback const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<VisualFeedback const>(shared_from_this());
+        return boost::static_pointer_cast<VisualFeedback const>(shared_from_this());
     }
     friend class VisibilityConstraintFunction;
 

--- a/plugins/rplanners/constraintparabolicsmoother.cpp
+++ b/plugins/rplanners/constraintparabolicsmoother.cpp
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 #include <fstream>
-
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
 
 #include "ParabolicPathSmooth/DynamicPath.h"
@@ -1108,7 +1108,7 @@ private:
 
 PlannerBasePtr CreateConstraintParabolicSmoother(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PlannerBasePtr(new ConstraintParabolicSmoother(penv,sinput));
+    return boost::make_shared<ConstraintParabolicSmoother>(penv, boost::ref(sinput));
 }
 
 #ifdef RAVE_REGISTER_BOOST

--- a/plugins/rplanners/cubicretimer.cpp
+++ b/plugins/rplanners/cubicretimer.cpp
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "trajectoryretimer.h"
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
-
 #include <openrave/mathextra.h>
 
 namespace rplanners {
@@ -312,7 +312,7 @@ protected:
 };
 
 PlannerBasePtr CreateCubicTrajectoryRetimer(EnvironmentBasePtr penv, std::istream& sinput) {
-    return PlannerBasePtr(new CubicTrajectoryRetimer(penv, sinput));
+    return boost::make_shared<CubicTrajectoryRetimer>(penv, boost::ref(sinput));
 }
 
 } // end namespace rplanners

--- a/plugins/rplanners/graspgradient.cpp
+++ b/plugins/rplanners/graspgradient.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 
+#include <boost/make_shared.hpp>
+
 class GraspGradientPlanner : public PlannerBase
 {
 public:
@@ -44,7 +46,7 @@ public:
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset();
-        boost::shared_ptr<GraspSetParameters> parameters(new GraspSetParameters(GetEnv()));
+        boost::shared_ptr<GraspSetParameters> parameters = boost::make_shared<GraspSetParameters>(GetEnv());
         parameters->copy(pparams);
         _robot = pbase;
         RobotBase::RobotStateSaver savestate(_robot);
@@ -334,5 +336,5 @@ private:
 };
 
 PlannerBasePtr CreateGraspGradientPlanner(EnvironmentBasePtr penv, std::istream& sinput) {
-    return PlannerBasePtr(new GraspGradientPlanner(penv, sinput));
+    return boost::make_shared<GraspGradientPlanner>(penv, boost::ref(sinput));
 }

--- a/plugins/rplanners/linearretimer.cpp
+++ b/plugins/rplanners/linearretimer.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "trajectoryretimer.h"
 
+#include <boost/make_shared.hpp>
+
 namespace rplanners {
 
 class LinearTrajectoryRetimer : public TrajectoryRetimer
@@ -243,7 +245,7 @@ protected:
 
 
 PlannerBasePtr CreateLinearTrajectoryRetimer(EnvironmentBasePtr penv, std::istream& sinput) {
-    return PlannerBasePtr(new LinearTrajectoryRetimer(penv, sinput));
+    return boost::make_shared<LinearTrajectoryRetimer>(penv, boost::ref(sinput));
 }
 
 } // end namespace rplanners

--- a/plugins/rplanners/linearshortcutadvanced.cpp
+++ b/plugins/rplanners/linearshortcutadvanced.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 
+#include <boost/make_shared.hpp>
+
 class ShortcutLinearPlanner : public PlannerBase
 {
 public:
@@ -348,5 +350,5 @@ protected:
 };
 
 PlannerBasePtr CreateShortcutLinearPlanner(EnvironmentBasePtr penv, std::istream& sinput) {
-    return PlannerBasePtr(new ShortcutLinearPlanner(penv, sinput));
+    return boost::make_shared<ShortcutLinearPlanner>(penv, boost::ref(sinput));
 }

--- a/plugins/rplanners/linearsmoother.cpp
+++ b/plugins/rplanners/linearsmoother.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 
+#include <boost/make_shared.hpp>
+
 class LinearSmoother : public PlannerBase
 {
 public:
@@ -457,5 +459,5 @@ protected:
 };
 
 PlannerBasePtr CreateLinearSmoother(EnvironmentBasePtr penv, std::istream& sinput) {
-    return PlannerBasePtr(new LinearSmoother(penv, sinput));
+    return boost::make_shared<LinearSmoother>(penv, boost::ref(sinput));
 }

--- a/plugins/rplanners/parabolicretimer.cpp
+++ b/plugins/rplanners/parabolicretimer.cpp
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "trajectoryretimer.h"
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
 
 #include "ParabolicPathSmooth/ParabolicRamp.h"
@@ -917,7 +918,7 @@ protected:
 };
 
 PlannerBasePtr CreateParabolicTrajectoryRetimer(EnvironmentBasePtr penv, std::istream& sinput) {
-    return PlannerBasePtr(new ParabolicTrajectoryRetimer(penv, sinput));
+    return boost::make_shared<ParabolicTrajectoryRetimer>(penv, boost::ref(sinput));
 }
 
 } // end namespace rplanners

--- a/plugins/rplanners/parabolicretimer2.cpp
+++ b/plugins/rplanners/parabolicretimer2.cpp
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with this program.
 // If not, see <http://www.gnu.org/licenses/>.
 #include "trajectoryretimer2.h"
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
 
 #include "rampoptimizer/interpolator.h"
@@ -972,7 +973,7 @@ protected:
 
 PlannerBasePtr CreateParabolicTrajectoryRetimer2(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PlannerBasePtr(new ParabolicTrajectoryRetimer2(penv, sinput));
+    return boost::make_shared<ParabolicTrajectoryRetimer2>(penv, boost::ref(sinput));
 }
 
 } // end namespace rplanners

--- a/plugins/rplanners/parabolicsmoother.cpp
+++ b/plugins/rplanners/parabolicsmoother.cpp
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 #include <fstream>
-
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
 
 #include "manipconstraints.h"
@@ -2545,7 +2545,7 @@ protected:
 
 PlannerBasePtr CreateParabolicSmoother(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PlannerBasePtr(new ParabolicSmoother(penv,sinput));
+    return boost::make_shared<ParabolicSmoother>(penv, boost::ref(sinput));
 }
 
 } // using namespace rplanners

--- a/plugins/rplanners/parabolicsmoother2.cpp
+++ b/plugins/rplanners/parabolicsmoother2.cpp
@@ -13,6 +13,7 @@
 // If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 #include <fstream>
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
 
 #include "rampoptimizer/interpolator.h"
@@ -1850,7 +1851,7 @@ protected:
 
 PlannerBasePtr CreateParabolicSmoother2(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PlannerBasePtr(new ParabolicSmoother2(penv, sinput));
+    return boost::make_shared<ParabolicSmoother2>(penv, boost::ref(sinput));
 }
 
 } // end namespace rplanners

--- a/plugins/rplanners/randomized-astar.cpp
+++ b/plugins/rplanners/randomized-astar.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 
+#include <boost/make_shared.hpp>
+
 class RandomizedAStarPlanner : public PlannerBase
 {
     class SimpleCostMetric
@@ -622,5 +624,5 @@ private:
 };
 
 PlannerBasePtr CreateRandomizedAStarPlanner(EnvironmentBasePtr penv, std::istream& sinput) {
-    return PlannerBasePtr(new RandomizedAStarPlanner(penv, sinput));
+    return boost::make_shared<RandomizedAStarPlanner>(penv, boost::ref(sinput));
 }

--- a/plugins/rplanners/rplanners.cpp
+++ b/plugins/rplanners/rplanners.cpp
@@ -17,6 +17,7 @@
 #include "openraveplugindefs.h"
 #include "rrt.h"
 
+#include <boost/make_shared.hpp>
 #include <openrave/plugin.h>
 
 PlannerBasePtr CreateShortcutLinearPlanner(EnvironmentBasePtr penv, std::istream& sinput);
@@ -43,17 +44,17 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
             return CreateRandomizedAStarPlanner(penv,sinput);
         }
         else if( interfacename == "birrt") {
-            return InterfaceBasePtr(new BirrtPlanner(penv));
+            return boost::make_shared<BirrtPlanner>(penv);
         }
         else if( interfacename == "rbirrt") {
             RAVELOG_WARN("rBiRRT is deprecated, use BiRRT\n");
-            return InterfaceBasePtr(new BirrtPlanner(penv));
+            return boost::make_shared<BirrtPlanner>(penv);
         }
         else if( interfacename == "basicrrt") {
-            return InterfaceBasePtr(new BasicRrtPlanner(penv));
+            return boost::make_shared<BasicRrtPlanner>(penv);
         }
         else if( interfacename == "explorationrrt" ) {
-            return InterfaceBasePtr(new ExplorationPlanner(penv));
+            return boost::make_shared<ExplorationPlanner>(penv);
         }
         else if( interfacename == "graspgradient" ) {
             return CreateGraspGradientPlanner(penv,sinput);

--- a/plugins/rplanners/rrt.h
+++ b/plugins/rplanners/rrt.h
@@ -256,10 +256,10 @@ protected:
     std::vector< NodeBase* > _vecInitialNodes;
 
     inline boost::shared_ptr<RrtPlanner> shared_planner() {
-        return boost::dynamic_pointer_cast<RrtPlanner>(shared_from_this());
+        return boost::static_pointer_cast<RrtPlanner>(shared_from_this());
     }
     inline boost::shared_ptr<RrtPlanner const> shared_planner_const() const {
-        return boost::dynamic_pointer_cast<RrtPlanner const>(shared_from_this());
+        return boost::static_pointer_cast<RrtPlanner const>(shared_from_this());
     }
 };
 

--- a/plugins/rplanners/subparabolicsmoother.cpp
+++ b/plugins/rplanners/subparabolicsmoother.cpp
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 #include <fstream>
-
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
 
 #include "ParabolicPathSmooth/DynamicPath.h"
@@ -458,7 +458,7 @@ protected:
 
 PlannerBasePtr CreateSubParabolicSmoother(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PlannerBasePtr(new SubParabolicSmoother(penv,sinput));
+    return boost::make_shared<SubParabolicSmoother>(penv, boost::ref(sinput));
 }
 
 #ifdef RAVE_REGISTER_BOOST

--- a/plugins/rplanners/trajectoryretimer.h
+++ b/plugins/rplanners/trajectoryretimer.h
@@ -16,6 +16,8 @@
 #ifndef OPENRAVE_TRAJECTORY_RETIMER
 #define OPENRAVE_TRAJECTORY_RETIMER
 
+#include <boost/make_shared.hpp>
+
 #include "openraveplugindefs.h"
 #include "manipconstraints.h"
 
@@ -423,7 +425,7 @@ protected:
 
     /// \brief createa s group info
     virtual GroupInfoPtr CreateGroupInfo(int degree, const ConfigurationSpecification& spec, const ConfigurationSpecification::Group& gpos, const ConfigurationSpecification::Group &gvel) {
-        return GroupInfoPtr(new GroupInfo(degree, gpos, gvel));
+        return boost::make_shared<GroupInfo>(degree, gpos, gvel);
     }
     /// \brief resets any cached data in the group info
     virtual void ResetCachedGroupInfo(GroupInfoPtr g) {

--- a/plugins/rplanners/trajectoryretimer2.h
+++ b/plugins/rplanners/trajectoryretimer2.h
@@ -14,6 +14,7 @@
 #ifndef OPENRAVE_TRAJECTORY_RETIMER
 #define OPENRAVE_TRAJECTORY_RETIMER
 
+#include <boost/make_shared.hpp>
 #include "openraveplugindefs.h"
 #include "manipconstraints2.h"
 
@@ -421,7 +422,7 @@ protected:
 
     /// \brief createa s group info
     virtual GroupInfoPtr CreateGroupInfo(int degree, const ConfigurationSpecification& spec, const ConfigurationSpecification::Group& gpos, const ConfigurationSpecification::Group &gvel) {
-        return GroupInfoPtr(new GroupInfo(degree, gpos, gvel));
+        return boost::make_shared<GroupInfo>(degree, gpos, gvel);
     }
     /// \brief resets any cached data in the group info
     virtual void ResetCachedGroupInfo(GroupInfoPtr g) {

--- a/plugins/rplanners/workspacetrajectorytracker.cpp
+++ b/plugins/rplanners/workspacetrajectorytracker.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
 
+#include <boost/make_shared.hpp>
+
 class WorkspaceTrajectoryTracker : public PlannerBase
 {
 public:
@@ -432,5 +434,5 @@ protected:
 };
 
 PlannerBasePtr CreateWorkspaceTrajectoryTracker(EnvironmentBasePtr penv, std::istream& sinput) {
-    return PlannerBasePtr(new WorkspaceTrajectoryTracker(penv, sinput));
+    return boost::make_shared<WorkspaceTrajectoryTracker>(penv, boost::ref(sinput));
 }

--- a/plugins/textserver/textserver.cpp
+++ b/plugins/textserver/textserver.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "plugindefs.h"
 #include "textserver.h"
+#include <boost/make_shared.hpp>
 #include <openrave/plugin.h>
 
 InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string& interfacename, std::istream& sinput, EnvironmentBasePtr penv)
@@ -22,7 +23,7 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
     switch(type) {
     case OpenRAVE::PT_Module:
         if( interfacename == "textserver")
-            return InterfaceBasePtr(new SimpleTextServer(penv));
+            return boost::make_shared<SimpleTextServer>(penv);
         break;
     default:
         break;

--- a/plugins/textserver/textserver.h
+++ b/plugins/textserver/textserver.h
@@ -472,10 +472,10 @@ public:
 private:
 
     inline boost::shared_ptr<SimpleTextServer> shared_server() {
-        return boost::dynamic_pointer_cast<SimpleTextServer>(shared_from_this());
+        return boost::static_pointer_cast<SimpleTextServer>(shared_from_this());
     }
     inline boost::shared_ptr<SimpleTextServer const> shared_server_const() const {
-        return boost::dynamic_pointer_cast<SimpleTextServer const>(shared_from_this());
+        return boost::static_pointer_cast<SimpleTextServer const>(shared_from_this());
     }
 
     // called from threads other than the main worker to wait until

--- a/python/bindings/openravepy_collisionchecker.cpp
+++ b/python/bindings/openravepy_collisionchecker.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
+
 namespace openravepy {
 
 class PyCollisionReport
@@ -591,7 +593,7 @@ CollisionCheckerBasePtr GetCollisionChecker(PyCollisionCheckerBasePtr pyCollisio
 
 PyInterfaceBasePtr toPyCollisionChecker(CollisionCheckerBasePtr pCollisionChecker, PyEnvironmentBasePtr pyenv)
 {
-    return !pCollisionChecker ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PyCollisionCheckerBase(pCollisionChecker,pyenv));
+    return !pCollisionChecker ? PyInterfaceBasePtr() : boost::make_shared<PyCollisionCheckerBase>(pCollisionChecker,pyenv);
 }
 
 CollisionReportPtr GetCollisionReport(object o)
@@ -642,7 +644,7 @@ PyCollisionCheckerBasePtr RaveCreateCollisionChecker(PyEnvironmentBasePtr pyenv,
     if( !p ) {
         return PyCollisionCheckerBasePtr();
     }
-    return PyCollisionCheckerBasePtr(new PyCollisionCheckerBase(p,pyenv));
+    return boost::make_shared<PyCollisionCheckerBase>(p,pyenv);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CheckCollisionRays_overloads, CheckCollisionRays, 2, 3)

--- a/python/bindings/openravepy_controller.cpp
+++ b/python/bindings/openravepy_controller.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
+
 namespace openravepy {
 
 class PyControllerBase : public PyInterfaceBase
@@ -81,7 +83,7 @@ public:
         if( IS_PYTHONOBJECT_NONE(otransform) ) {
             return SetDesired(o);
         }
-        return _pcontroller->SetDesired(ExtractArray<dReal>(o),TransformConstPtr(new Transform(ExtractTransform(otransform))));
+        return _pcontroller->SetDesired(ExtractArray<dReal>(o), boost::make_shared<Transform>(ExtractTransform(otransform)));
     }
 
     bool SetPath(PyTrajectoryBasePtr pytraj)
@@ -158,10 +160,10 @@ PyInterfaceBasePtr toPyController(ControllerBasePtr pcontroller, PyEnvironmentBa
     // TODO this is a hack
     // unfortunately dynamic_pointer_cast will not work. The most ideal situation is to have MultiControllerBase registered as its own individual interface....
     else if( pcontroller->GetXMLId() == std::string("MultiController") ) {
-        return PyInterfaceBasePtr(new PyMultiControllerBase(boost::static_pointer_cast<MultiControllerBase>(pcontroller), pyenv));
+        return boost::make_shared<PyMultiControllerBase>(boost::static_pointer_cast<MultiControllerBase>(pcontroller), pyenv);
     }
     else {
-        return PyInterfaceBasePtr(new PyControllerBase(pcontroller, pyenv));
+        return boost::make_shared<PyControllerBase>(pcontroller, pyenv);
     }
 }
 
@@ -171,7 +173,7 @@ PyControllerBasePtr RaveCreateController(PyEnvironmentBasePtr pyenv, const std::
     if( !pcontroller ) {
         return PyControllerBasePtr();
     }
-    return PyControllerBasePtr(new PyControllerBase(pcontroller, pyenv));
+    return boost::make_shared<PyControllerBase>(pcontroller, pyenv);
 }
 
 PyMultiControllerBasePtr RaveCreateMultiController(PyEnvironmentBasePtr pyenv, const std::string& name)
@@ -180,7 +182,7 @@ PyMultiControllerBasePtr RaveCreateMultiController(PyEnvironmentBasePtr pyenv, c
     if( !pcontroller ) {
         return PyMultiControllerBasePtr();
     }
-    return PyMultiControllerBasePtr(new PyMultiControllerBase(pcontroller, pyenv));
+    return boost::make_shared<PyMultiControllerBase>(pcontroller, pyenv);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Reset_overloads, Reset, 0, 1)

--- a/python/bindings/openravepy_global.cpp
+++ b/python/bindings/openravepy_global.cpp
@@ -19,6 +19,7 @@
 
 #include <openrave/xmlreaders.h>
 #include <openrave/utils.h>
+#include <boost/make_shared.hpp>
 
 namespace openravepy {
 
@@ -81,7 +82,7 @@ object toPyXMLReadable(XMLReadablePtr p) {
     if( !p ) {
         return object();
     }
-    return object(PyXMLReadablePtr(new PyXMLReadable(p)));
+    return object(boost::make_shared<PyXMLReadable>(p));
 }
 
 namespace xmlreaders
@@ -94,7 +95,7 @@ public:
 
 PyXMLReadablePtr pyCreateStringXMLReadable(const std::string& xmlid, const std::string& data)
 {
-    return PyXMLReadablePtr(new PyXMLReadable(XMLReadablePtr(new OpenRAVE::xmlreaders::StringXMLReadable(xmlid, data))));
+    return boost::make_shared<PyXMLReadable>(boost::make_shared<OpenRAVE::xmlreaders::StringXMLReadable>(xmlid, data));
 }
 
 } // end namespace xmlreaders
@@ -524,7 +525,7 @@ public:
 
     PyConfigurationSpecificationPtr __add__(PyConfigurationSpecificationPtr r)
     {
-        return PyConfigurationSpecificationPtr(new PyConfigurationSpecification(_spec + r->_spec));
+        return boost::make_shared<PyConfigurationSpecification>(_spec + r->_spec);
     }
 
     PyConfigurationSpecificationPtr __iadd__(PyConfigurationSpecificationPtr r)
@@ -563,7 +564,7 @@ public:
 
 PyConfigurationSpecificationPtr toPyConfigurationSpecification(const ConfigurationSpecification &spec)
 {
-    return PyConfigurationSpecificationPtr(new PyConfigurationSpecification(spec));
+    return boost::make_shared<PyConfigurationSpecification>(spec);
 }
 
 const ConfigurationSpecification& GetConfigurationSpecification(PyConfigurationSpecificationPtr p)

--- a/python/bindings/openravepy_ikparameterization.cpp
+++ b/python/bindings/openravepy_ikparameterization.cpp
@@ -17,6 +17,7 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
 #include <openrave/planningutils.h>
 
 namespace openravepy {
@@ -311,12 +312,12 @@ public:
 
     PyIkParameterizationPtr __mul__(object otrans)
     {
-        return PyIkParameterizationPtr(new PyIkParameterization(_param * ExtractTransform(otrans)));
+        return boost::make_shared<PyIkParameterization>(_param * ExtractTransform(otrans));
     }
 
     PyIkParameterizationPtr __rmul__(object otrans)
     {
-        return PyIkParameterizationPtr(new PyIkParameterization(ExtractTransform(otrans) * _param));
+        return boost::make_shared<PyIkParameterization>(ExtractTransform(otrans) * _param);
     }
 
     IkParameterization _param;
@@ -334,12 +335,12 @@ bool ExtractIkParameterization(object o, IkParameterization& ikparam) {
 
 object toPyIkParameterization(const IkParameterization &ikparam)
 {
-    return object(PyIkParameterizationPtr(new PyIkParameterization(ikparam)));
+    return object(boost::make_shared<PyIkParameterization>(ikparam));
 }
 
 object toPyIkParameterization(const std::string& serializeddata)
 {
-    return object(PyIkParameterizationPtr(new PyIkParameterization(serializeddata)));
+    return object(boost::make_shared<PyIkParameterization>(serializeddata));
 }
 
 class IkParameterization_pickle_suite : public pickle_suite

--- a/python/bindings/openravepy_iksolver.cpp
+++ b/python/bindings/openravepy_iksolver.cpp
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
+#include <boost/make_shared.hpp>
 #include <openrave/utils.h>
 
 namespace openravepy {
@@ -156,7 +157,7 @@ public:
         }
         _pIkSolver->SolveAll(ikparam, filteroptions, vikreturns);
         FOREACH(itikreturn,vikreturns) {
-            pyreturns.append(object(PyIkReturnPtr(new PyIkReturn(*itikreturn))));
+            pyreturns.append(object(boost::make_shared<PyIkReturn>(*itikreturn)));
         }
         return pyreturns;
     }
@@ -194,7 +195,7 @@ public:
         }
         _pIkSolver->SolveAll(ikparam, vFreeParameters, filteroptions, vikreturns);
         FOREACH(itikreturn,vikreturns) {
-            pyreturns.append(object(PyIkReturnPtr(new PyIkReturn(*itikreturn))));
+            pyreturns.append(object(boost::make_shared<PyIkReturn>(*itikreturn)));
         }
         return pyreturns;
     }

--- a/python/bindings/openravepy_iksolver.cpp
+++ b/python/bindings/openravepy_iksolver.cpp
@@ -202,7 +202,7 @@ public:
 
     PyIkReturnPtr CallFilters(object oparam)
     {
-        PyIkReturnPtr pyreturn(new PyIkReturn(IKRA_Reject));
+        PyIkReturnPtr pyreturn = boost::make_shared<PyIkReturn>(IKRA_Reject);
         IkReturnPtr preturn(&pyreturn->_ret, utils::null_deleter());
         IkParameterization ikparam;
         if( !ExtractIkParameterization(oparam,ikparam) ) {
@@ -237,7 +237,7 @@ bool ExtractIkReturn(object o, IkReturn& ikfr)
 
 object toPyIkReturn(const IkReturn& ret)
 {
-    return object(PyIkReturnPtr(new PyIkReturn(ret)));
+    return object(boost::make_shared<PyIkReturn>(ret));
 }
 
 IkSolverBasePtr GetIkSolver(PyIkSolverBasePtr pyIkSolver)
@@ -247,7 +247,7 @@ IkSolverBasePtr GetIkSolver(PyIkSolverBasePtr pyIkSolver)
 
 PyInterfaceBasePtr toPyIkSolver(IkSolverBasePtr pIkSolver, PyEnvironmentBasePtr pyenv)
 {
-    return !pIkSolver ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PyIkSolverBase(pIkSolver,pyenv));
+    return !pIkSolver ? PyInterfaceBasePtr() : boost::make_shared<PyIkSolverBase>(pIkSolver,pyenv);
 }
 
 PyIkSolverBasePtr RaveCreateIkSolver(PyEnvironmentBasePtr pyenv, const std::string& name)
@@ -256,7 +256,7 @@ PyIkSolverBasePtr RaveCreateIkSolver(PyEnvironmentBasePtr pyenv, const std::stri
     if( !p ) {
         return PyIkSolverBasePtr();
     }
-    return PyIkSolverBasePtr(new PyIkSolverBase(p,pyenv));
+    return boost::make_shared<PyIkSolverBase>(p,pyenv);
 }
 
 void init_openravepy_iksolver()

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
 #include <openrave/utils.h>
 
 namespace openravepy
@@ -1747,7 +1748,7 @@ PyEnvironmentBasePtr PyInterfaceBase::GetEnv() const
     return _pyenv;
 #else
     // if raw shared_ptr is returned, then python will throw RuntimeError: tr1::bad_weak_ptr when env is used
-    return PyEnvironmentBasePtr(new PyEnvironmentBase(_pyenv->GetEnv()));
+    return boost::make_shared<PyEnvironmentBase>(_pyenv->GetEnv());
 #endif
 }
 
@@ -1826,7 +1827,7 @@ object RaveGetEnvironments()
     OpenRAVE::RaveGetEnvironments(listenvironments);
     boost::python::list oenvironments;
     FOREACH(it,listenvironments) {
-        oenvironments.append(PyEnvironmentBasePtr(new PyEnvironmentBase(*it)));
+        oenvironments.append(boost::make_shared<PyEnvironmentBase>(*it));
     }
     return oenvironments;
 }
@@ -1841,7 +1842,7 @@ PyEnvironmentBasePtr RaveGetEnvironment(int id)
     if( !penv ) {
         return PyEnvironmentBasePtr();
     }
-    return PyEnvironmentBasePtr(new PyEnvironmentBase(penv));
+    return boost::make_shared<PyEnvironmentBase>(penv);
 }
 
 PyInterfaceBasePtr RaveCreateInterface(PyEnvironmentBasePtr pyenv, InterfaceType type, const std::string& name)
@@ -1850,7 +1851,7 @@ PyInterfaceBasePtr RaveCreateInterface(PyEnvironmentBasePtr pyenv, InterfaceType
     if( !p ) {
         return PyInterfaceBasePtr();
     }
-    return PyInterfaceBasePtr(new PyInterfaceBase(p,pyenv));
+    return boost::make_shared<PyInterfaceBase>(p,pyenv);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(LoadURI_overloads, LoadURI, 1, 2)

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -126,7 +126,7 @@ public:
     ViewerManager() {
         _bShutdown = false;
         _bInMain = false;
-        _threadviewer.reset(new boost::thread(boost::bind(&ViewerManager::_RunViewerThread, this)));
+        _threadviewer = boost::make_shared<boost::thread>(boost::bind(&ViewerManager::_RunViewerThread, this));
     }
 
     virtual ~ViewerManager() {
@@ -377,7 +377,7 @@ boost::shared_ptr<ViewerManager> GetViewerManager()
 {
     static boost::shared_ptr<ViewerManager> viewermanager;
     if( !viewermanager ) {
-        viewermanager.reset(new ViewerManager());
+        viewermanager = boost::make_shared<ViewerManager>();
     }
     return viewermanager;
 }
@@ -404,16 +404,16 @@ object PyInterfaceBase::SendCommand(const string& in, bool releasegil, bool lock
         openravepy::PythonThreadSaverPtr statesaver;
         openravepy::PyEnvironmentLockSaverPtr envsaver;
         if( releasegil ) {
-            statesaver.reset(new openravepy::PythonThreadSaver());
+            statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             if( lockenv ) {
                 // GIL is already released, so use a regular environment lock
-                envsaver.reset(new openravepy::PyEnvironmentLockSaver(_pyenv, true));
+                envsaver = boost::make_shared<openravepy::PyEnvironmentLockSaver>(_pyenv, true);
             }
         }
         else {
             if( lockenv ) {
                 // try to safely lock the environment first
-                envsaver.reset(new openravepy::PyEnvironmentLockSaver(_pyenv, false));
+                envsaver = boost::make_shared<openravepy::PyEnvironmentLockSaver>(_pyenv, false);
             }
         }
         sout << std::setprecision(std::numeric_limits<dReal>::digits10+1);     /// have to do this or otherwise precision gets lost

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NO_IMPORT_ARRAY
 #include "openravepy_kinbody.h"
+#include <boost/make_shared.hpp>
 
 namespace openravepy {
 
@@ -147,7 +148,7 @@ public:
     }
     PyLinkInfo(const KinBody::LinkInfo& info) {
         FOREACHC(itgeominfo, info._vgeometryinfos) {
-            _vgeometryinfos.append(PyGeometryInfoPtr(new PyGeometryInfo(**itgeominfo)));
+            _vgeometryinfos.append(boost::make_shared<PyGeometryInfo>(**itgeominfo));
         }
         _name = ConvertStringToUnicode(info._name);
         _t = ReturnTransform(info._t);
@@ -400,7 +401,7 @@ public:
         _bIsCircular = bIsCircular;
         _bIsActive = info._bIsActive;
         if( !!info._infoElectricMotor ) {
-            _infoElectricMotor = PyElectricMotorActuatorInfoPtr(new PyElectricMotorActuatorInfo(*info._infoElectricMotor));
+            _infoElectricMotor = boost::make_shared<PyElectricMotorActuatorInfo>(*info._infoElectricMotor);
         }
     }
 
@@ -668,7 +669,7 @@ public:
             return toPyVector3(_pgeometry->GetAmbientColor());
         }
         object GetInfo() {
-            return object(PyGeometryInfoPtr(new PyGeometryInfo(_pgeometry->GetInfo())));
+            return object(boost::make_shared<PyGeometryInfo>(_pgeometry->GetInfo()));
         }
         bool __eq__(boost::shared_ptr<PyGeometry> p) {
             return !!p && _pgeometry == p->_pgeometry;
@@ -719,7 +720,7 @@ public:
             return object(toPyRobot(RaveInterfaceCast<RobotBase>(_plink->GetParent()),_pyenv));
         }
         else {
-            return object(PyKinBodyPtr(new PyKinBody(_plink->GetParent(),_pyenv)));
+            return object(boost::make_shared<PyKinBody>(_plink->GetParent(),_pyenv));
         }
     }
 
@@ -729,7 +730,7 @@ public:
         _plink->GetParentLinks(vParentLinks);
         boost::python::list links;
         FOREACHC(itlink, vParentLinks) {
-            links.append(PyLinkPtr(new PyLink(*itlink, _pyenv)));
+            links.append(boost::make_shared<PyLink>(*itlink, _pyenv));
         }
         return links;
     }
@@ -852,7 +853,7 @@ public:
     {
         boost::python::list ogeometryinfos;
         FOREACHC(itinfo, _plink->GetGeometriesFromGroup(name)) {
-            ogeometryinfos.append(PyGeometryInfoPtr(new PyGeometryInfo(**itinfo)));
+            ogeometryinfos.append(boost::make_shared<PyGeometryInfo>(**itinfo));
         }
         return ogeometryinfos;
     }
@@ -880,7 +881,7 @@ public:
         _plink->GetRigidlyAttachedLinks(vattachedlinks);
         boost::python::list links;
         FOREACHC(itlink, vattachedlinks) {
-            links.append(PyLinkPtr(new PyLink(*itlink, _pyenv)));
+            links.append(boost::make_shared<PyLink>(*itlink, _pyenv));
         }
         return links;
     }
@@ -945,10 +946,10 @@ public:
         _plink->UpdateInfo();
     }
     object GetInfo() {
-        return object(PyLinkInfoPtr(new PyLinkInfo(_plink->GetInfo())));
+        return object(boost::make_shared<PyLinkInfo>(_plink->GetInfo()));
     }
     object UpdateAndGetInfo() {
-        return object(PyLinkInfoPtr(new PyLinkInfo(_plink->UpdateAndGetInfo())));
+        return object(boost::make_shared<PyLinkInfo>(_plink->UpdateAndGetInfo()));
     }
 
 
@@ -1034,14 +1035,14 @@ public:
     }
 
     PyKinBodyPtr GetParent() const {
-        return PyKinBodyPtr(new PyKinBody(_pjoint->GetParent(),_pyenv));
+        return boost::make_shared<PyKinBody>(_pjoint->GetParent(),_pyenv);
     }
 
     PyLinkPtr GetFirstAttached() const {
-        return !_pjoint->GetFirstAttached() ? PyLinkPtr() : PyLinkPtr(new PyLink(_pjoint->GetFirstAttached(), _pyenv));
+        return !_pjoint->GetFirstAttached() ? PyLinkPtr() : boost::make_shared<PyLink>(_pjoint->GetFirstAttached(), _pyenv);
     }
     PyLinkPtr GetSecondAttached() const {
-        return !_pjoint->GetSecondAttached() ? PyLinkPtr() : PyLinkPtr(new PyLink(_pjoint->GetSecondAttached(), _pyenv));
+        return !_pjoint->GetSecondAttached() ? PyLinkPtr() : boost::make_shared<PyLink>(_pjoint->GetSecondAttached(), _pyenv);
     }
 
     KinBody::JointType GetType() const {
@@ -1084,10 +1085,10 @@ public:
         return toPyVector3(_pjoint->GetAxis(iaxis));
     }
     PyLinkPtr GetHierarchyParentLink() const {
-        return !_pjoint->GetHierarchyParentLink() ? PyLinkPtr() : PyLinkPtr(new PyLink(_pjoint->GetHierarchyParentLink(),_pyenv));
+        return !_pjoint->GetHierarchyParentLink() ? PyLinkPtr() : boost::make_shared<PyLink>(_pjoint->GetHierarchyParentLink(),_pyenv);
     }
     PyLinkPtr GetHierarchyChildLink() const {
-        return !_pjoint->GetHierarchyChildLink() ? PyLinkPtr() : PyLinkPtr(new PyLink(_pjoint->GetHierarchyChildLink(),_pyenv));
+        return !_pjoint->GetHierarchyChildLink() ? PyLinkPtr() : boost::make_shared<PyLink>(_pjoint->GetHierarchyChildLink(),_pyenv);
     }
     object GetInternalHierarchyAxis(int iaxis) {
         return toPyVector3(_pjoint->GetInternalHierarchyAxis(iaxis));
@@ -1247,10 +1248,10 @@ public:
         _pjoint->UpdateInfo();
     }
     object GetInfo() {
-        return object(PyJointInfoPtr(new PyJointInfo(_pjoint->GetInfo(), _pyenv)));
+        return object(boost::make_shared<PyJointInfo>(_pjoint->GetInfo(), _pyenv));
     }
     object UpdateAndGetInfo() {
-        return object(PyJointInfoPtr(new PyJointInfo(_pjoint->UpdateAndGetInfo(), _pyenv)));
+        return object(boost::make_shared<PyJointInfo>(_pjoint->UpdateAndGetInfo(), _pyenv));
     }
 
     string __repr__() {
@@ -1355,7 +1356,7 @@ public:
     }
     PyLinkPtr GetOffsetLink() const {
         KinBody::LinkPtr plink = _pdata->GetOffsetLink();
-        return !plink ? PyLinkPtr() : PyLinkPtr(new PyLink(plink,_pyenv));
+        return !plink ? PyLinkPtr() : boost::make_shared<PyLink>(plink,_pyenv);
     }
     bool IsPresent() {
         return _pdata->IsPresent();
@@ -1746,7 +1747,7 @@ object PyKinBody::GetLinks() const
 {
     boost::python::list links;
     FOREACHC(itlink, _pbody->GetLinks()) {
-        links.append(PyLinkPtr(new PyLink(*itlink, GetEnv())));
+        links.append(boost::make_shared<PyLink>(*itlink, GetEnv()));
     }
     return links;
 }
@@ -1759,7 +1760,7 @@ object PyKinBody::GetLinks(object oindices) const
     vector<int> vindices = ExtractArray<int>(oindices);
     boost::python::list links;
     FOREACHC(it, vindices) {
-        links.append(PyLinkPtr(new PyLink(_pbody->GetLinks().at(*it),GetEnv())));
+        links.append(boost::make_shared<PyLink>(_pbody->GetLinks().at(*it),GetEnv()));
     }
     return links;
 }
@@ -1767,14 +1768,14 @@ object PyKinBody::GetLinks(object oindices) const
 object PyKinBody::GetLink(const std::string& linkname) const
 {
     KinBody::LinkPtr plink = _pbody->GetLink(linkname);
-    return !plink ? object() : object(PyLinkPtr(new PyLink(plink,GetEnv())));
+    return !plink ? object() : object(boost::make_shared<PyLink>(plink,GetEnv()));
 }
 
 object PyKinBody::GetJoints() const
 {
     boost::python::list joints;
     FOREACHC(itjoint, _pbody->GetJoints()) {
-        joints.append(PyJointPtr(new PyJoint(*itjoint, GetEnv())));
+        joints.append(boost::make_shared<PyJoint>(*itjoint, GetEnv()));
     }
     return joints;
 }
@@ -1787,7 +1788,7 @@ object PyKinBody::GetJoints(object oindices) const
     vector<int> vindices = ExtractArray<int>(oindices);
     boost::python::list joints;
     FOREACHC(it, vindices) {
-        joints.append(PyJointPtr(new PyJoint(_pbody->GetJoints().at(*it),GetEnv())));
+        joints.append(boost::make_shared<PyJoint>(_pbody->GetJoints().at(*it),GetEnv()));
     }
     return joints;
 }
@@ -1796,7 +1797,7 @@ object PyKinBody::GetPassiveJoints()
 {
     boost::python::list joints;
     FOREACHC(itjoint, _pbody->GetPassiveJoints()) {
-        joints.append(PyJointPtr(new PyJoint(*itjoint, GetEnv())));
+        joints.append(boost::make_shared<PyJoint>(*itjoint, GetEnv()));
     }
     return joints;
 }
@@ -1805,7 +1806,7 @@ object PyKinBody::GetDependencyOrderedJoints()
 {
     boost::python::list joints;
     FOREACHC(itjoint, _pbody->GetDependencyOrderedJoints()) {
-        joints.append(PyJointPtr(new PyJoint(*itjoint, GetEnv())));
+        joints.append(boost::make_shared<PyJoint>(*itjoint, GetEnv()));
     }
     return joints;
 }
@@ -1816,7 +1817,7 @@ object PyKinBody::GetClosedLoops()
     FOREACHC(itloop, _pbody->GetClosedLoops()) {
         boost::python::list loop;
         FOREACHC(itpair,*itloop) {
-            loop.append(boost::python::make_tuple(PyLinkPtr(new PyLink(itpair->first,GetEnv())),PyJointPtr(new PyJoint(itpair->second,GetEnv()))));
+            loop.append(boost::python::make_tuple(boost::make_shared<PyLink>(itpair->first,GetEnv()), boost::make_shared<PyJoint>(itpair->second,GetEnv())));
         }
         loops.append(loop);
     }
@@ -1830,7 +1831,7 @@ object PyKinBody::GetRigidlyAttachedLinks(int linkindex) const
     _pbody->GetLinks().at(linkindex)->GetRigidlyAttachedLinks(vattachedlinks);
     boost::python::list links;
     FOREACHC(itlink, vattachedlinks) {
-        links.append(PyLinkPtr(new PyLink(*itlink, GetEnv())));
+        links.append(boost::make_shared<PyLink>(*itlink, GetEnv()));
     }
     return links;
 }
@@ -1842,14 +1843,14 @@ object PyKinBody::GetChain(int linkindex1, int linkindex2,bool returnjoints) con
         std::vector<KinBody::JointPtr> vjoints;
         _pbody->GetChain(linkindex1,linkindex2,vjoints);
         FOREACHC(itjoint, vjoints) {
-            chain.append(PyJointPtr(new PyJoint(*itjoint, GetEnv())));
+            chain.append(boost::make_shared<PyJoint>(*itjoint, GetEnv()));
         }
     }
     else {
         std::vector<KinBody::LinkPtr> vlinks;
         _pbody->GetChain(linkindex1,linkindex2,vlinks);
         FOREACHC(itlink, vlinks) {
-            chain.append(PyLinkPtr(new PyLink(*itlink, GetEnv())));
+            chain.append(boost::make_shared<PyLink>(*itlink, GetEnv()));
         }
     }
     return chain;
@@ -1868,13 +1869,13 @@ int PyKinBody::GetJointIndex(const std::string& jointname) const
 object PyKinBody::GetJoint(const std::string& jointname) const
 {
     KinBody::JointPtr pjoint = _pbody->GetJoint(jointname);
-    return !pjoint ? object() : object(PyJointPtr(new PyJoint(pjoint,GetEnv())));
+    return !pjoint ? object() : object(boost::make_shared<PyJoint>(pjoint,GetEnv()));
 }
 
 object PyKinBody::GetJointFromDOFIndex(int dofindex) const
 {
     KinBody::JointPtr pjoint = _pbody->GetJointFromDOFIndex(dofindex);
-    return !pjoint ? object() : object(PyJointPtr(new PyJoint(pjoint,GetEnv())));
+    return !pjoint ? object() : object(boost::make_shared<PyJoint>(pjoint,GetEnv()));
 }
 
 object PyKinBody::GetTransform() const {
@@ -2373,7 +2374,7 @@ object PyKinBody::GetAttached() const
     std::set<KinBodyPtr> vattached;
     _pbody->GetAttached(vattached);
     FOREACHC(it,vattached)
-    attached.append(PyKinBodyPtr(new PyKinBody(*it,_pyenv)));
+    attached.append(boost::make_shared<PyKinBody>(*it,_pyenv));
     return attached;
 }
 
@@ -2483,7 +2484,7 @@ object PyKinBody::GetCollisionData() const
 object PyKinBody::GetManageData() const
 {
     KinBody::ManageDataPtr pdata = _pbody->GetManageData();
-    return !pdata ? object() : object(PyManageDataPtr(new PyManageData(pdata,_pyenv)));
+    return !pdata ? object() : object(boost::make_shared<PyManageData>(pdata,_pyenv));
 }
 int PyKinBody::GetUpdateStamp() const
 {
@@ -2552,7 +2553,7 @@ object toPyKinBodyLink(KinBody::LinkPtr plink, PyEnvironmentBasePtr pyenv)
     if( !plink ) {
         return object();
     }
-    return object(PyLinkPtr(new PyLink(plink,pyenv)));
+    return object(boost::make_shared<PyLink>(plink,pyenv));
 }
 
 object toPyKinBodyLink(KinBody::LinkPtr plink, object opyenv)
@@ -2569,7 +2570,7 @@ object toPyKinBodyJoint(KinBody::JointPtr pjoint, PyEnvironmentBasePtr pyenv)
     if( !pjoint ) {
         return object();
     }
-    return object(PyJointPtr(new PyJoint(pjoint,pyenv)));
+    return object(boost::make_shared<PyJoint>(pjoint,pyenv));
 }
 
 KinBody::LinkPtr GetKinBodyLink(object o)
@@ -2653,7 +2654,7 @@ PyInterfaceBasePtr toPyKinBody(KinBodyPtr pkinbody, PyEnvironmentBasePtr pyenv)
     if( pkinbody->IsRobot() ) {
         return toPyRobot(RaveInterfaceCast<RobotBase>(pkinbody), pyenv);
     }
-    return PyInterfaceBasePtr(new PyKinBody(pkinbody,pyenv));
+    return boost::make_shared<PyKinBody>(pkinbody,pyenv);
 }
 
 object toPyKinBody(KinBodyPtr pkinbody, object opyenv)
@@ -2671,7 +2672,7 @@ PyKinBodyPtr RaveCreateKinBody(PyEnvironmentBasePtr pyenv, const std::string& na
     if( !p ) {
         return PyKinBodyPtr();
     }
-    return PyKinBodyPtr(new PyKinBody(p,pyenv));
+    return boost::make_shared<PyKinBody>(p,pyenv);
 }
 
 class GeometryInfo_pickle_suite : public pickle_suite

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -500,7 +500,7 @@ public:
                 object omimic = _vmimic[i];
                 if( !IS_PYTHONOBJECT_NONE(omimic) ) {
                     OPENRAVE_ASSERT_OP(len(omimic),==,3);
-                    info._vmimic[i].reset(new KinBody::MimicInfo());
+                    info._vmimic[i] = boost::make_shared<KinBody::MimicInfo>();
                     for(size_t j = 0; j < 3; ++j) {
                         info._vmimic[i]->_equations.at(j) = boost::python::extract<std::string>(omimic[j]);
                     }
@@ -2018,7 +2018,7 @@ object PyKinBody::GetLinkAccelerations(object odofaccelerations, object oexterna
     KinBody::AccelerationMapPtr pmapExternalAccelerations;
     if( !IS_PYTHONOBJECT_NONE(oexternalaccelerations) ) {
         //externalaccelerations
-        pmapExternalAccelerations.reset(new KinBody::AccelerationMap());
+        pmapExternalAccelerations = boost::make_shared<KinBody::AccelerationMap>();
         boost::python::dict odict = (boost::python::dict)oexternalaccelerations;
         boost::python::list iterkeys = (boost::python::list)odict.iterkeys();
         vector<dReal> v;
@@ -2508,10 +2508,10 @@ PyStateRestoreContextBase* PyKinBody::CreateKinBodyStateSaver(object options)
 {
     PyKinBodyStateSaverPtr saver;
     if( IS_PYTHONOBJECT_NONE(options) ) {
-        saver.reset(new PyKinBodyStateSaver(_pbody,_pyenv));
+        saver = boost::make_shared<PyKinBodyStateSaver>(_pbody,_pyenv);
     }
     else {
-        saver.reset(new PyKinBodyStateSaver(_pbody,_pyenv,options));
+        saver = boost::make_shared<PyKinBodyStateSaver>(_pbody,_pyenv,options);
     }
     return new PyStateRestoreContext<PyKinBodyStateSaverPtr, PyKinBodyPtr>(saver);
 }

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -92,7 +92,7 @@ public:
     }
 
     KinBody::GeometryInfoPtr GetGeometryInfo() {
-        KinBody::GeometryInfoPtr pinfo(new KinBody::GeometryInfo());
+        KinBody::GeometryInfoPtr pinfo = boost::make_shared<KinBody::GeometryInfo>();
         KinBody::GeometryInfo& info = *pinfo;
         info._t = ExtractTransform(_t);
         info._vGeomData = ExtractVector<dReal>(_vGeomData);
@@ -174,7 +174,7 @@ public:
     }
 
     KinBody::LinkInfoPtr GetLinkInfo() {
-        KinBody::LinkInfoPtr pinfo(new KinBody::LinkInfo());
+        KinBody::LinkInfoPtr pinfo = boost::make_shared<KinBody::LinkInfo>();
         KinBody::LinkInfo& info = *pinfo;
         info._vgeometryinfos.resize(len(_vgeometryinfos));
         for(size_t i = 0; i < info._vgeometryinfos.size(); ++i) {
@@ -276,7 +276,7 @@ public:
     }
 
     ElectricMotorActuatorInfoPtr GetElectricMotorActuatorInfo() {
-        ElectricMotorActuatorInfoPtr pinfo(new ElectricMotorActuatorInfo());
+        ElectricMotorActuatorInfoPtr pinfo = boost::make_shared<ElectricMotorActuatorInfo>();
         ElectricMotorActuatorInfo& info = *pinfo;
         info.model_type = model_type;
         info.gear_ratio = gear_ratio;
@@ -406,7 +406,7 @@ public:
     }
 
     KinBody::JointInfoPtr GetJointInfo() {
-        KinBody::JointInfoPtr pinfo(new KinBody::JointInfo());
+        KinBody::JointInfoPtr pinfo = boost::make_shared<KinBody::JointInfo>();
         KinBody::JointInfo& info = *pinfo;
         info._type = _type;
         if( !IS_PYTHONOBJECT_NONE(_name) ) {
@@ -826,7 +826,7 @@ public:
         boost::python::list geoms;
         size_t N = _plink->GetGeometries().size();
         for(size_t i = 0; i < N; ++i) {
-            geoms.append(boost::shared_ptr<PyGeometry>(new PyGeometry(_plink->GetGeometry(i))));
+            geoms.append(boost::make_shared<PyGeometry>(_plink->GetGeometry(i)));
         }
         return geoms;
     }

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -1716,7 +1716,7 @@ object PyKinBody::GetDOFWeights(object oindices) const
     if( vindices.size() == 0 ) {
         return numeric::array(boost::python::list());
     }
-    vector<dReal> values, v;
+    vector<dReal> values;
     values.reserve(vindices.size());
     FOREACHC(it, vindices) {
         KinBody::JointPtr pjoint = _pbody->GetJointFromDOFIndex(*it);
@@ -1741,7 +1741,7 @@ object PyKinBody::GetDOFResolutions(object oindices) const
     if( vindices.size() == 0 ) {
         return numeric::array(boost::python::list());
     }
-    vector<dReal> values, v;
+    vector<dReal> values;
     values.reserve(vindices.size());
     FOREACHC(it, vindices) {
         KinBody::JointPtr pjoint = _pbody->GetJointFromDOFIndex(*it);

--- a/python/bindings/openravepy_module.cpp
+++ b/python/bindings/openravepy_module.cpp
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
+#include <boost/make_shared.hpp>
 
 namespace openravepy {
 
@@ -48,7 +49,7 @@ ModuleBasePtr GetModule(PyModuleBasePtr pymodule)
 
 PyInterfaceBasePtr toPyModule(ModuleBasePtr pmodule, PyEnvironmentBasePtr pyenv)
 {
-    return !pmodule ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PyModuleBase(pmodule,pyenv));
+    return !pmodule ? PyInterfaceBasePtr() : boost::make_shared<PyModuleBase>(pmodule,pyenv);
 }
 
 PyModuleBasePtr RaveCreateModule(PyEnvironmentBasePtr pyenv, const std::string& name)
@@ -57,7 +58,7 @@ PyModuleBasePtr RaveCreateModule(PyEnvironmentBasePtr pyenv, const std::string& 
     if( !p ) {
         return PyModuleBasePtr();
     }
-    return PyModuleBasePtr(new PyModuleBase(p,pyenv));
+    return boost::make_shared<PyModuleBase>(p,pyenv);
 }
 
 void init_openravepy_module()

--- a/python/bindings/openravepy_physicsengine.cpp
+++ b/python/bindings/openravepy_physicsengine.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
+
 namespace openravepy {
 
 class PyPhysicsEngineBase : public PyInterfaceBase
@@ -173,7 +175,7 @@ PyPhysicsEngineBasePtr RaveCreatePhysicsEngine(PyEnvironmentBasePtr pyenv, const
     if( !p ) {
         return PyPhysicsEngineBasePtr();
     }
-    return PyPhysicsEngineBasePtr(new PyPhysicsEngineBase(p,pyenv));
+    return boost::make_shared<PyPhysicsEngineBase>(p, pyenv);
 }
 
 void init_openravepy_physicsengine()

--- a/python/bindings/openravepy_planner.cpp
+++ b/python/bindings/openravepy_planner.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
+
 namespace openravepy {
 
 class PyPlannerProgress
@@ -224,7 +226,7 @@ public:
         if( !params ) {
             return PyPlannerParametersPtr();
         }
-        return PyPlannerParametersPtr(new PyPlannerParameters(params));
+        return boost::make_shared<PyPlannerParameters>(params);
     }
 
     static PlannerAction _PlanCallback(object fncallback, PyEnvironmentBasePtr pyenv, const PlannerBase::PlannerProgress& progress)
@@ -282,7 +284,7 @@ PlannerBasePtr GetPlanner(PyPlannerBasePtr pyplanner)
 
 PyInterfaceBasePtr toPyPlanner(PlannerBasePtr pplanner, PyEnvironmentBasePtr pyenv)
 {
-    return !pplanner ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PyPlannerBase(pplanner,pyenv));
+    return !pplanner ? PyInterfaceBasePtr() : boost::make_shared<PyPlannerBase>(pplanner,pyenv);
 }
 
 PlannerBase::PlannerParametersPtr GetPlannerParameters(object o)
@@ -308,7 +310,7 @@ object toPyPlannerParameters(PlannerBase::PlannerParametersPtr params)
     if( !params ) {
         return object();
     }
-    return object(PyPlannerBase::PyPlannerParametersPtr(new PyPlannerBase::PyPlannerParameters(params)));
+    return object(boost::make_shared<PyPlannerBase::PyPlannerParameters>(params));
 }
 
 PyPlannerBasePtr RaveCreatePlanner(PyEnvironmentBasePtr pyenv, const std::string& name)
@@ -317,7 +319,7 @@ PyPlannerBasePtr RaveCreatePlanner(PyEnvironmentBasePtr pyenv, const std::string
     if( !p ) {
         return PyPlannerBasePtr();
     }
-    return PyPlannerBasePtr(new PyPlannerBase(p,pyenv));
+    return boost::make_shared<PyPlannerBase>(p,pyenv);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(InitPlan_overloads, InitPlan, 2, 3)

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -233,7 +233,7 @@ public:
         {
             openravepy::PythonThreadSaverPtr statesaver;
             if( releasegil ) {
-                statesaver.reset(new openravepy::PythonThreadSaver());
+                statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             }
             return _pmanip->FindIKSolution(ikparam,solution,filteroptions);
 
@@ -242,7 +242,7 @@ public:
         {
             openravepy::PythonThreadSaverPtr statesaver;
             if( releasegil ) {
-                statesaver.reset(new openravepy::PythonThreadSaver());
+                statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             }
             return _pmanip->FindIKSolution(ikparam,vFreeParameters, solution,filteroptions);
         }
@@ -250,7 +250,7 @@ public:
         {
             openravepy::PythonThreadSaverPtr statesaver;
             if( releasegil ) {
-                statesaver.reset(new openravepy::PythonThreadSaver());
+                statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             }
             return _pmanip->FindIKSolution(ikparam,filteroptions,IkReturnPtr(&ikreturn,utils::null_deleter()));
         }
@@ -258,7 +258,7 @@ public:
         {
             openravepy::PythonThreadSaverPtr statesaver;
             if( releasegil ) {
-                statesaver.reset(new openravepy::PythonThreadSaver());
+                statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             }
             return _pmanip->FindIKSolution(ikparam,vFreeParameters, filteroptions,IkReturnPtr(&ikreturn,utils::null_deleter()));
         }
@@ -267,7 +267,7 @@ public:
         {
             openravepy::PythonThreadSaverPtr statesaver;
             if( releasegil ) {
-                statesaver.reset(new openravepy::PythonThreadSaver());
+                statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             }
             return _pmanip->FindIKSolutions(ikparam,solutions,filteroptions);
         }
@@ -275,7 +275,7 @@ public:
         {
             openravepy::PythonThreadSaverPtr statesaver;
             if( releasegil ) {
-                statesaver.reset(new openravepy::PythonThreadSaver());
+                statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             }
             return _pmanip->FindIKSolutions(ikparam,vFreeParameters,solutions,filteroptions);
         }
@@ -283,7 +283,7 @@ public:
         {
             openravepy::PythonThreadSaverPtr statesaver;
             if( releasegil ) {
-                statesaver.reset(new openravepy::PythonThreadSaver());
+                statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             }
             return _pmanip->FindIKSolutions(ikparam,filteroptions,vikreturns);
         }
@@ -291,7 +291,7 @@ public:
         {
             openravepy::PythonThreadSaverPtr statesaver;
             if( releasegil ) {
-                statesaver.reset(new openravepy::PythonThreadSaver());
+                statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
             }
             return _pmanip->FindIKSolutions(ikparam,vFreeParameters,filteroptions,vikreturns);
         }
@@ -658,7 +658,7 @@ public:
 
         RobotBase::AttachedSensorInfoPtr GetAttachedSensorInfo() const
         {
-            RobotBase::AttachedSensorInfoPtr pinfo(new RobotBase::AttachedSensorInfo());
+            RobotBase::AttachedSensorInfoPtr pinfo = boost::make_shared<RobotBase::AttachedSensorInfo>();
             pinfo->_name = boost::python::extract<std::string>(_name);
             pinfo->_linkname = boost::python::extract<std::string>(_linkname);
             pinfo->_trelative = ExtractTransform(_trelative);
@@ -778,7 +778,7 @@ public:
 
         RobotBase::GrabbedInfoPtr GetGrabbedInfo() const
         {
-            RobotBase::GrabbedInfoPtr pinfo(new RobotBase::GrabbedInfo());
+            RobotBase::GrabbedInfoPtr pinfo = boost::make_shared<RobotBase::GrabbedInfo>();
             pinfo->_grabbedname = boost::python::extract<std::string>(_grabbedname);
             pinfo->_robotlinkname = boost::python::extract<std::string>(_robotlinkname);
             pinfo->_trelative = ExtractTransform(_trelative);
@@ -951,7 +951,7 @@ public:
     {
         boost::python::list sensors;
         FOREACH(itsensor, _probot->GetAttachedSensors()) {
-            sensors.append(boost::shared_ptr<PyAttachedSensor>(new PyAttachedSensor(*itsensor,_pyenv)));
+            sensors.append(boost::make_shared<PyAttachedSensor>(*itsensor,_pyenv));
         }
         return sensors;
     }
@@ -1372,10 +1372,10 @@ public:
     PyStateRestoreContextBase* CreateRobotStateSaver(object options=object()) {
         PyRobotStateSaverPtr saver;
         if( IS_PYTHONOBJECT_NONE(options) ) {
-            saver.reset(new PyRobotStateSaver(_probot,_pyenv));
+            saver = boost::make_shared<PyRobotStateSaver>(_probot, _pyenv);
         }
         else {
-            saver.reset(new PyRobotStateSaver(_probot,_pyenv,options));
+            saver = boost::make_shared<PyRobotStateSaver>(_probot, _pyenv, options);
         }
         return new PyStateRestoreContext<PyRobotStateSaverPtr, PyRobotBasePtr>(saver);
     }

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define NO_IMPORT_ARRAY
 #include "openravepy_kinbody.h"
+#include <boost/make_shared.hpp>
 
 namespace openravepy {
 
@@ -113,7 +114,7 @@ public:
         }
 
         PyRobotBasePtr GetRobot() {
-            return PyRobotBasePtr(new PyRobotBase(_pmanip->GetRobot(),_pyenv));
+            return boost::make_shared<PyRobotBase>(_pmanip->GetRobot(),_pyenv);
         }
 
         bool SetIkSolver(PyIkSolverBasePtr iksolver) {
@@ -580,7 +581,7 @@ public:
         }
 
         object GetInfo() {
-            return object(PyManipulatorInfoPtr(new PyManipulatorInfo(_pmanip->GetInfo())));
+            return object(boost::make_shared<PyManipulatorInfo>(_pmanip->GetInfo()));
         }
 
         string GetStructureHash() const {
@@ -614,7 +615,7 @@ public:
     };
     typedef boost::shared_ptr<PyManipulator> PyManipulatorPtr;
     PyManipulatorPtr _GetManipulator(RobotBase::ManipulatorPtr pmanip) {
-        return !pmanip ? PyManipulatorPtr() : PyManipulatorPtr(new PyManipulator(pmanip,_pyenv));
+        return !pmanip ? PyManipulatorPtr() : boost::make_shared<PyManipulator>(pmanip,_pyenv);
     }
 
     class PyAttachedSensorInfo
@@ -677,7 +678,7 @@ public:
             return toPyArray(_pattached->GetTransform());
         }
         PyRobotBasePtr GetRobot() const {
-            return _pattached->GetRobot() ? PyRobotBasePtr() : PyRobotBasePtr(new PyRobotBase(_pattached->GetRobot(), _pyenv));
+            return _pattached->GetRobot() ? PyRobotBasePtr() : boost::make_shared<PyRobotBase>(_pattached->GetRobot(), _pyenv);
         }
         object GetName() const {
             return ConvertStringToUnicode(_pattached->GetName());
@@ -700,11 +701,11 @@ public:
         }
 
         object UpdateAndGetInfo(SensorBase::SensorType type=SensorBase::ST_Invalid) {
-            return object(PyAttachedSensorInfoPtr(new PyAttachedSensorInfo(_pattached->UpdateAndGetInfo(type))));
+            return object(boost::make_shared<PyAttachedSensorInfo>(_pattached->UpdateAndGetInfo(type)));
         }
 
         object GetInfo() {
-            return object(PyAttachedSensorInfoPtr(new PyAttachedSensorInfo(_pattached->GetInfo())));
+            return object(boost::make_shared<PyAttachedSensorInfo>(_pattached->GetInfo()));
         }
 
         string __repr__() {
@@ -730,7 +731,7 @@ public:
     typedef boost::shared_ptr<PyAttachedSensor> PyAttachedSensorPtr;
     boost::shared_ptr<PyAttachedSensor> _GetAttachedSensor(RobotBase::AttachedSensorPtr pattachedsensor)
     {
-        return !pattachedsensor ? PyAttachedSensorPtr() : PyAttachedSensorPtr(new PyAttachedSensor(pattachedsensor, _pyenv));
+        return !pattachedsensor ? PyAttachedSensorPtr() : boost::make_shared<PyAttachedSensor>(pattachedsensor, _pyenv);
     }
 
     class PyGrabbedInfo
@@ -1272,7 +1273,7 @@ public:
         std::vector<KinBodyPtr> vbodies;
         _probot->GetGrabbed(vbodies);
         FOREACH(itbody, vbodies) {
-            bodies.append(PyKinBodyPtr(new PyKinBody(*itbody,_pyenv)));
+            bodies.append(boost::make_shared<PyKinBody>(*itbody,_pyenv));
         }
         return bodies;
     }
@@ -1283,7 +1284,7 @@ public:
         std::vector<RobotBase::GrabbedInfoPtr> vgrabbedinfo;
         _probot->GetGrabbedInfo(vgrabbedinfo);
         FOREACH(itgrabbed, vgrabbedinfo) {
-            ograbbed.append(PyGrabbedInfoPtr(new PyGrabbedInfo(**itgrabbed)));
+            ograbbed.append(boost::make_shared<PyGrabbedInfo>(**itgrabbed));
         }
         return ograbbed;
     }
@@ -1418,7 +1419,7 @@ RobotBasePtr GetRobot(PyRobotBasePtr pyrobot)
 
 PyInterfaceBasePtr toPyRobot(RobotBasePtr probot, PyEnvironmentBasePtr pyenv)
 {
-    return !probot ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PyRobotBase(probot,pyenv));
+    return !probot ? PyInterfaceBasePtr() : boost::make_shared<PyRobotBase>(probot,pyenv);
 }
 
 RobotBase::ManipulatorPtr GetRobotManipulator(object o)
@@ -1432,7 +1433,7 @@ RobotBase::ManipulatorPtr GetRobotManipulator(object o)
 
 object toPyRobotManipulator(RobotBase::ManipulatorPtr pmanip, PyEnvironmentBasePtr pyenv)
 {
-    return !pmanip ? object() : object(PyRobotBase::PyManipulatorPtr(new PyRobotBase::PyManipulator(pmanip,pyenv)));
+    return !pmanip ? object() : object(boost::make_shared<PyRobotBase::PyManipulator>(pmanip,pyenv));
 }
 
 PyRobotBasePtr RaveCreateRobot(PyEnvironmentBasePtr pyenv, const std::string& name)
@@ -1441,7 +1442,7 @@ PyRobotBasePtr RaveCreateRobot(PyEnvironmentBasePtr pyenv, const std::string& na
     if( !p ) {
         return PyRobotBasePtr();
     }
-    return PyRobotBasePtr(new PyRobotBase(p,pyenv));
+    return boost::make_shared<PyRobotBase>(p,pyenv);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(GetIkParameterization_overloads, GetIkParameterization, 1, 2)

--- a/python/bindings/openravepy_sensor.cpp
+++ b/python/bindings/openravepy_sensor.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
+
 namespace openravepy {
 
 class PyCameraIntrinsics
@@ -684,7 +686,7 @@ SensorBasePtr GetSensor(PySensorBasePtr pysensor)
 
 PyInterfaceBasePtr toPySensor(SensorBasePtr psensor, PyEnvironmentBasePtr pyenv)
 {
-    return !psensor ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PySensorBase(psensor,pyenv));
+    return !psensor ? PyInterfaceBasePtr() : boost::make_shared<PySensorBase>(psensor,pyenv);
 }
 
 object toPySensorData(SensorBasePtr psensor, PyEnvironmentBasePtr pyenv)
@@ -701,17 +703,17 @@ PySensorBasePtr RaveCreateSensor(PyEnvironmentBasePtr pyenv, const std::string& 
     if( !p ) {
         return PySensorBasePtr();
     }
-    return PySensorBasePtr(new PySensorBase(p,pyenv));
+    return boost::make_shared<PySensorBase>(p,pyenv);
 }
 
 PySensorGeometryPtr toPySensorGeometry(SensorBase::SensorGeometryPtr pgeom)
 {
     if( !!pgeom ) {
         if( pgeom->GetType() == SensorBase::ST_Camera ) {
-            return PySensorGeometryPtr(new PyCameraGeomData(boost::static_pointer_cast<SensorBase::CameraGeomData const>(pgeom)));
+            return boost::make_shared<PyCameraGeomData>(boost::static_pointer_cast<SensorBase::CameraGeomData const>(pgeom));
         }
         else if( pgeom->GetType() == SensorBase::ST_Laser ) {
-            return PySensorGeometryPtr(new PyLaserGeomData(boost::static_pointer_cast<SensorBase::LaserGeomData const>(pgeom)));
+            return boost::make_shared<PyLaserGeomData>(boost::static_pointer_cast<SensorBase::LaserGeomData const>(pgeom));
         }
 
     }
@@ -720,12 +722,12 @@ PySensorGeometryPtr toPySensorGeometry(SensorBase::SensorGeometryPtr pgeom)
 
 PyCameraIntrinsicsPtr toPyCameraIntrinsics(const geometry::RaveCameraIntrinsics<float>& intrinsics)
 {
-    return PyCameraIntrinsicsPtr(new PyCameraIntrinsics(intrinsics));
+    return boost::make_shared<PyCameraIntrinsics>(intrinsics);
 }
 
 PyCameraIntrinsicsPtr toPyCameraIntrinsics(const geometry::RaveCameraIntrinsics<double>& intrinsics)
 {
-    return PyCameraIntrinsicsPtr(new PyCameraIntrinsics(intrinsics));
+    return boost::make_shared<PyCameraIntrinsics>(intrinsics);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Configure_overloads, Configure, 1, 2)

--- a/python/bindings/openravepy_sensor.cpp
+++ b/python/bindings/openravepy_sensor.cpp
@@ -97,7 +97,7 @@ public:
         return SensorBase::ST_Camera;
     }
     virtual SensorBase::SensorGeometryPtr GetGeometry() {
-        boost::shared_ptr<SensorBase::CameraGeomData> geom(new SensorBase::CameraGeomData());
+        boost::shared_ptr<SensorBase::CameraGeomData> geom = boost::make_shared<SensorBase::CameraGeomData>();
         geom->hardware_id = hardware_id;
         geom->width = width;
         geom->height = height;
@@ -144,7 +144,7 @@ public:
         return SensorBase::ST_Laser;
     }
     virtual SensorBase::SensorGeometryPtr GetGeometry() {
-        boost::shared_ptr<SensorBase::LaserGeomData> geom(new SensorBase::LaserGeomData());
+        boost::shared_ptr<SensorBase::LaserGeomData> geom = boost::make_shared<SensorBase::LaserGeomData>();
         geom->min_angle[0] = (dReal)boost::python::extract<dReal>(min_angle[0]);
         geom->min_angle[1] = (dReal)boost::python::extract<dReal>(min_angle[1]);
         geom->max_angle[0] = (dReal)boost::python::extract<dReal>(max_angle[0]);
@@ -176,7 +176,7 @@ public:
         return SensorBase::ST_JointEncoder;
     }
     virtual SensorBase::SensorGeometryPtr GetGeometry() {
-        boost::shared_ptr<SensorBase::JointEncoderGeomData> geom(new SensorBase::JointEncoderGeomData());
+        boost::shared_ptr<SensorBase::JointEncoderGeomData> geom = boost::make_shared<SensorBase::JointEncoderGeomData>();
         geom->resolution = ExtractArray<dReal>(resolution);
         return geom;
     }
@@ -198,7 +198,7 @@ public:
         return SensorBase::ST_Force6D;
     }
     virtual SensorBase::SensorGeometryPtr GetGeometry() {
-        boost::shared_ptr<SensorBase::Force6DGeomData> geom(new SensorBase::Force6DGeomData());
+        boost::shared_ptr<SensorBase::Force6DGeomData> geom = boost::make_shared<SensorBase::Force6DGeomData>();
         return geom;
     }
 };
@@ -219,7 +219,7 @@ public:
         return SensorBase::ST_IMU;
     }
     virtual SensorBase::SensorGeometryPtr GetGeometry() {
-        boost::shared_ptr<SensorBase::IMUGeomData> geom(new SensorBase::IMUGeomData());
+        boost::shared_ptr<SensorBase::IMUGeomData> geom = boost::make_shared<SensorBase::IMUGeomData>();
         geom->time_measurement = time_measurement;
         return geom;
     }
@@ -242,7 +242,7 @@ public:
         return SensorBase::ST_Odometry;
     }
     virtual SensorBase::SensorGeometryPtr GetGeometry() {
-        boost::shared_ptr<SensorBase::OdometryGeomData> geom(new SensorBase::OdometryGeomData());
+        boost::shared_ptr<SensorBase::OdometryGeomData> geom = boost::make_shared<SensorBase::OdometryGeomData>();
         geom->targetid = targetid;
         return geom;
     }
@@ -267,7 +267,7 @@ public:
         return SensorBase::ST_Tactile;
     }
     virtual SensorBase::SensorGeometryPtr GetGeometry() {
-        boost::shared_ptr<SensorBase::TactileGeomData> geom(new SensorBase::TactileGeomData());
+        boost::shared_ptr<SensorBase::TactileGeomData> geom = boost::make_shared<SensorBase::TactileGeomData>();
         geom->thickness = thickness;
         return geom;
     }
@@ -305,7 +305,7 @@ public:
         return SensorBase::ST_Actuator;
     }
     virtual SensorBase::SensorGeometryPtr GetGeometry() {
-        boost::shared_ptr<SensorBase::ActuatorGeomData> geom(new SensorBase::ActuatorGeomData());
+        boost::shared_ptr<SensorBase::ActuatorGeomData> geom = boost::make_shared<SensorBase::ActuatorGeomData>();
         geom->maxtorque = maxtorque;
         geom->maxcurrent = maxcurrent;
         geom->nominalcurrent = nominalcurrent;
@@ -570,21 +570,21 @@ public:
     {
         switch(type) {
         case SensorBase::ST_Laser:
-            return boost::shared_ptr<PySensorGeometry>(new PyLaserGeomData(boost::static_pointer_cast<SensorBase::LaserGeomData const>(_psensor->GetSensorGeometry())));
+            return boost::make_shared<PyLaserGeomData>(boost::static_pointer_cast<SensorBase::LaserGeomData const>(_psensor->GetSensorGeometry()));
         case SensorBase::ST_Camera:
-            return boost::shared_ptr<PySensorGeometry>(new PyCameraGeomData(boost::static_pointer_cast<SensorBase::CameraGeomData const>(_psensor->GetSensorGeometry())));
+            return boost::make_shared<PyCameraGeomData>(boost::static_pointer_cast<SensorBase::CameraGeomData const>(_psensor->GetSensorGeometry()));
         case SensorBase::ST_JointEncoder:
-            return boost::shared_ptr<PySensorGeometry>(new PyJointEncoderGeomData(boost::static_pointer_cast<SensorBase::JointEncoderGeomData const>(_psensor->GetSensorGeometry())));
+            return boost::make_shared<PyJointEncoderGeomData>(boost::static_pointer_cast<SensorBase::JointEncoderGeomData const>(_psensor->GetSensorGeometry()));
         case SensorBase::ST_Force6D:
-            return boost::shared_ptr<PySensorGeometry>(new PyForce6DGeomData(boost::static_pointer_cast<SensorBase::Force6DGeomData const>(_psensor->GetSensorGeometry())));
+            return boost::make_shared<PyForce6DGeomData>(boost::static_pointer_cast<SensorBase::Force6DGeomData const>(_psensor->GetSensorGeometry()));
         case SensorBase::ST_IMU:
-            return boost::shared_ptr<PySensorGeometry>(new PyIMUGeomData(boost::static_pointer_cast<SensorBase::IMUGeomData const>(_psensor->GetSensorGeometry())));
+            return boost::make_shared<PyIMUGeomData>(boost::static_pointer_cast<SensorBase::IMUGeomData const>(_psensor->GetSensorGeometry()));
         case SensorBase::ST_Odometry:
-            return boost::shared_ptr<PySensorGeometry>(new PyOdometryGeomData(boost::static_pointer_cast<SensorBase::OdometryGeomData const>(_psensor->GetSensorGeometry())));
+            return boost::make_shared<PyOdometryGeomData>(boost::static_pointer_cast<SensorBase::OdometryGeomData const>(_psensor->GetSensorGeometry()));
         case SensorBase::ST_Tactile:
-            return boost::shared_ptr<PySensorGeometry>(new PyTactileGeomData(boost::static_pointer_cast<SensorBase::TactileGeomData const>(_psensor->GetSensorGeometry())));
+            return boost::make_shared<PyTactileGeomData>(boost::static_pointer_cast<SensorBase::TactileGeomData const>(_psensor->GetSensorGeometry()));
         case SensorBase::ST_Actuator:
-            return boost::shared_ptr<PySensorGeometry>(new PyActuatorGeomData(boost::static_pointer_cast<SensorBase::ActuatorGeomData const>(_psensor->GetSensorGeometry())));
+            return boost::make_shared<PyActuatorGeomData>(boost::static_pointer_cast<SensorBase::ActuatorGeomData const>(_psensor->GetSensorGeometry()));
         case SensorBase::ST_Invalid:
             break;
         }
@@ -623,21 +623,21 @@ public:
         }
         switch(psensordata->GetType()) {
         case SensorBase::ST_Laser:
-            return boost::shared_ptr<PySensorData>(new PyLaserSensorData(boost::static_pointer_cast<SensorBase::LaserGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::LaserSensorData>(psensordata)));
+            return boost::make_shared<PyLaserSensorData>(boost::static_pointer_cast<SensorBase::LaserGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::LaserSensorData>(psensordata));
         case SensorBase::ST_Camera:
-            return boost::shared_ptr<PySensorData>(new PyCameraSensorData(boost::static_pointer_cast<SensorBase::CameraGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::CameraSensorData>(psensordata)));
+            return boost::make_shared<PyCameraSensorData>(boost::static_pointer_cast<SensorBase::CameraGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::CameraSensorData>(psensordata));
         case SensorBase::ST_JointEncoder:
-            return boost::shared_ptr<PySensorData>(new PyJointEncoderSensorData(boost::static_pointer_cast<SensorBase::JointEncoderGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::JointEncoderSensorData>(psensordata)));
+            return boost::make_shared<PyJointEncoderSensorData>(boost::static_pointer_cast<SensorBase::JointEncoderGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::JointEncoderSensorData>(psensordata));
         case SensorBase::ST_Force6D:
-            return boost::shared_ptr<PySensorData>(new PyForce6DSensorData(boost::static_pointer_cast<SensorBase::Force6DGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::Force6DSensorData>(psensordata)));
+            return boost::make_shared<PyForce6DSensorData>(boost::static_pointer_cast<SensorBase::Force6DGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::Force6DSensorData>(psensordata));
         case SensorBase::ST_IMU:
-            return boost::shared_ptr<PySensorData>(new PyIMUSensorData(boost::static_pointer_cast<SensorBase::IMUGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::IMUSensorData>(psensordata)));
+            return boost::make_shared<PyIMUSensorData>(boost::static_pointer_cast<SensorBase::IMUGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::IMUSensorData>(psensordata));
         case SensorBase::ST_Odometry:
-            return boost::shared_ptr<PySensorData>(new PyOdometrySensorData(boost::static_pointer_cast<SensorBase::OdometryGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::OdometrySensorData>(psensordata)));
+            return boost::make_shared<PyOdometrySensorData>(boost::static_pointer_cast<SensorBase::OdometryGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::OdometrySensorData>(psensordata));
         case SensorBase::ST_Tactile:
-            return boost::shared_ptr<PySensorData>(new PyTactileSensorData(boost::static_pointer_cast<SensorBase::TactileGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::TactileSensorData>(psensordata)));
+            return boost::make_shared<PyTactileSensorData>(boost::static_pointer_cast<SensorBase::TactileGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::TactileSensorData>(psensordata));
         case SensorBase::ST_Actuator:
-            return boost::shared_ptr<PySensorData>(new PyActuatorSensorData(boost::static_pointer_cast<SensorBase::ActuatorGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::ActuatorSensorData>(psensordata)));
+            return boost::make_shared<PyActuatorSensorData>(boost::static_pointer_cast<SensorBase::ActuatorGeomData const>(_psensor->GetSensorGeometry()), boost::static_pointer_cast<SensorBase::ActuatorSensorData>(psensordata));
         case SensorBase::ST_Invalid:
             break;
         }

--- a/python/bindings/openravepy_sensorsystem.cpp
+++ b/python/bindings/openravepy_sensorsystem.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
+
 namespace openravepy {
 
 class PySensorSystemBase : public PyInterfaceBase
@@ -42,7 +44,7 @@ SensorSystemBasePtr GetSensorSystem(PySensorSystemBasePtr pySensorSystem)
 
 PyInterfaceBasePtr toPySensorSystem(SensorSystemBasePtr pSensorSystem, PyEnvironmentBasePtr pyenv)
 {
-    return !pSensorSystem ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PySensorSystemBase(pSensorSystem,pyenv));
+    return !pSensorSystem ? PyInterfaceBasePtr() : boost::make_shared<PySensorSystemBase>(pSensorSystem, pyenv);
 }
 
 PySensorSystemBasePtr RaveCreateSensorSystem(PyEnvironmentBasePtr pyenv, const std::string& name)
@@ -51,7 +53,7 @@ PySensorSystemBasePtr RaveCreateSensorSystem(PyEnvironmentBasePtr pyenv, const s
     if( !p ) {
         return PySensorSystemBasePtr();
     }
-    return PySensorSystemBasePtr(new PySensorSystemBase(p,pyenv));
+    return boost::make_shared<PySensorSystemBase>(p, pyenv);
 }
 
 void init_openravepy_sensorsystem()

--- a/python/bindings/openravepy_spacesampler.cpp
+++ b/python/bindings/openravepy_spacesampler.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
+
 namespace openravepy {
 
 class PySpaceSamplerBase : public PyInterfaceBase
@@ -167,7 +169,7 @@ SpaceSamplerBasePtr GetSpaceSampler(PySpaceSamplerBasePtr pyspacesampler)
 
 PyInterfaceBasePtr toPySpaceSampler(SpaceSamplerBasePtr pspacesampler, PyEnvironmentBasePtr pyenv)
 {
-    return !pspacesampler ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PySpaceSamplerBase(pspacesampler,pyenv));
+    return !pspacesampler ? PyInterfaceBasePtr() : boost::make_shared<PySpaceSamplerBase>(pspacesampler,pyenv);
 }
 
 PySpaceSamplerBasePtr RaveCreateSpaceSampler(PyEnvironmentBasePtr pyenv, const std::string& name)
@@ -176,7 +178,7 @@ PySpaceSamplerBasePtr RaveCreateSpaceSampler(PyEnvironmentBasePtr pyenv, const s
     if( !p ) {
         return PySpaceSamplerBasePtr();
     }
-    return PySpaceSamplerBasePtr(new PySpaceSamplerBase(p,pyenv));
+    return boost::make_shared<PySpaceSamplerBase>(p, pyenv);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(SampleSequenceOneReal_overloads, SampleSequenceOneReal, 0, 1)

--- a/python/bindings/openravepy_trajectory.cpp
+++ b/python/bindings/openravepy_trajectory.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/make_shared.hpp>
+
 namespace openravepy {
 
 class PyTrajectoryBase : public PyInterfaceBase
@@ -192,7 +194,7 @@ public:
     {
         std::stringstream ss(s);
         InterfaceBasePtr p = _ptrajectory->deserialize(ss);
-        return PyTrajectoryBasePtr(new PyTrajectoryBase(RaveInterfaceCast<TrajectoryBase>(p),_pyenv));
+        return boost::make_shared<PyTrajectoryBase>(RaveInterfaceCast<TrajectoryBase>(p),_pyenv);
     }
 
     object serialize(object ooptions=object())
@@ -235,7 +237,7 @@ TrajectoryBasePtr GetTrajectory(PyTrajectoryBasePtr pytrajectory)
 
 PyInterfaceBasePtr toPyTrajectory(TrajectoryBasePtr ptrajectory, PyEnvironmentBasePtr pyenv)
 {
-    return !ptrajectory ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PyTrajectoryBase(ptrajectory,pyenv));
+    return !ptrajectory ? PyInterfaceBasePtr() : boost::make_shared<PyTrajectoryBase>(ptrajectory,pyenv);
 }
 
 object toPyTrajectory(TrajectoryBasePtr ptraj, object opyenv)
@@ -258,7 +260,7 @@ PyTrajectoryBasePtr RaveCreateTrajectory(PyEnvironmentBasePtr pyenv, const std::
     if( !p ) {
         return PyTrajectoryBasePtr();
     }
-    return PyTrajectoryBasePtr(new PyTrajectoryBase(p,pyenv));
+    return boost::make_shared<PyTrajectoryBase>(p,pyenv);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(serialize_overloads, serialize, 0, 1)

--- a/python/bindings/openravepy_viewer.cpp
+++ b/python/bindings/openravepy_viewer.cpp
@@ -17,6 +17,7 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 #include <csignal>
+#include <boost/make_shared.hpp>
 
 #if defined(_WIN32) && !defined(sighandler_t)
 typedef void (*sighandler_t)(int);
@@ -188,7 +189,7 @@ public:
 #endif
         //s_prevsignal = signal(SIGINT,viewer_sigint_handler); // control C
         // have to release the GIL since this is an infinite loop
-        openravepy::PythonThreadSaverPtr statesaver(new openravepy::PythonThreadSaver());
+        openravepy::PythonThreadSaverPtr statesaver = boost::make_shared<openravepy::PythonThreadSaver>();
         bool bSuccess=false;
         try {
             bSuccess = _pviewer->main(bShow);
@@ -302,7 +303,7 @@ ViewerBasePtr GetViewer(PyViewerBasePtr pyviewer)
 
 PyInterfaceBasePtr toPyViewer(ViewerBasePtr pviewer, PyEnvironmentBasePtr pyenv)
 {
-    return !pviewer ? PyInterfaceBasePtr() : PyInterfaceBasePtr(new PyViewerBase(pviewer,pyenv));
+    return !pviewer ? PyInterfaceBasePtr() : boost::make_shared<PyViewerBase>(pviewer,pyenv);
 }
 
 PyViewerBasePtr RaveCreateViewer(PyEnvironmentBasePtr pyenv, const std::string& name)
@@ -311,7 +312,7 @@ PyViewerBasePtr RaveCreateViewer(PyEnvironmentBasePtr pyenv, const std::string& 
     if( !p ) {
         return PyViewerBasePtr();
     }
-    return PyViewerBasePtr(new PyViewerBase(p,pyenv));
+    return boost::make_shared<PyViewerBase>(p,pyenv);
 }
 
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(main_overloads, main, 1, 2)

--- a/src/cppexamples/customreader.cpp
+++ b/src/cppexamples/customreader.cpp
@@ -8,6 +8,8 @@
 #include <openrave/openrave.h>
 #include <openrave/plugin.h>
 
+#include <boost/make_shared.hpp>
+
 using namespace std;
 using namespace OpenRAVE;
 
@@ -75,7 +77,7 @@ protected:
     static BaseXMLReaderPtr CreateXMLReader(InterfaceBasePtr ptr, const AttributesList& atts)
     {
         // ptr is the robot interface that this reader is being created for
-        return BaseXMLReaderPtr(new PIDXMLReader(boost::shared_ptr<XMLData>(),atts));
+        return boost::make_shared<PIDXMLReader>(boost::shared_ptr<XMLData>(),atts);
     }
 
     CustomController(EnvironmentBasePtr penv) : ControllerBase(penv)
@@ -154,7 +156,7 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
     switch(type) {
     case PT_Controller:
         if( interfacename == "customcontroller")
-            return InterfaceBasePtr(new cppexamples::CustomController(penv));
+            return boost::make_shared<cppexamples::CustomController>(penv);
         break;
     default:
         break;

--- a/src/cppexamples/orcollision.cpp
+++ b/src/cppexamples/orcollision.cpp
@@ -126,7 +126,7 @@ int main(int argc, char ** argv)
         }
         pbody->SetDOFValues(values,true);
 
-        CollisionReportPtr report(new CollisionReport());
+        CollisionReportPtr report = boost::make_shared<CollisionReport>();
         penv->GetCollisionChecker()->SetCollisionOptions(CO_Contacts);
         if( pbody->CheckSelfCollision(report) ) {
             contactpoints = (int)report->contacts.size();

--- a/src/cppexamples/orconveyormovement.cpp
+++ b/src/cppexamples/orconveyormovement.cpp
@@ -14,6 +14,8 @@
 
 #include "orexample.h"
 
+#include <boost/make_shared.hpp>
+
 using namespace OpenRAVE;
 using namespace std;
 
@@ -112,7 +114,7 @@ public:
 
     static InterfaceBasePtr create(EnvironmentBasePtr penv, std::istream& is)
     {
-        return InterfaceBasePtr(new ConveyorBeltModule(penv,is));
+        return boost::make_shared<ConveyorBeltModule>(penv,is);
     }
 
 private:

--- a/src/cppexamples/orplanning_door.cpp
+++ b/src/cppexamples/orplanning_door.cpp
@@ -77,8 +77,8 @@ public:
 
     bool _SetState(std::vector<dReal>& v, int filteroptions=IKFO_CheckEnvCollisions|IKFO_IgnoreCustomFilters) {
         // save state before modifying it
-        RobotBase::RobotStateSaverPtr savestate1(new RobotBase::RobotStateSaver(_probot));
-        RobotBase::RobotStateSaverPtr savestate2(new RobotBase::RobotStateSaver(_ptarget));
+        RobotBase::RobotStateSaverPtr savestate1 = boost::make_shared<RobotBase::RobotStateSaver>(_probot);
+        RobotBase::RobotStateSaverPtr savestate2 = boost::make_shared<RobotBase::RobotStateSaver>(_ptarget);
 
         vector<dReal> vdoor(1); vdoor[0] = v.back();
         _ptarget->SetActiveDOFValues(vdoor);

--- a/src/cppexamples/orplanning_planner.cpp
+++ b/src/cppexamples/orplanning_planner.cpp
@@ -58,7 +58,7 @@ public:
 
                 probot->SetActiveDOFs(pmanip->GetArmIndices());
 
-                PlannerBase::PlannerParametersPtr params(new PlannerBase::PlannerParameters());
+                PlannerBase::PlannerParametersPtr params = boost::make_shared<PlannerBase::PlannerParameters>();
                 params->_nMaxIterations = 4000; // max iterations before failure
                 params->SetRobotActiveJoints(probot); // set planning configuration space to current active dofs
                 params->vgoalconfig.resize(probot->GetActiveDOF());

--- a/src/cppexamples/orpythonbinding.cpp
+++ b/src/cppexamples/orpythonbinding.cpp
@@ -35,9 +35,10 @@
 #include <pyconfig.h>
 
 #include <exception>
-#include <boost/shared_ptr.hpp>
-#include <boost/format.hpp>
 #include <boost/assert.hpp>
+#include <boost/format.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include <vector>
 #include <cstring>
@@ -60,7 +61,7 @@ class PythonBindingModule : public ModuleBase
 {
 public:
     PythonBindingModule(EnvironmentBasePtr penv, std::istream&) : ModuleBase(penv) {
-        SetUserData(UserDataPtr(new FunctionUserData()));
+        SetUserData(boost::make_shared<FunctionUserData>());
     }
     virtual ~PythonBindingModule() {
         RAVELOG_DEBUG("destroying python binding\n");
@@ -92,7 +93,7 @@ boost::shared_ptr<void> g_PythonBindingInterfaceHandle;
 
 InterfaceBasePtr PythonBindingCreateInterface(EnvironmentBasePtr penv, std::istream& istream)
 {
-    return InterfaceBasePtr(new PythonBindingModule(penv,istream));
+    return boost::make_shared<PythonBindingModule>(penv,istream);
 }
 
 InterfaceBasePtr RegisterSimulationFunction(int environmentid, boost::python::object simulationfn)

--- a/src/cppexamples/plugincpp.cpp
+++ b/src/cppexamples/plugincpp.cpp
@@ -40,6 +40,7 @@
 #include <openrave/openrave.h>
 #include <openrave/plugin.h>
 #include <boost/bind.hpp>
+#include <boost/make_shared.hpp>
 
 using namespace std;
 using namespace OpenRAVE;
@@ -90,7 +91,7 @@ public:
 InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string& interfacename, std::istream& sinput, EnvironmentBasePtr penv)
 {
     if( type == PT_Module && interfacename == "mymodule" ) {
-        return InterfaceBasePtr(new cppexamples::MyModule(penv));
+        return boost::make_shared<cppexamples::MyModule>(penv);
     }
     return InterfaceBasePtr();
 }

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "colladacommon.h"
+#include <boost/make_shared.hpp>
 #include <boost/algorithm/string.hpp>
 #include <openrave/xmlreaders.h>
 
@@ -4069,7 +4070,7 @@ private:
                 if( !!tec ) {
                     daeElementRef pdata = tec->getChild("data");
                     if( !!pdata ) {
-                        pbody->SetReadableInterface(xmlid, XMLReadablePtr(new xmlreaders::StringXMLReadable(xmlid, pdata->getCharData())));
+                        pbody->SetReadableInterface(xmlid, boost::make_shared<xmlreaders::StringXMLReadable>(xmlid, pdata->getCharData()));
                     }
                 }
             }
@@ -4111,7 +4112,7 @@ private:
                 if( !!ptec ) {
                     daeElementRef ptype = ptec->getChild("interface");
                     if( !!ptype ) {
-                        return InterfaceTypePtr(new InterfaceType(ptype->getAttribute("type"), ptype->getCharData()));
+                        return boost::make_shared<InterfaceType>(ptype->getAttribute("type"), ptype->getCharData());
                     }
                 }
             }
@@ -4127,7 +4128,7 @@ private:
                 if( !!tec ) {
                     daeElementRef ptype = tec->getChild("interface");
                     if( !!ptype ) {
-                        return InterfaceTypePtr(new InterfaceType(ptype->getAttribute("type"), ptype->getCharData()));
+                        return boost::make_shared<InterfaceType>(ptype->getAttribute("type"), ptype->getCharData());
                     }
                 }
             }

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -18,9 +18,10 @@
 using namespace ColladaDOM150;
 
 #include <locale>
+#include <boost/algorithm/string.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/time_facet.hpp>
-#include <boost/algorithm/string.hpp>
+#include <boost/make_shared.hpp>
 
 #define LIBXML_SAX1_ENABLED
 #include <libxml/globals.h>
@@ -279,7 +280,7 @@ public:
                     throw OPENRAVE_EXCEPTION_FORMAT(_("failed to add attribute %s to element %s"), xmltag%itatt->first, ORE_InvalidArguments);
                 }
             }
-            return BaseXMLWriterPtr(new ColladaInterfaceWriter(childelt));
+            return boost::make_shared<ColladaInterfaceWriter>(childelt);
         }
         virtual void SetCharData(const std::string& data) {
             if( !_elt->setCharData(data) ) {

--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -395,7 +395,7 @@ public:
     virtual EnvironmentBasePtr CloneSelf(int options)
     {
         EnvironmentMutex::scoped_lock lockenv(GetMutex());
-        boost::shared_ptr<Environment> penv(new Environment());
+        boost::shared_ptr<Environment> penv = boost::make_shared<Environment>();
         penv->_Clone(boost::static_pointer_cast<Environment const>(shared_from_this()),options,false);
         return penv;
     }
@@ -758,7 +758,7 @@ public:
     virtual UserDataPtr RegisterBodyCallback(const BodyCallbackFn& callback)
     {
         boost::timed_mutex::scoped_lock lock(_mutexInterfaces);
-        BodyCallbackDataPtr pdata(new BodyCallbackData(callback,boost::dynamic_pointer_cast<Environment>(shared_from_this())));
+        BodyCallbackDataPtr pdata = boost::make_shared<BodyCallbackData>(callback,boost::dynamic_pointer_cast<Environment>(shared_from_this()));
         pdata->_iterator = _listRegisteredBodyCallbacks.insert(_listRegisteredBodyCallbacks.end(),pdata);
         return pdata;
     }
@@ -830,7 +830,7 @@ public:
     virtual UserDataPtr RegisterCollisionCallback(const CollisionCallbackFn& callback)
     {
         boost::timed_mutex::scoped_lock lock(_mutexInterfaces);
-        CollisionCallbackDataPtr pdata(new CollisionCallbackData(callback,boost::dynamic_pointer_cast<Environment>(shared_from_this())));
+        CollisionCallbackDataPtr pdata = boost::make_shared<CollisionCallbackData>(callback,boost::dynamic_pointer_cast<Environment>(shared_from_this()));
         pdata->_iterator = _listRegisteredCollisionCallbacks.insert(_listRegisteredCollisionCallbacks.end(),pdata);
         return pdata;
     }
@@ -1545,7 +1545,7 @@ public:
             }
         }
         if( !ptrimesh ) {
-            ptrimesh.reset(new TriMesh());
+            ptrimesh = boost::make_shared<TriMesh>();
         }
         if( !OpenRAVEXMLParser::CreateTriMeshFromFile(shared_from_this(),filedata, vScaleGeometry, *ptrimesh, diffuseColor, ambientColor, ftransparency) ) {
             ptrimesh.reset();
@@ -1577,7 +1577,7 @@ public:
             }
         }
         if( !ptrimesh ) {
-            ptrimesh.reset(new TriMesh());
+            ptrimesh = boost::make_shared<TriMesh>();
         }
         if( !OpenRAVEXMLParser::CreateTriMeshFromData(data, formathint, vScaleGeometry, *ptrimesh, diffuseColor, ambientColor, ftransparency) ) {
             ptrimesh.reset();
@@ -1648,7 +1648,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->plot3(ppoints, numPoints, stride, fPointSize, color, drawstyle));
         }
@@ -1660,7 +1660,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->plot3(ppoints, numPoints, stride, fPointSize, colors, drawstyle, bhasalpha));
         }
@@ -1672,7 +1672,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawlinestrip(ppoints, numPoints, stride, fwidth,color));
         }
@@ -1684,7 +1684,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawlinestrip(ppoints, numPoints, stride, fwidth,colors));
         }
@@ -1696,7 +1696,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawlinelist(ppoints, numPoints, stride, fwidth,color));
         }
@@ -1708,7 +1708,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawlinelist(ppoints, numPoints, stride, fwidth,colors));
         }
@@ -1720,7 +1720,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawarrow(p1,p2,fwidth,color));
         }
@@ -1732,7 +1732,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawbox(vpos, vextents));
         }
@@ -1744,7 +1744,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawplane(tplane, vextents, vtexture));
         }
@@ -1756,7 +1756,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawtrimesh(ppoints, stride, pIndices, numTriangles, color));
         }
@@ -1768,7 +1768,7 @@ public:
         if( _listViewers.size() == 0 ) {
             return OpenRAVE::GraphHandlePtr();
         }
-        GraphHandleMultiPtr handles(new GraphHandleMulti());
+        GraphHandleMultiPtr handles = boost::make_shared<GraphHandleMulti>();
         FOREACHC(itviewer, _listViewers) {
             handles->Add((*itviewer)->drawtrimesh(ppoints, stride, pIndices, numTriangles, colors));
         }
@@ -2468,7 +2468,7 @@ protected:
     {
         if( !_threadSimulation ) {
             _bShutdownSimulation = false;
-            _threadSimulation.reset(new boost::thread(boost::bind(&Environment::_SimulationThread, this)));
+            _threadSimulation = boost::make_shared<boost::thread>(boost::bind(&Environment::_SimulationThread, this));
         }
     }
 

--- a/src/libopenrave-core/genericcollisionchecker.cpp
+++ b/src/libopenrave-core/genericcollisionchecker.cpp
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ravep.h"
 
+#include <boost/make_shared.hpp>
+
 namespace OpenRAVE {
 
 class GenericCollisionChecker : public CollisionCheckerBase
@@ -126,7 +128,7 @@ public:
 
 CollisionCheckerBasePtr CreateGenericCollisionChecker(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return CollisionCheckerBasePtr(new GenericCollisionChecker(penv,sinput));
+    return boost::make_shared<GenericCollisionChecker>(penv, boost::ref(sinput));
 }
 
 }

--- a/src/libopenrave-core/genericphysicsengine.cpp
+++ b/src/libopenrave-core/genericphysicsengine.cpp
@@ -16,6 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ravep.h"
 
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
 namespace OpenRAVE {
 
 class GenericPhysicsEngine : public PhysicsEngineBase
@@ -143,7 +146,7 @@ private:
 
 PhysicsEngineBasePtr CreateGenericPhysicsEngine(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return PhysicsEngineBasePtr(new GenericPhysicsEngine(penv,sinput));
+    return boost::make_shared<GenericPhysicsEngine>(penv, boost::ref(sinput));
 }
 
 }

--- a/src/libopenrave-core/multicontroller.cpp
+++ b/src/libopenrave-core/multicontroller.cpp
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "ravep.h"
 
+#include <boost/make_shared.hpp>
+
 namespace OpenRAVE {
 
 class MultiController : public MultiControllerBase
@@ -233,7 +235,7 @@ protected:
 
 MultiControllerBasePtr CreateMultiController(EnvironmentBasePtr penv, std::istream& sinput)
 {
-    return MultiControllerBasePtr(new MultiController(penv));
+    return boost::make_shared<MultiController>(penv);
 }
 
 }

--- a/src/libopenrave-core/openrave-core.cpp
+++ b/src/libopenrave-core/openrave-core.cpp
@@ -18,7 +18,7 @@
 
 namespace OpenRAVE {
 EnvironmentBasePtr RaveCreateEnvironment(int options) {
-    boost::shared_ptr<Environment> p(new Environment());
+    boost::shared_ptr<Environment> p = boost::make_shared<Environment>();
     p->Init(!!(options&ECO_StartSimulationThread));
     return p;
 }

--- a/src/libopenrave-core/xfileparser/XFileBindings.cpp
+++ b/src/libopenrave-core/xfileparser/XFileBindings.cpp
@@ -20,6 +20,7 @@
 #include "XFileParser.h"
 
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 
 #ifdef HAVE_BOOST_FILESYSTEM
 #include <boost/filesystem/operations.hpp>
@@ -342,7 +343,7 @@ protected:
             KinBody::GeometryInfo g;
             _ExtractGeometry(*it, g);
             g._t = plink->_info._t.inverse() * tflipyz * tnode;
-            plink->_vGeometries.push_back(KinBody::Link::GeometryPtr(new KinBody::Link::Geometry(plink,g)));
+            plink->_vGeometries.push_back(boost::make_shared<KinBody::Link::Geometry>(plink,g));
         }
 
         FOREACH(it,node->mChildren) {

--- a/src/libopenrave/iksolver.cpp
+++ b/src/libopenrave/iksolver.cpp
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "libopenrave.h"
 
+#include <boost/make_shared.hpp>
+
 namespace OpenRAVE {
 
 bool IkReturn::Append(const IkReturn& r)
@@ -126,7 +128,7 @@ bool IkSolverBase::SolveAll(const IkParameterization& param, int filteroptions, 
     }
     ikreturns.resize(vsolutions.size());
     for(size_t i = 0; i < ikreturns.size(); ++i) {
-        ikreturns[i].reset(new IkReturn(IKRA_Success));
+        ikreturns[i] = boost::make_shared<IkReturn>(IKRA_Success);
         ikreturns[i]->_vsolution = vsolutions[i];
         ikreturns[i]->_action = IKRA_Success;
     }
@@ -157,7 +159,7 @@ bool IkSolverBase::SolveAll(const IkParameterization& param, const std::vector<d
     }
     ikreturns.resize(vsolutions.size());
     for(size_t i = 0; i < ikreturns.size(); ++i) {
-        ikreturns[i].reset(new IkReturn(IKRA_Success));
+        ikreturns[i] = boost::make_shared<IkReturn>(IKRA_Success);
         ikreturns[i]->_vsolution = vsolutions[i];
         ikreturns[i]->_action = IKRA_Success;
     }

--- a/src/libopenrave/iksolver.cpp
+++ b/src/libopenrave/iksolver.cpp
@@ -168,7 +168,7 @@ bool IkSolverBase::SolveAll(const IkParameterization& param, const std::vector<d
 
 UserDataPtr IkSolverBase::RegisterCustomFilter(int32_t priority, const IkSolverBase::IkFilterCallbackFn &filterfn)
 {
-    CustomIkSolverFilterDataPtr pdata(new CustomIkSolverFilterData(priority,filterfn,shared_iksolver()));
+    CustomIkSolverFilterDataPtr pdata = boost::make_shared<CustomIkSolverFilterData>(priority,filterfn,shared_iksolver());
     std::list<UserDataWeakPtr>::iterator it;
     FORIT(it, __listRegisteredFilters) {
         CustomIkSolverFilterDataPtr pitdata = boost::dynamic_pointer_cast<CustomIkSolverFilterData>(it->lock());
@@ -182,7 +182,7 @@ UserDataPtr IkSolverBase::RegisterCustomFilter(int32_t priority, const IkSolverB
 
 UserDataPtr IkSolverBase::RegisterFinishCallback(const IkFinishCallbackFn& finishfn)
 {
-    IkSolverFinishCallbackDataPtr pdata(new IkSolverFinishCallbackData(finishfn,shared_iksolver()));
+    IkSolverFinishCallbackDataPtr pdata = boost::make_shared<IkSolverFinishCallbackData>(finishfn,shared_iksolver());
     pdata->_iterator = __listRegisteredFinishCallbacks.insert(__listRegisteredFinishCallbacks.end(), pdata);
     return pdata;
 }

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "libopenrave.h"
 #include <algorithm>
+#include <boost/make_shared.hpp>
 
 // used for functions that are also used internally
 #define CHECK_INTERNAL_COMPUTATION0 OPENRAVE_ASSERT_FORMAT(_nHierarchyComputed != 0, "body %s internal structures need to be computed, current value is %d. Are you sure Environment::AddRobot/AddKinBody was called?", GetName()%_nHierarchyComputed, ORE_NotInitialized);
@@ -4172,7 +4173,7 @@ void KinBody::_ComputeInternalInformation()
         if( (*itlink)->_info._mapExtraGeometries.find(selfgroup) == (*itlink)->_info._mapExtraGeometries.end() ) {
             std::vector<GeometryInfoPtr> vgeoms;
             FOREACH(itgeom, (*itlink)->_vGeometries) {
-                vgeoms.push_back(GeometryInfoPtr(new GeometryInfo((*itgeom)->GetInfo())));
+                vgeoms.push_back(boost::make_shared<GeometryInfo>((*itgeom)->GetInfo()));
             }
             (*itlink)->_info._mapExtraGeometries.insert(make_pair(selfgroup, vgeoms));
         }

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -412,7 +412,7 @@ void KinBody::SetLinkGeometriesFromGroup(const std::string& geomname)
         }
         (*itlink)->_vGeometries.resize(pvinfos->size());
         for(size_t i = 0; i < pvinfos->size(); ++i) {
-            (*itlink)->_vGeometries[i].reset(new Link::Geometry(*itlink,*pvinfos->at(i)));
+            (*itlink)->_vGeometries[i] = boost::make_shared<Link::Geometry>(*itlink,*pvinfos->at(i));
             if( (*itlink)->_vGeometries[i]->GetCollisionMesh().vertices.size() == 0 ) { // try to avoid recomputing
                 (*itlink)->_vGeometries[i]->InitCollisionMesh();
             }
@@ -478,12 +478,12 @@ bool KinBody::Init(const std::vector<KinBody::LinkInfoConstPtr>& linkinfos, cons
             throw OPENRAVE_EXCEPTION_FORMAT(_("joint %s is declared more than once"), rawinfo->_name, ORE_InvalidArguments);
         }
         setusednames.insert(rawinfo->_name);
-        JointPtr pjoint(new Joint(shared_kinbody(), rawinfo->_type));
+        JointPtr pjoint = boost::make_shared<Joint>(shared_kinbody(), rawinfo->_type);
         pjoint->_info = *rawinfo;
         JointInfo& info = pjoint->_info;
         for(size_t i = 0; i < info._vmimic.size(); ++i) {
             if( !!info._vmimic[i] ) {
-                pjoint->_vmimic[i].reset(new Mimic());
+                pjoint->_vmimic[i] = boost::make_shared<Mimic>();
                 pjoint->_vmimic[i]->_equations = info._vmimic[i]->_equations;
             }
         }
@@ -4493,7 +4493,7 @@ void KinBody::Clone(InterfaceBaseConstPtr preference, int cloningoptions)
         // have to copy all the geometries too!
         std::vector<Link::GeometryPtr> vnewgeometries(pnewlink->_vGeometries.size());
         for(size_t igeom = 0; igeom < vnewgeometries.size(); ++igeom) {
-            vnewgeometries[igeom].reset(new Link::Geometry(pnewlink, pnewlink->_vGeometries[igeom]->_info));
+            vnewgeometries[igeom] = boost::make_shared<Link::Geometry>(pnewlink, pnewlink->_vGeometries[igeom]->_info);
         }
         pnewlink->_vGeometries = vnewgeometries;
         _veclinks.push_back(pnewlink);

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -87,7 +87,7 @@ static void fparser_sass(std::vector<dReal>& res, const vector<dReal>& coeffs)
 
 OpenRAVEFunctionParserRealPtr CreateJointFunctionParser()
 {
-    OpenRAVEFunctionParserRealPtr parser(new OpenRAVEFunctionParserReal());
+    OpenRAVEFunctionParserRealPtr parser = boost::make_shared<OpenRAVEFunctionParserReal>();
 #ifdef OPENRAVE_FPARSER_SETEPSILON
     parser->setEpsilon(g_fEpsilonLinear);
 #endif
@@ -1234,12 +1234,12 @@ std::string KinBody::Joint::GetMimicEquation(int iaxis, int itype, const std::st
         std::string sout;
         KinBodyConstPtr parent(_parent);
         FOREACHC(itdofformat, _vmimic.at(iaxis)->_vdofformat) {
-            JointConstPtr pjoint = itdofformat->GetJoint(parent);
-            if( pjoint->GetDOF() > 1 ) {
-                Vars.push_back(str(boost::format("<csymbol>%s_%d</csymbol>")%pjoint->GetName()%(int)itdofformat->axis));
+            const Joint &joint = *(itdofformat->GetJoint(parent));
+            if( joint.GetDOF() > 1 ) {
+                Vars.push_back(str(boost::format("<csymbol>%s_%d</csymbol>")%joint.GetName()%(int)itdofformat->axis));
             }
             else {
-                Vars.push_back(str(boost::format("<csymbol>%s</csymbol>")%pjoint->GetName()));
+                Vars.push_back(str(boost::format("<csymbol>%s</csymbol>")%joint.GetName()));
             }
         }
         if( itype == 0 ) {
@@ -1343,9 +1343,9 @@ void KinBody::Joint::SetMimicEquations(int iaxis, const std::string& poseq, cons
             dofformat.axis = 0;
         }
         dofformat.dofindex = -1;
-        JointPtr pjoint = dofformat.GetJoint(parent);
-        if((pjoint->GetDOFIndex() >= 0)&& !pjoint->IsMimic(dofformat.axis) ) {
-            dofformat.dofindex = pjoint->GetDOFIndex()+dofformat.axis;
+        Joint &joint = *(dofformat.GetJoint(parent));
+        if((joint.GetDOFIndex() >= 0)&& !joint.IsMimic(dofformat.axis) ) {
+            dofformat.dofindex = joint.GetDOFIndex()+dofformat.axis;
             MIMIC::DOFHierarchy h;
             h.dofindex = dofformat.dofindex;
             h.dofformatindex = mimic->_vdofformat.size();

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <boost/algorithm/string.hpp> // boost::trim
 #include <boost/lexical_cast.hpp>
+#include <boost/make_shared.hpp>
 
 #include "fparsermulti.h"
 
@@ -1295,7 +1296,7 @@ void KinBody::Joint::SetMimicEquations(int iaxis, const std::string& poseq, cons
 
     // copy equations into the info
     if( !_info._vmimic.at(iaxis) ) {
-        _info._vmimic.at(iaxis).reset(new MimicInfo());
+        _info._vmimic.at(iaxis) = boost::make_shared<MimicInfo>();
     }
     _info._vmimic.at(iaxis)->_equations = mimic->_equations;
 

--- a/src/libopenrave/kinbodylink.cpp
+++ b/src/libopenrave/kinbodylink.cpp
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "libopenrave.h"
 #include <algorithm>
+#include <boost/make_shared.hpp>
 
 namespace OpenRAVE {
 
@@ -323,7 +324,7 @@ void KinBody::Link::InitGeometries(std::vector<KinBody::GeometryInfoConstPtr>& g
 {
     _vGeometries.resize(geometries.size());
     for(size_t i = 0; i < geometries.size(); ++i) {
-        _vGeometries[i].reset(new Geometry(shared_from_this(),*geometries[i]));
+        _vGeometries[i] = boost::make_shared<Geometry>(shared_from_this(),*geometries[i]);
         if( _vGeometries[i]->GetCollisionMesh().vertices.size() == 0 ) {
             RAVELOG_VERBOSE("geometry has empty collision mesh\n");
             _vGeometries[i]->InitCollisionMesh(); // have to initialize the mesh since some plugins might not understand all geometry types
@@ -334,7 +335,7 @@ void KinBody::Link::InitGeometries(std::vector<KinBody::GeometryInfoConstPtr>& g
     std::vector<KinBody::GeometryInfoPtr> vgeometryinfos;
     vgeometryinfos.resize(_vGeometries.size());
     for(size_t i = 0; i < vgeometryinfos.size(); ++i) {
-        vgeometryinfos[i].reset(new KinBody::GeometryInfo());
+        vgeometryinfos[i] = boost::make_shared<KinBody::GeometryInfo>();
         *vgeometryinfos[i] = _vGeometries[i]->_info;
     }
     SetGroupGeometries("self", vgeometryinfos);
@@ -346,7 +347,7 @@ void KinBody::Link::InitGeometries(std::list<KinBody::GeometryInfo>& geometries)
     _vGeometries.resize(geometries.size());
     size_t i = 0;
     FOREACH(itinfo,geometries) {
-        _vGeometries[i].reset(new Geometry(shared_from_this(),*itinfo));
+        _vGeometries[i] = boost::make_shared<Geometry>(shared_from_this(),*itinfo);
         if( _vGeometries[i]->GetCollisionMesh().vertices.size() == 0 ) {
             RAVELOG_VERBOSE("geometry has empty collision mesh\n");
             _vGeometries[i]->InitCollisionMesh(); // have to initialize the mesh since some plugins might not understand all geometry types
@@ -358,7 +359,7 @@ void KinBody::Link::InitGeometries(std::list<KinBody::GeometryInfo>& geometries)
     std::vector<KinBody::GeometryInfoPtr> vgeometryinfos;
     vgeometryinfos.resize(_vGeometries.size());
     for(size_t i = 0; i < vgeometryinfos.size(); ++i) {
-        vgeometryinfos[i].reset(new KinBody::GeometryInfo());
+        vgeometryinfos[i] = boost::make_shared<KinBody::GeometryInfo>();
         *vgeometryinfos[i] = _vGeometries[i]->_info;
     }
     SetGroupGeometries("self", vgeometryinfos);
@@ -380,7 +381,7 @@ void KinBody::Link::SetGeometriesFromGroup(const std::string& groupname)
     }
     _vGeometries.resize(pvinfos->size());
     for(size_t i = 0; i < pvinfos->size(); ++i) {
-        _vGeometries[i].reset(new Geometry(shared_from_this(),*pvinfos->at(i)));
+        _vGeometries[i] = boost::make_shared<Geometry>(shared_from_this(),*pvinfos->at(i));
         if( _vGeometries[i]->GetCollisionMesh().vertices.size() == 0 ) {
             RAVELOG_VERBOSE("geometry has empty collision mesh\n");
             _vGeometries[i]->InitCollisionMesh();
@@ -493,7 +494,7 @@ void KinBody::Link::UpdateInfo()
         _info._vgeometryinfos.resize(_vGeometries.size());
         for(size_t i = 0; i < _info._vgeometryinfos.size(); ++i) {
             if( !_info._vgeometryinfos[i] ) {
-                _info._vgeometryinfos[i].reset(new KinBody::GeometryInfo());
+                _info._vgeometryinfos[i] = boost::make_shared<KinBody::GeometryInfo>();
             }
             *_info._vgeometryinfos[i] = _vGeometries[i]->GetInfo();
         }

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -2339,7 +2339,7 @@ typedef boost::shared_ptr<CustomSamplerCallbackData> CustomSamplerCallbackDataPt
 
 UserDataPtr SpaceSamplerBase::RegisterStatusCallback(const StatusCallbackFn& callbackfn)
 {
-    CustomSamplerCallbackDataPtr pdata(new CustomSamplerCallbackData(callbackfn,shared_sampler()));
+    CustomSamplerCallbackDataPtr pdata = boost::make_shared<CustomSamplerCallbackData>(callbackfn,shared_sampler());
     pdata->_iterator = __listRegisteredCallbacks.insert(__listRegisteredCallbacks.end(),pdata);
     return pdata;
 }

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -16,9 +16,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "libopenrave.h"
 
+#include <boost/make_shared.hpp>
 #include <boost/scoped_ptr.hpp>
-#include <boost/utility.hpp>
 #include <boost/thread/once.hpp>
+#include <boost/utility.hpp>
 
 #include <streambuf>
 
@@ -653,7 +654,7 @@ protected:
 
     UserDataPtr RegisterXMLReader(InterfaceType type, const std::string& xmltag, const CreateXMLReaderFn& fn)
     {
-        return UserDataPtr(new XMLReaderFunctionData(type,xmltag,fn,shared_from_this()));
+        return boost::make_shared<XMLReaderFunctionData>(type, xmltag, fn, shared_from_this());
     }
 
     const BaseXMLReaderPtr CallXMLReader(InterfaceType type, const std::string& xmltag, InterfaceBasePtr pinterface, const AttributesList& atts)

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -442,7 +442,7 @@ public:
             RAVELOG_WARN("failed to set to C locale: %s\n",e.what());
         }
 
-        _pdatabase.reset(new RaveDatabase());
+        _pdatabase = boost::make_shared<RaveDatabase>();
         if( !_pdatabase->Init(bLoadAllPlugins) ) {
             RAVELOG_FATAL("failed to create the openrave plugin database\n");
         }
@@ -2199,7 +2199,7 @@ BaseXMLReader::ProcessElement DummyXMLReader::startElement(const std::string& na
     }
 
     // create a new parser
-    _pcurreader.reset(new DummyXMLReader(name, _parentname,_osrecord));
+    _pcurreader = boost::make_shared<DummyXMLReader>(name, _parentname,_osrecord);
     return PE_Support;
 }
 
@@ -2440,7 +2440,7 @@ void DefaultStartElementSAXFunc(void *ctx, const xmlChar *name, const xmlChar **
         BaseXMLReader::ProcessElement pestatus = pdata->_reader.startElement(s, listatts);
         if( pestatus != BaseXMLReader::PE_Support ) {
             // not handling, so create a temporary class to handle it
-            pdata->_pdummy.reset(new DummyXMLReader(s,"(libxml)"));
+            pdata->_pdummy = boost::make_shared<DummyXMLReader>(s,"(libxml)");
         }
     }
 }

--- a/src/libopenrave/libopenrave.h
+++ b/src/libopenrave/libopenrave.h
@@ -26,6 +26,8 @@
 
 //#include <boost/math/special_functions/round.hpp>
 
+#include <boost/make_shared.hpp>
+
 // include boost for vc++ only (to get typeof working)
 #ifdef _MSC_VER
 #include <boost/typeof/std/string.hpp>
@@ -347,9 +349,9 @@ public:
         std::map<KinBody::LinkConstPtr, int>::iterator itnoncolliding;
         std::vector<KinBody::LinkPtr > vbodyattachedlinks;
         FOREACHC(itgrabbed, probot->_vGrabbedBodies) {
-            boost::shared_ptr<Grabbed const> pgrabbed = boost::dynamic_pointer_cast<Grabbed const>(*itgrabbed);
-            bool bsamelink = find(_vattachedlinks.begin(),_vattachedlinks.end(), pgrabbed->_plinkrobot) != _vattachedlinks.end();
-            KinBodyPtr pothergrabbedbody(pgrabbed->_pgrabbedbody);
+            const Grabbed &grabbed = *(*itgrabbed);
+            bool bsamelink = find(_vattachedlinks.begin(),_vattachedlinks.end(), grabbed._plinkrobot) != _vattachedlinks.end();
+            KinBodyPtr pothergrabbedbody(grabbed._pgrabbedbody);
             if( !!pothergrabbedbody && pothergrabbedbody != pgrabbedbody && pothergrabbedbody->GetLinks().size() > 0 ) {
                 if( bsamelink ) {
                     pothergrabbedbody->GetLinks().at(0)->GetRigidlyAttachedLinks(vbodyattachedlinks);
@@ -365,10 +367,10 @@ public:
                             // new body?
                             if( !colsaver ) {
                                 // have to reset the collision options
-                                colsaver.reset(new CollisionOptionsStateSaver(pchecker,0));
+                                colsaver = boost::make_shared<CollisionOptionsStateSaver>(pchecker,0);
                             }
                             if( !othergrabbedbodysaver ) {
-                                othergrabbedbodysaver.reset(new KinBody::KinBodyStateSaver(pothergrabbedbody, KinBody::Save_LinkEnable));
+                                othergrabbedbodysaver = boost::make_shared<KinBody::KinBodyStateSaver>(pothergrabbedbody, KinBody::Save_LinkEnable);
                                 pothergrabbedbody->Enable(true);
                             }
                             _mapLinkIsNonColliding[*itgrabbedlink] = !pchecker->CheckCollision(KinBody::LinkConstPtr(*itgrabbedlink), pgrabbedbody);
@@ -380,8 +382,8 @@ public:
 
         std::set<KinBodyConstPtr> _setgrabbed;
         FOREACHC(itgrabbed, probot->_vGrabbedBodies) {
-            boost::shared_ptr<Grabbed const> pgrabbed = boost::dynamic_pointer_cast<Grabbed const>(*itgrabbed);
-            KinBodyConstPtr pothergrabbedbody(pgrabbed->_pgrabbedbody);
+            const Grabbed &grabbed = *(*itgrabbed);
+            KinBodyConstPtr pothergrabbedbody(grabbed._pgrabbedbody);
             if( !!pothergrabbedbody ) {
                 _setgrabbed.insert(pothergrabbedbody);
             }

--- a/src/libopenrave/libopenrave_c.cpp
+++ b/src/libopenrave/libopenrave_c.cpp
@@ -254,7 +254,7 @@ bool ORCEnvironmentSetViewer(void* env, const char* viewername)
 
     if( !!viewername && strlen(viewername) > 0 ) {
         boost::mutex::scoped_lock lock(s_mutexViewer);
-        boost::shared_ptr<boost::thread> threadviewer(new boost::thread(boost::bind(CViewerThread, penv, std::string(viewername), true)));
+        boost::shared_ptr<boost::thread> threadviewer = boost::make_shared<boost::thread>(boost::bind(CViewerThread, penv, std::string(viewername), true));
         s_mapEnvironmentThreadViewers[penv] = threadviewer;
         s_conditionViewer.wait(lock);
     }

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -478,7 +478,7 @@ public:
                 vsampletimes.resize(vabstimes.size());
                 std::merge(vabstimes.begin(), vabstimes.begin()+trajectory->GetNumWaypoints(), vabstimes.begin()+trajectory->GetNumWaypoints(), vabstimes.end(), vsampletimes.begin());
                 std::vector<dReal> vprevdata, vprevdatavel;
-                ConstraintFilterReturnPtr filterreturn(new ConstraintFilterReturn());
+                ConstraintFilterReturnPtr filterreturn = boost::make_shared<ConstraintFilterReturn>();
                 trajectory->Sample(vprevdata,0,_parameters->_configurationspecification);
                 trajectory->Sample(vprevdatavel,0,velspec);
                 std::vector<dReal>::iterator itprevtime = vsampletimes.begin();
@@ -560,7 +560,7 @@ void VerifyTrajectory(PlannerBase::PlannerParametersConstPtr parameters, Traject
 {
     EnvironmentMutex::scoped_lock lockenv(trajectory->GetEnv()->GetMutex());
     if( !parameters ) {
-        PlannerBase::PlannerParametersPtr newparams(new PlannerBase::PlannerParameters());
+        PlannerBase::PlannerParametersPtr newparams = boost::make_shared<PlannerBase::PlannerParameters>();
         newparams->SetConfigurationSpecification(trajectory->GetEnv(), trajectory->GetConfigurationSpecification().GetTimeDerivativeSpecification(0));
         parameters = newparams;
     }
@@ -585,7 +585,7 @@ PlannerStatus _PlanActiveDOFTrajectory(TrajectoryBasePtr traj, RobotBasePtr prob
     EnvironmentMutex::scoped_lock lockenv(env->GetMutex());
     CollisionOptionsStateSaver optionstate(env->GetCollisionChecker(),env->GetCollisionChecker()->GetCollisionOptions()|CO_ActiveDOFs,false);
     PlannerBasePtr planner = RaveCreatePlanner(env,plannername.size() > 0 ? plannername : string("parabolicsmoother"));
-    TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
+    TrajectoryTimingParametersPtr params = boost::make_shared<TrajectoryTimingParameters>();
     params->SetRobotActiveJoints(probot);
     FOREACH(it,params->_vConfigVelocityLimit) {
         *it *= fmaxvelmult;
@@ -626,7 +626,7 @@ ActiveDOFTrajectorySmoother::ActiveDOFTrajectorySmoother(RobotBasePtr robot, con
     _nRobotAffineDOF = _robot->GetAffineDOF();
     _vRobotRotationAxis = _robot->GetAffineRotationAxis();
     _planner = RaveCreatePlanner(robot->GetEnv(),plannername);
-    TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
+    TrajectoryTimingParametersPtr params = boost::make_shared<TrajectoryTimingParameters>();
     params->SetRobotActiveJoints(_robot);
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
@@ -667,7 +667,7 @@ void ActiveDOFTrajectorySmoother::_UpdateParameters()
 {
     RobotBase::RobotStateSaver saver(_robot, KinBody::Save_ActiveDOF);
     _robot->SetActiveDOFs(_vRobotActiveIndices, _nRobotAffineDOF, _vRobotRotationAxis);
-    TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
+    TrajectoryTimingParametersPtr params = boost::make_shared<TrajectoryTimingParameters>();
     params->SetRobotActiveJoints(_robot);
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
@@ -687,7 +687,7 @@ ActiveDOFTrajectoryRetimer::ActiveDOFTrajectoryRetimer(RobotBasePtr robot, const
     _nRobotAffineDOF = _robot->GetAffineDOF();
     _vRobotRotationAxis = _robot->GetAffineRotationAxis();
     _planner = RaveCreatePlanner(robot->GetEnv(),plannername);
-    TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
+    TrajectoryTimingParametersPtr params = boost::make_shared<TrajectoryTimingParameters>();
     params->SetRobotActiveJoints(_robot);
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
@@ -731,7 +731,7 @@ void ActiveDOFTrajectoryRetimer::_UpdateParameters()
 {
     RobotBase::RobotStateSaver saver(_robot, KinBody::Save_ActiveDOF);
     _robot->SetActiveDOFs(_vRobotActiveIndices, _nRobotAffineDOF, _vRobotRotationAxis);
-    TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
+    TrajectoryTimingParametersPtr params = boost::make_shared<TrajectoryTimingParameters>();
     params->SetRobotActiveJoints(_robot);
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
@@ -761,7 +761,7 @@ PlannerStatus _PlanTrajectory(TrajectoryBasePtr traj, bool hastimestamps, dReal 
 
     EnvironmentMutex::scoped_lock lockenv(traj->GetEnv()->GetMutex());
     PlannerBasePtr planner = RaveCreatePlanner(traj->GetEnv(),plannername.size() > 0 ? plannername : string("parabolicsmoother"));
-    TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
+    TrajectoryTimingParametersPtr params = boost::make_shared<TrajectoryTimingParameters>();
     params->SetConfigurationSpecification(traj->GetEnv(),traj->GetConfigurationSpecification().GetTimeDerivativeSpecification(0));
     FOREACH(it,params->_vConfigVelocityLimit) {
         *it *= fmaxvelmult;
@@ -895,7 +895,7 @@ static PlannerStatus _PlanAffineTrajectory(TrajectoryBasePtr traj, const std::ve
     // don't need to convert since the planner does that automatically
     //ConvertTrajectorySpecification(traj,newspec);
     PlannerBasePtr planner = RaveCreatePlanner(traj->GetEnv(),plannername.size() > 0 ? plannername : string("parabolicsmoother"));
-    TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
+    TrajectoryTimingParametersPtr params = boost::make_shared<TrajectoryTimingParameters>();
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_vConfigVelocityLimit = maxvelocities;
     params->_vConfigAccelerationLimit = maxaccelerations;
@@ -961,9 +961,9 @@ static PlannerStatus _PlanAffineTrajectory(TrajectoryBasePtr traj, const std::ve
             params->_getstatefn = boost::bind(_GetAffineState,_1,params->GetDOF(), boost::ref(listgetfunctions));
             params->_distmetricfn = boost::bind(_ComputeAffineDistanceMetric,_1,_2,boost::ref(listdistfunctions));
             std::list<KinBodyPtr> listCheckCollisions; listCheckCollisions.push_back(robot);
-            boost::shared_ptr<DynamicsCollisionConstraint> pcollision(new DynamicsCollisionConstraint(params, listCheckCollisions, 0xffffffff&~CFO_CheckTimeBasedConstraints));
+            boost::shared_ptr<DynamicsCollisionConstraint> pcollision = boost::make_shared<DynamicsCollisionConstraint>(params, listCheckCollisions, 0xffffffff&~CFO_CheckTimeBasedConstraints);
             params->_checkpathvelocityconstraintsfn = boost::bind(&DynamicsCollisionConstraint::Check,pcollision,_1, _2, _3, _4, _5, _6, _7, _8);
-            statesaver.reset(new PlannerStateSaver(newspec.GetDOF(), params->_setstatevaluesfn, params->_getstatefn));
+            statesaver = boost::make_shared<PlannerStateSaver>(newspec.GetDOF(), params->_setstatevaluesfn, params->_getstatefn);
         }
     }
     else {
@@ -1046,7 +1046,7 @@ PlannerStatus AffineTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, const st
     //ConvertTrajectorySpecification(traj,trajspec);
     TrajectoryTimingParametersPtr parameters;
     if( !_parameters ) {
-        parameters.reset(new TrajectoryTimingParameters());
+        parameters = boost::make_shared<TrajectoryTimingParameters>();
         parameters->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
         parameters->_setstatevaluesfn.clear();
         parameters->_setstatefn.clear();
@@ -1447,7 +1447,7 @@ size_t InsertWaypointWithRetiming(int waypointindex, const std::vector<dReal>& d
 
 size_t InsertWaypointWithSmoothing(int index, const std::vector<dReal>& dofvalues, const std::vector<dReal>& dofvelocities, TrajectoryBasePtr traj, dReal fmaxvelmult, dReal fmaxaccelmult, const std::string& plannername)
 {
-    TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
+    TrajectoryTimingParametersPtr params = boost::make_shared<TrajectoryTimingParameters>();
     ConfigurationSpecification specpos = traj->GetConfigurationSpecification().GetTimeDerivativeSpecification(0);
     OPENRAVE_ASSERT_OP(specpos.GetDOF(),==,(int)dofvalues.size());
     params->SetConfigurationSpecification(traj->GetEnv(),specpos);
@@ -2000,7 +2000,7 @@ void GetDHParameters(std::vector<DHParameter>& vparameters, KinBodyConstPtr pbod
 DynamicsCollisionConstraint::DynamicsCollisionConstraint(PlannerBase::PlannerParametersConstPtr parameters, const std::list<KinBodyPtr>& listCheckBodies, int filtermask) : _listCheckBodies(listCheckBodies), _filtermask(filtermask), _torquelimitmode(0), _perturbation(0.1)
 {
     BOOST_ASSERT(listCheckBodies.size()>0);
-    _report.reset(new CollisionReport());
+    _report = boost::make_shared<CollisionReport>();
     _parameters = parameters;
     if( !!parameters ) {
         _specvel = parameters->_configurationspecification.ConvertToVelocitySpecification();
@@ -3056,7 +3056,7 @@ ManipulatorIKGoalSampler::ManipulatorIKGoalSampler(RobotBase::ManipulatorConstPt
         s._numleft = _nummaxsamples;
         _listsamples.push_back(s);
     }
-    _report.reset(new CollisionReport());
+    _report = boost::make_shared<CollisionReport>();
     pmanip->GetIkSolver()->GetFreeParameters(_vfreestart);
 
     std::stringstream ssout, ssin;
@@ -3174,7 +3174,7 @@ IkReturnPtr ManipulatorIKGoalSampler::Sample()
                                     if( (!bCheckEndEffector || !_pmanip->CheckEndEffectorCollision(ikparamjittered,_report, numRedundantSamplesForEEChecking)) && (!bCheckEndEffectorSelf || !_pmanip->CheckEndEffectorSelfCollision(ikparamjittered,_report, numRedundantSamplesForEEChecking)) ) {
                                         // make sure at least one ik solution exists...
                                         if( !ikreturnjittered ) {
-                                            ikreturnjittered.reset(new IkReturn(IKRA_Success));
+                                            ikreturnjittered = boost::make_shared<IkReturn>(IKRA_Success);
                                         }
                                         bool biksuccess = _pmanip->FindIKSolution(ikparamjittered, _ikfilteroptions, ikreturnjittered);
                                         if( biksuccess ) {
@@ -3208,7 +3208,7 @@ IkReturnPtr ManipulatorIKGoalSampler::Sample()
                                 try {
                                     if( (!bCheckEndEffector || !_pmanip->CheckEndEffectorCollision(ikparamjittered, _report, numRedundantSamplesForEEChecking)) && (!bCheckEndEffectorSelf || !_pmanip->CheckEndEffectorSelfCollision(ikparamjittered, _report, numRedundantSamplesForEEChecking)) ) {
                                         if( !ikreturnjittered ) {
-                                            ikreturnjittered.reset(new IkReturn(IKRA_Success));
+                                            ikreturnjittered = boost::make_shared<IkReturn>(IKRA_Success);
                                         }
                                         bool biksuccess = _pmanip->FindIKSolution(ikparamjittered, _ikfilteroptions, ikreturnjittered);
                                         if( biksuccess ) {

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "libopenrave.h"
 
+#include <boost/make_shared.hpp>
+
 #define CHECK_INTERNAL_COMPUTATION OPENRAVE_ASSERT_FORMAT(_nHierarchyComputed == 2, "robot %s internal structures need to be computed, current value is %d. Are you sure Environment::AddRobot/AddKinBody was called?", GetName()%_nHierarchyComputed, ORE_NotInitialized);
 
 namespace OpenRAVE {
@@ -2468,7 +2470,7 @@ void RobotBase::Clone(InterfaceBaseConstPtr preference, int cloningoptions)
 
     _vecSensors.clear();
     FOREACHC(itsensor, r->_vecSensors) {
-        _vecSensors.push_back(AttachedSensorPtr(new AttachedSensor(shared_robot(),**itsensor,cloningoptions)));
+        _vecSensors.push_back(boost::make_shared<AttachedSensor>(shared_robot(),**itsensor,cloningoptions));
     }
     _UpdateAttachedSensors();
 

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -232,7 +232,7 @@ void RobotBase::RobotStateSaver::_RestoreRobot(boost::shared_ptr<RobotBase> prob
                         RAVELOG_WARN(str(boost::format("body %s is not similar across environments")%pbody->GetName()));
                     }
                     else {
-                        GrabbedPtr pnewgrabbed(new Grabbed(pnewbody,probot->GetLinks().at(KinBody::LinkPtr(pgrabbed->_plinkrobot)->GetIndex())));
+                        GrabbedPtr pnewgrabbed = boost::make_shared<Grabbed>(pnewbody,probot->GetLinks().at(KinBody::LinkPtr(pgrabbed->_plinkrobot)->GetIndex()));
                         pnewgrabbed->_troot = pgrabbed->_troot;
                         pnewgrabbed->_listNonCollidingLinks.clear();
                         FOREACHC(itlinkref, pgrabbed->_listNonCollidingLinks) {
@@ -343,7 +343,7 @@ bool RobotBase::Init(const std::vector<KinBody::LinkInfoConstPtr>& linkinfos, co
     }
     _vecSensors.resize(0);
     FOREACHC(itattachedsensorinfo, attachedsensorinfos) {
-        AttachedSensorPtr newattachedsensor(new AttachedSensor(shared_robot(),**itattachedsensorinfo));
+        AttachedSensorPtr newattachedsensor = boost::make_shared<AttachedSensor>(shared_robot(),**itattachedsensorinfo);
         _vecSensors.push_back(newattachedsensor);
         newattachedsensor->UpdateInfo(); // just in case
         __hashrobotstructure.resize(0);
@@ -2527,7 +2527,7 @@ void RobotBase::Clone(InterfaceBaseConstPtr preference, int cloningoptions)
             pgrabbedbody = GetEnv()->GetBodyFromEnvironmentId(pbodyref->GetEnvironmentId());
             BOOST_ASSERT(pgrabbedbody->GetName() == pbodyref->GetName());
 
-            GrabbedPtr pgrabbed(new Grabbed(pgrabbedbody,_veclinks.at(KinBody::LinkPtr(pgrabbedref->_plinkrobot)->GetIndex())));
+            GrabbedPtr pgrabbed = boost::make_shared<Grabbed>(pgrabbedbody,_veclinks.at(KinBody::LinkPtr(pgrabbedref->_plinkrobot)->GetIndex()));
             pgrabbed->_troot = pgrabbedref->_troot;
             pgrabbed->_listNonCollidingLinks.clear();
             FOREACHC(itlinkref, pgrabbedref->_listNonCollidingLinks) {

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -1046,12 +1046,12 @@ bool RobotBase::Manipulator::CheckIndependentCollision(CollisionReportPtr report
 
             // check if any grabbed bodies are attached to this link
             FOREACHC(itgrabbed,probot->_vGrabbedBodies) {
-                GrabbedConstPtr pgrabbed = boost::dynamic_pointer_cast<Grabbed const>(*itgrabbed);
-                if( pgrabbed->_plinkrobot == *itlink ) {
+                const Grabbed &grabbed = *(*itgrabbed);
+                if( grabbed._plinkrobot == *itlink ) {
                     if( vbodyexcluded.empty() ) {
                         vbodyexcluded.push_back(KinBodyConstPtr(probot));
                     }
-                    KinBodyPtr pbody = pgrabbed->_pgrabbedbody.lock();
+                    KinBodyPtr pbody = grabbed._pgrabbedbody.lock();
                     if( !!pbody && probot->GetEnv()->CheckCollision(KinBodyConstPtr(pbody),vbodyexcluded, vlinkexcluded, report) ) {
                         return true;
                     }

--- a/src/libopenrave/sensorsystem.cpp
+++ b/src/libopenrave/sensorsystem.cpp
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "libopenrave.h"
 
+#include <boost/make_shared.hpp>
+
 namespace OpenRAVE {
 
 SimpleSensorSystem::SimpleXMLReader::SimpleXMLReader(boost::shared_ptr<XMLData> p) : _pdata(p)
@@ -91,7 +93,7 @@ void SimpleSensorSystem::SimpleXMLReader::characters(const std::string& ch)
 
 BaseXMLReaderPtr SimpleSensorSystem::CreateXMLReaderId(const string& xmlid, InterfaceBasePtr ptr, const AttributesList& atts)
 {
-    return BaseXMLReaderPtr(new SimpleXMLReader(boost::shared_ptr<XMLData>(new XMLData(xmlid))));
+    return boost::make_shared<SimpleXMLReader>(boost::make_shared<XMLData>(xmlid));
 }
 
 UserDataPtr SimpleSensorSystem::RegisterXMLReaderId(EnvironmentBasePtr penv, const string& xmlid)
@@ -211,9 +213,9 @@ bool SimpleSensorSystem::SwitchBody(KinBodyPtr pbody1, KinBodyPtr pbody2)
 
 boost::shared_ptr<SimpleSensorSystem::BodyData> SimpleSensorSystem::CreateBodyData(KinBodyPtr pbody, boost::shared_ptr<XMLData const> pdata)
 {
-    boost::shared_ptr<XMLData> pnewdata(new XMLData(_xmlid));
+    boost::shared_ptr<XMLData> pnewdata = boost::make_shared<XMLData>(_xmlid);
     pnewdata->copy(pdata);
-    return boost::shared_ptr<BodyData>(new BodyData(RaveInterfaceCast<SimpleSensorSystem>(shared_from_this()),pbody, pnewdata));
+    return boost::make_shared<BodyData>(RaveInterfaceCast<SimpleSensorSystem>(shared_from_this()),pbody, pnewdata);
 }
 
 void SimpleSensorSystem::_UpdateBodies(list<SimpleSensorSystem::SNAPSHOT>& listbodies)


### PR DESCRIPTION
* Use make_shared instead of shared_ptr(new ...) and reset whenever possible. make_shared is faster than reset according to my test.
* Use reference instead of creating another shared_ptr when it makes sense