### PR TITLE
minor fixes

### DIFF
--- a/src/libopenrave-core/xmlreaders-core.cpp
+++ b/src/libopenrave-core/xmlreaders-core.cpp
@@ -661,7 +661,7 @@ public:
                 }
             }
 
-            if( !!scene->mMaterials && input_mesh->mMaterialIndex>=0 && input_mesh->mMaterialIndex<scene->mNumMaterials) {
+            if( !!scene->mMaterials&& input_mesh->mMaterialIndex<scene->mNumMaterials) {
                 aiMaterial* mtrl = scene->mMaterials[input_mesh->mMaterialIndex];
                 aiColor4D color;
                 aiGetMaterialColor(mtrl,AI_MATKEY_COLOR_DIFFUSE,&color);

--- a/src/libopenrave/configurationspecification.cpp
+++ b/src/libopenrave/configurationspecification.cpp
@@ -710,7 +710,6 @@ ConfigurationSpecification& ConfigurationSpecification::operator+= (const Config
                         itcompatgroup->interpolation = itrgroup->interpolation;
                     }
                 }
-                itrgroup->interpolation != itcompatgroup->interpolation;
             }
 
             if( itcompatgroup->name == itrgroup->name ) {


### PR DESCRIPTION
fixed issues reported by clang-tidy

- delete string comparison whose result was unused 
- delete an always-true check