### PR TITLE
Fix bulletcollision

### DIFF
--- a/plugins/bulletrave/bulletcollision.h
+++ b/plugins/bulletrave/bulletcollision.h
@@ -168,7 +168,7 @@ public:
             // check if links are in adjacency list
             int index0 = plink0->GetIndex();
             int index1 = plink1->GetIndex();
-            return _setadjacency.find(index0|(index1<<16)) != _setadjacency.end() || _setadjacency.find(index1|(index0<<16)) != _setadjacency.end();
+            return find(_setadjacency.begin(), _setadjacency.end(), index0|(index1<<16)) != _setadjacency.end() || find(_setadjacency.begin(), _setadjacency.end(), index1|(index0<<16)) != _setadjacency.end();
         }
 
         KinBodyConstPtr _pparent;


### PR DESCRIPTION
std::vector does not have find member method, so we have to use std::find here.

(Well, during discussion with Antoine-san, it turned out I accidentally installed libbullet-dev)