### PR TITLE
Disable initial show command, which seems to be causing XIOError.

### DIFF
--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1206,7 +1206,7 @@ bool QtOSGViewer::_StartViewerLoopCommand(ostream& sout, istream& sinput)
     sinput >> bcallmain;
     _nQuitMainLoop = -1;
     //_StartPlaybackTimer();
-    // this->show();
+    Show(1);
     if( bcallmain ) {
         _posgWidget->SetHome();
         QApplication::instance()->exec();
@@ -1244,11 +1244,9 @@ int QtOSGViewer::main(bool bShow)
     }
     _nQuitMainLoop = -1;
     //_StartPlaybackTimer();
-    // if (bShow) {
-    //     if( _nQuitMainLoop < 0 ) {
-    //         this->show();
-    //     }
-    // }
+    if (bShow) {
+        Show(1);
+    }
 
     UpdateFromModel();
     _posgWidget->SetHome();

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1206,7 +1206,7 @@ bool QtOSGViewer::_StartViewerLoopCommand(ostream& sout, istream& sinput)
     sinput >> bcallmain;
     _nQuitMainLoop = -1;
     //_StartPlaybackTimer();
-    this->show();
+    // this->show();
     if( bcallmain ) {
         _posgWidget->SetHome();
         QApplication::instance()->exec();
@@ -1244,11 +1244,11 @@ int QtOSGViewer::main(bool bShow)
     }
     _nQuitMainLoop = -1;
     //_StartPlaybackTimer();
-    if (bShow) {
-        if( _nQuitMainLoop < 0 ) {
-            this->show();
-        }
-    }
+    // if (bShow) {
+    //     if( _nQuitMainLoop < 0 ) {
+    //         this->show();
+    //     }
+    // }
 
     UpdateFromModel();
     _posgWidget->SetHome();

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1245,7 +1245,9 @@ int QtOSGViewer::main(bool bShow)
     _nQuitMainLoop = -1;
     //_StartPlaybackTimer();
     if (bShow) {
-        Show(1);
+        if( _nQuitMainLoop < 0 ) {
+            Show(1);
+        }
     }
 
     UpdateFromModel();


### PR DESCRIPTION
Posting the initial show as command to command queue. Let's try to see if running exec() before show() help fix this rare crash.

```
#9  0x00007fac2980eb75 in exit () from /lib/x86_64-linux-gnu/libc.so.6
#10 0x00007fac241945f8 in qt_xio_errhandler () at kernel/qapplication_x11.cpp:773
#11 0x00007fac219cc3fe in _XIOError (dpy=dpy@entry=0x7fab6c04dab0) at ../../src/XlibInt.c:1616
#12 0x00007fac219ca4bc in _XReply (dpy=dpy@entry=0x7fab6c04dab0, rep=rep@entry=0x7fabb4bb0810, extra=extra@entry=0, discard=discard@entry=0) at ../../src/xcb_io.c:708
#13 0x00007fac219b036a in XGetWindowProperty (dpy=0x7fab6c04dab0, w=29360156, property=281, offset=0, length=5, delete=0, req_type=281, actual_type=0x7fabb4bb08d0, actual_format=0x7fabb4bb08cc, 
    nitems=0x7fabb4bb08d8, bytesafter=0x7fabb4bb08e0, prop=0x7fabb4bb08e8) at ../../src/GetProp.c:69
#14 0x00007fac241b9103 in GetMWMHints (display=<optimized out>, window=<optimized out>) at kernel/qwidget_x11.cpp:148
#15 0x00007fac241bb55d in QWidgetPrivate::setConstraints_sys (this=this@entry=0x7fab6c05db60) at kernel/qwidget_x11.cpp:2687
#16 0x00007fac241777f8 in QWidget::setMinimumSize (this=this@entry=0x7fab6c05d430, minw=2, minh=2) at kernel/qwidget.cpp:4007
#17 0x00007fac24154c80 in setMinimumSize (s=<synthetic pointer>, this=0x7fab6c05d430) at ../../include/QtGui/../../src/gui/kernel/qwidget.h:970
#18 QLayout::activate (this=0x7fab6c05ddd0) at kernel/qlayout.cpp:1252
#19 0x00007fac2417ca64 in QWidget::setVisible (this=0x7fab6c05d430, visible=<optimized out>) at kernel/qwidget.cpp:7758
#20 0x00007fabe9b7b0ef in qtosgrave::QtOSGViewer::main(bool) () from /opt/lib/openrave0.9-plugins/libqtosgrave.so
```