### PR TITLE
Set window title in gui thread.

### DIFF
--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1748,9 +1748,14 @@ void QtOSGViewer::Move(int x, int y)
     _PostToGUIThread(boost::bind(&QtOSGViewer::move, this, x, y));
 }
 
-void QtOSGViewer::SetName(const string& ptitle)
+void QtOSGViewer::SetName(const string& name)
 {
-    setWindowTitle(ptitle.c_str());
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_SetName, this, name));
+}
+
+void QtOSGViewer::_SetName(const string& name)
+{
+    setWindowTitle(name.c_str());
 }
 
 bool QtOSGViewer::LoadModel(const string& filename)

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -322,6 +322,8 @@ public:
 
     virtual void _SetProjectionMode(const std::string& projectionMode);
 
+    virtual void _SetName(const std::string& name);
+
     /// \brief posts a function to be executed in the GUI thread
     ///
     /// \param fn the function to execute


### PR DESCRIPTION
Kevin reported that sometimes window title does not change, causing his code to fail to find the correct window.