### PR TITLE
Update KinBody::Joint::GetTorqueLimits to use GetMaxTorque if available and _vmaxtorque is not set

### DIFF
--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -877,7 +877,12 @@ void KinBody::Joint::GetTorqueLimits(std::vector<dReal>& vmax, bool bAppend) con
         vmax.resize(0);
     }
     for(int i = 0; i < GetDOF(); ++i) {
-        vmax.push_back(_info._vmaxtorque[i]);
+        if( _info._infoElectricMotor ) {
+            vmax.push_back(GetMaxTorque(i));
+        }
+        else {
+            vmax.push_back(_info._vmaxtorque[i]);
+        }
     }
 }
 

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -877,7 +877,7 @@ void KinBody::Joint::GetTorqueLimits(std::vector<dReal>& vmax, bool bAppend) con
         vmax.resize(0);
     }
     for(int i = 0; i < GetDOF(); ++i) {
-        if( _info._infoElectricMotor ) {
+        if( _info._vmaxtorque[i] == 0 && _info._infoElectricMotor ) {
             vmax.push_back(GetMaxTorque(i));
         }
         else {


### PR DESCRIPTION
Currently I cannot use robot.GetDOFTorqueLimits() (all returned values are zero). `[e.GetMaxTorque() for e in robot.GetJoints()]` is a workaround, but it is not intuitive.