### PR TITLE
env was cloned twice, and the first clone was not destroyed

### DIFF
--- a/plugins/grasper/graspermodule.cpp
+++ b/plugins/grasper/graspermodule.cpp
@@ -808,13 +808,14 @@ public:
         worker_params->affinedofs = _robot->GetAffineDOF();
         worker_params->affineaxis = _robot->GetAffineRotationAxis();
 
-        EnvironmentBasePtr pcloneenv = GetEnv()->CloneSelf(Clone_Bodies|Clone_Simulation);
-
         _bContinueWorker = true;
         // start worker threads
         vector<boost::shared_ptr<boost::thread> > listthreads(numthreads);
-        FOREACH(itthread,listthreads) {
-            itthread->reset(new boost::thread(boost::bind(&GrasperModule::_WorkerThread,this,worker_params,pcloneenv)));
+        {
+            EnvironmentBasePtr penv = GetEnv();
+            FOREACH(itthread,listthreads) {
+                itthread->reset(new boost::thread(boost::bind(&GrasperModule::_WorkerThread,this,worker_params,penv)));
+            }
         }
 
         _listGraspResults.clear();


### PR DESCRIPTION
The environment is cloned again in _WorkerThread. Therefore, cloning beforehand is not necessary. In addition, the first clone was not being destroyed.