### PR TITLE
Fix collada memory leak

### DIFF
--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -360,9 +360,15 @@ private:
         if( !!_dae && !!_doc ) {
             _doc = NULL;
             // If GlobalDAE is not resetted, there will be memory leak inside the
-            // Collada library because there are some static cache/table that will
-            // only be cleaned when the number of DAE instances alive becomes 0.
+            // Collada library because static daeStringTable in daeStringRef.cpp
+            // will only be cleaned by daeStringRef::releaseStringTable when
+            // the number of DAE instances alive becomes 0.
+            //
+            // There is no simple workaround for libxml2 before 2.9.0. Read
+            // the comments of GetGlobalDAE() in OpenRAVE for more details
+#if LIBXML_VERSION >= 20900
             SetGlobalDAE(boost::shared_ptr<DAE>());
+#endif
         }
     }
 

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -358,7 +358,6 @@ private:
     virtual ~ColladaWriter()
     {
         if( !!_dae && !!_doc ) {
-            _doc = NULL;
             // If GlobalDAE is not resetted, there will be memory leak inside the
             // Collada library because static daeStringTable in daeStringRef.cpp
             // will only be cleaned by daeStringRef::releaseStringTable when
@@ -368,7 +367,10 @@ private:
             // the comments of GetGlobalDAE() in OpenRAVE for more details
 #if LIBXML_VERSION >= 20900
             SetGlobalDAE(boost::shared_ptr<DAE>());
+#else
+            _dae->getDatabase()->removeDocument(_doc);
 #endif
+            _doc = NULL;
         }
     }
 

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -358,20 +358,20 @@ private:
     virtual ~ColladaWriter()
     {
         if( !!_dae && !!_doc ) {
-            // If GlobalDAE is not resetted, there will be memory leak inside the
-            // Collada library because static daeStringTable in daeStringRef.cpp
-            // will only be cleaned by daeStringRef::releaseStringTable when
-            // the number of DAE instances alive becomes 0.
-            //
-            // There is no simple workaround for libxml2 before 2.9.0. Read
-            // the comments of GetGlobalDAE() in OpenRAVE for more details
-#if LIBXML_VERSION >= 20900
-            SetGlobalDAE(boost::shared_ptr<DAE>());
-#else
             _dae->getDatabase()->removeDocument(_doc);
-#endif
             _doc = NULL;
         }
+
+        // If GlobalDAE is not resetted, there will be memory leak inside the
+        // Collada library because static daeStringTable in daeStringRef.cpp
+        // will only be cleaned by daeStringRef::releaseStringTable when
+        // the number of DAE instances alive becomes 0.
+        //
+        // There is no simple workaround for libxml2 before 2.9.0. Read
+        // the comments of GetGlobalDAE() in OpenRAVE for more details
+#if LIBXML_VERSION >= 20900
+        SetGlobalDAE(boost::shared_ptr<DAE>());
+#endif
     }
 
     /// \param docname the top level document?

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -361,6 +361,10 @@ private:
             _dae->getDatabase()->removeDocument(_doc);
             _doc = NULL;
         }
+        // If GlobalDAE is not resetted, there will be memory leak inside the
+        // Collada library because there are some static cache/table that will
+        // only be cleaned when the number of DAE instances alive becomes 0.
+        SetGlobalDAE(boost::shared_ptr<DAE>());
     }
 
     /// \param docname the top level document?

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -358,13 +358,12 @@ private:
     virtual ~ColladaWriter()
     {
         if( !!_dae && !!_doc ) {
-            _dae->getDatabase()->removeDocument(_doc);
             _doc = NULL;
+            // If GlobalDAE is not resetted, there will be memory leak inside the
+            // Collada library because there are some static cache/table that will
+            // only be cleaned when the number of DAE instances alive becomes 0.
+            SetGlobalDAE(boost::shared_ptr<DAE>());
         }
-        // If GlobalDAE is not resetted, there will be memory leak inside the
-        // Collada library because there are some static cache/table that will
-        // only be cleaned when the number of DAE instances alive becomes 0.
-        SetGlobalDAE(boost::shared_ptr<DAE>());
     }
 
     /// \param docname the top level document?


### PR DESCRIPTION
To reproduce the memory leak: Just open an environment and keep calling env.Save()

I can also change the code such that we only call SetGlobalDAE for libxml2 2.9+. However, the #ifdefs might make the code hard to read. Please let me know.