### PR TITLE
Fix projection mode switching. Add Zoom function for orthogonal projection

### DIFF
--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -898,7 +898,7 @@ void ViewerWidget::Zoom(float factor)
         const int height = _osgview->getCamera()->getViewport()->height();
         const double aspect = static_cast<double>(width)/static_cast<double>(height);
         const double nearplane = GetCameraNearPlane();
-        const double distance = 0.5 * _osgCameraManipulator->getDistance() * factor;
+        const double distance = 0.5 * _osgCameraManipulator->getDistance() / factor;
 
         _osgview->getCamera()->setProjectionMatrixAsOrtho(-distance, distance, -distance/aspect, distance/aspect, nearplane, 10000*nearplane);
     }

--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -900,6 +900,21 @@ void ViewerWidget::SetViewport(int width, int height, double metersinunit)
     _osgHudText->setCharacterSize(textheight);
 }
 
+void ViewerWidget::Zoom(float factor)
+{
+    if ( _osgview->getCamera()->getProjectionMatrix()(2,3) == 0 ) {
+        int width = _osgview->getCamera()->getViewport()->width();
+        int height = _osgview->getCamera()->getViewport()->height();
+        double aspect = static_cast<double>(width)/static_cast<double>(height);
+        double nearplane = GetCameraNearPlane();
+
+        double distance = 0.5 * _osgCameraManipulator->getDistance() * factor;
+        _osgview->getCamera()->setProjectionMatrixAsOrtho(-distance, distance, -distance/aspect, distance/aspect, nearplane, 10000*nearplane);
+    } else {
+        // TODO: implement this
+    }   
+}
+
 void ViewerWidget::SetTextureCubeMap(const std::string& posx, const std::string& negx, const std::string& posy,
                                      const std::string& negy, const std::string& posz, const std::string& negz)
 {

--- a/plugins/qtosgrave/osgviewerwidget.h
+++ b/plugins/qtosgrave/osgviewerwidget.h
@@ -81,6 +81,8 @@ public:
     /// \brief sets the near plane for the camera
     void SetNearPlane(double nearplane);
 
+    void Zoom(float factor);
+
     /// \brief set the cubemap for skybox
     void SetTextureCubeMap(const std::string& posx,
             const std::string& negx,

--- a/plugins/qtosgrave/osgviewerwidget.h
+++ b/plugins/qtosgrave/osgviewerwidget.h
@@ -81,6 +81,8 @@ public:
     /// \brief sets the near plane for the camera
     void SetNearPlane(double nearplane);
 
+    /// \brief sets the zoom factor. only affects orthogonal view 
+    /// \param factor > 1.0 = Zoom in. < 1.0 = Zoom out
     void Zoom(float factor);
 
     /// \brief set the cubemap for skybox

--- a/plugins/qtosgrave/osgviewerwidget.h
+++ b/plugins/qtosgrave/osgviewerwidget.h
@@ -215,6 +215,9 @@ protected:
 
     bool _bLightOn; ///< whether lights are on or not
     bool _bIsSelectiveActive; ///< if true, then can select a new
+    double _zNear; ///< In OSG, znear and zfar are updated by CullVisitor, which
+                   ///  causing getProjectionMatrixAsXXX to return negative 
+                   ///  values. Therefore, we manage zNear ourselves
 };
 
 }

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -160,6 +160,8 @@ QtOSGViewer::QtOSGViewer(EnvironmentBasePtr penv, std::istream& sinput) : QMainW
                     "starts the viewer sync loop and shows the viewer. expects someone else will call the qapplication exec fn");
     RegisterCommand("SetProjectionMode", boost::bind(&QtOSGViewer::_SetProjectionModeCommand, this, _1, _2),
                     "sets the viewer projection mode, perspective or orthogonal");
+    RegisterCommand("Zoom", boost::bind(&QtOSGViewer::_ZoomCommand, this, _1, _2),
+                    "Set the zooming factor of the view");
     _bLockEnvironment = true;
     _InitGUI(bCreateStatusBar, bCreateMenu);
     _bUpdateEnvironment = true;
@@ -1242,6 +1244,14 @@ bool QtOSGViewer::_SetProjectionModeCommand(ostream& sout, istream& sinput)
     std::string projectionMode = "";
     sinput >> projectionMode;
     _PostToGUIThread(boost::bind(&QtOSGViewer::_SetProjectionMode, this, projectionMode));
+    return true;
+}
+
+bool QtOSGViewer::_ZoomCommand(ostream& sout, istream& sinput)
+{
+    float factor = 1.0f;
+    sinput >> factor;
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Zoom, this, factor));
     return true;
 }
 

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1779,6 +1779,16 @@ void QtOSGViewer::Move(int x, int y)
     _PostToGUIThread(boost::bind(&QtOSGViewer::move, this, x, y));
 }
 
+void QtOSGViewer::Zoom(float factor)
+{
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Zoom, this, factor));   
+}
+
+void QtOSGViewer::_Zoom(float factor)
+{
+    _posgWidget->Zoom(factor);
+}
+
 void QtOSGViewer::SetName(const string& name)
 {
     _PostToGUIThread(boost::bind(&QtOSGViewer::_SetName, this, name));

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -370,6 +370,7 @@ public:
     bool _SetTrackingAngleToUpCommand(ostream& sout, istream& sinput);
     bool _StartViewerLoopCommand(ostream& sout, istream& sinput);
     bool _SetProjectionModeCommand(ostream& sout, istream& sinput);
+    bool _ZoomCommand(ostream& sout, istream& sinput);
 
     //@{ Message Queue
     list<GUIThreadFunctionPtr> _listGUIFunctions; ///< list of GUI functions that should be called in the viewer update thread. protected by _mutexGUIFunctions

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -95,6 +95,8 @@ public:
     virtual void SetSize(int w, int h);
     virtual void Move(int x, int y);
 
+    /// \brief sets the zoom factor. only affects orthogonal view
+    /// \param factor > 1.0 = Zoom in. < 1.0 = Zoom out
     virtual void Zoom(float factor);
 
     /// \brief Set title of the viewer window

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -95,6 +95,8 @@ public:
     virtual void SetSize(int w, int h);
     virtual void Move(int x, int y);
 
+    virtual void Zoom(float factor);
+
     /// \brief Set title of the viewer window
     virtual void SetName(const string& name);
 
@@ -324,6 +326,7 @@ public:
     virtual void _SetBkgndColor(const RaveVector<float>& color);
 
     virtual void _SetName(const std::string& name);
+    virtual void _Zoom(float factor);
 
     /// \brief posts a function to be executed in the GUI thread
     ///


### PR DESCRIPTION
The projection mode fix is similar to what @ziyan had done in https://github.com/rdiankov/openrave/tree/qtosg-znear

Shall I change the code such that the Zoom function also affects perspective projection?