### PR TITLE
Fix equality checking

### DIFF
--- a/plugins/rplanners/ParabolicPathSmooth/ParabolicRamp.cpp
+++ b/plugins/rplanners/ParabolicPathSmooth/ParabolicRamp.cpp
@@ -381,8 +381,8 @@ bool ParabolicRamp1D::SolveFixedTime(Real amax,Real vmax,Real endTime)
 
     // Intervals 1 and 2 are derived from constraints on a1 (the acceleration of the first ramp)
     // I) sum1 <= B/tswitch1
-    if (sum1 == 0) {
-        if (B == 0) {
+    if (FuzzyZero(sum1, EpsilonA)) {
+        if (FuzzyZero(B, EpsilonV)) {
             // tswitch1 can be anything
         }
         else {
@@ -400,8 +400,8 @@ bool ParabolicRamp1D::SolveFixedTime(Real amax,Real vmax,Real endTime)
     }
 
     // II) B/tswitch1 <= sum2
-    if (sum2 == 0) {
-        if (B == 0) {
+    if (FuzzyZero(sum2, EpsilonA)) {
+        if (FuzzyZero(B, EpsilonV)) {
             // tswitch1 can be anything
         }
         else {
@@ -431,8 +431,8 @@ bool ParabolicRamp1D::SolveFixedTime(Real amax,Real vmax,Real endTime)
 
     // Intervals 3 and 3 are derived from constraints on a2 (the acceleration of the second (last) ramp)
     // III) sum1 <= B/(tswitch1 - t)
-    if (sum1 == 0) {
-        if (B == 0) {
+    if (FuzzyZero(sum1, EpsilonA)) {
+        if (FuzzyZero(B, EpsilonV)) {
             // tswitch1 can be anything
         }
         else {
@@ -449,8 +449,8 @@ bool ParabolicRamp1D::SolveFixedTime(Real amax,Real vmax,Real endTime)
     }
 
     // IV)
-    if (sum2 == 0) {
-        if (B == 0) {
+    if (FuzzyZero(sum2, EpsilonA)) {
+        if (FuzzyZero(B, EpsilonV)) {
             // tswitch1 can be anything
         }
         else {
@@ -773,7 +773,7 @@ bool ParabolicRamp1D::SolveFixedTime(Real amax,Real vmax,Real endTime)
 
             if (tswitch1 + tLastRamp > endTime) {
                 // Final fix
-                if (A == 0) {
+                if (FuzzyZero(A, EpsilonA)) {
                     PARABOLIC_RAMP_PLOG("(final fix) A = 0. Don't know how to deal with this case");
                     PARABOLIC_RAMP_PLOG("ParabolicRamp1D info: x0 = %.15e; x1 = %.15e; v0 = %.15e; v1 = %.15e; vm = %.15e; am = %.15e; newDuration = %.15e", x0, x1, dx0, dx1, vmax, amax, endTime);
                     return false;

--- a/plugins/rplanners/rampoptimizer/interpolator.cpp
+++ b/plugins/rplanners/rampoptimizer/interpolator.cpp
@@ -862,8 +862,8 @@ bool ParabolicInterpolator::Compute1DTrajectoryFixedDuration(dReal x0, dReal x1,
 
     // Intervals 1 and 2 are derived from constraints on a0 (the acceleration of the first ramp)
     // I) sum1 <= B/t0
-    if( sum1 == 0 ) {
-        if( B == 0 ) {
+    if( FuzzyZero(sum1, g_fRampEpsilon) ) {
+        if( FuzzyZero(B, g_fRampEpsilon) ) {
             // t0 can be anything
         }
         else {
@@ -881,8 +881,8 @@ bool ParabolicInterpolator::Compute1DTrajectoryFixedDuration(dReal x0, dReal x1,
     }
 
     // II) B/t0 <= sum2
-    if( sum2 == 0 ) {
-        if( B == 0 ) {
+    if( FuzzyZero(sum2, g_fRampEpsilon) ) {
+        if( FuzzyZero(B, g_fRampEpsilon) ) {
             // t0 can be anything
         }
         else {
@@ -912,8 +912,8 @@ bool ParabolicInterpolator::Compute1DTrajectoryFixedDuration(dReal x0, dReal x1,
 
     // Intervals 3 and 4 are derived from constraints on a1 (the acceleration of the second (last) ramp
     // III) sum1 <= B/(t0 - t)
-    if( sum1 == 0 ) {
-        if( B == 0 ) {
+    if( FuzzyZero(sum1, g_fRampEpsilon) ) {
+        if( FuzzyZero(B, g_fRampEpsilon) ) {
             // t0 can be anything
         }
         else {
@@ -931,8 +931,8 @@ bool ParabolicInterpolator::Compute1DTrajectoryFixedDuration(dReal x0, dReal x1,
     }
 
     // IV)
-    if( sum2 == 0 ) {
-        if( B == 0 ) {
+    if( FuzzyZero(sum2, g_fRampEpsilon) ) {
+        if( FuzzyZero(B, g_fRampEpsilon) ) {
             // t0 can be anything
         }
         else {


### PR DESCRIPTION
The previous `== 0` checking sometimes causes trajectory retiming to fail.