### PR TITLE
Add check of nEndTimeDiscretization in parabolicsmoother

### DIFF
--- a/plugins/rplanners/parabolicsmoother.cpp
+++ b/plugins/rplanners/parabolicsmoother.cpp
@@ -20,6 +20,7 @@
 
 #include "manipconstraints.h"
 #include "ParabolicPathSmooth/DynamicPath.h"
+#include "trajectoryretimer.h" // _(msgid)
 
 namespace rplanners {
 

--- a/plugins/rplanners/parabolicsmoother.cpp
+++ b/plugins/rplanners/parabolicsmoother.cpp
@@ -1776,6 +1776,9 @@ protected:
         }
         dReal originalEndTime = endTime;
         int nEndTimeDiscretization = (int)(endTime*fiMinDiscretization)+1;
+        if( nEndTimeDiscretization > 46340 ) {
+            throw OPENRAVE_EXCEPTION_FORMAT(_("nEndTimeDiscretization^2 must be less than 2^31 (%d^2). Try to increase mintimestep."), nEndTimeDiscretization, ORE_Assert);
+        }
         dReal dummyEndTime;
 
         /*
@@ -1890,8 +1893,9 @@ protected:
             {
                 int t1index = t1*fiMinDiscretization;
                 int t2index = t2*fiMinDiscretization;
-                int testpairindex = t1index*nEndTimeDiscretization+t2index;
-                if( testpairindex < (int)vVisitedDiscretization.size() && vVisitedDiscretization[testpairindex] ) {
+                int64_t testpairindex = t1index*nEndTimeDiscretization+t2index;
+                OPENRAVE_ASSERT_OP(testpairindex, <, (int64_t)vVisitedDiscretization.size());
+                if( vVisitedDiscretization[testpairindex] ) {
                     RAVELOG_VERBOSE_FORMAT("env = %d: shortcut iter = %d/%d: the sampled t1 (%f) and t2 (%f) are already tested", GetEnv()->GetId()%iters%numIters%t1%t2);
                     continue;
                 }


### PR DESCRIPTION
Or the square will overflow and vVisitedDiscretization.resize() will go wrong way.