### PR TITLE
avoid null in osgviewer

### DIFF
--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -815,14 +815,17 @@ void QtOSGViewer::_CreateDockWidgets()
 
 void QtOSGViewer::_OnObjectTreeClick(QTreeWidgetItem* item,int num)
 {
-    RobotBasePtr robot;
     KinBodyPtr kinbody;
     KinBody::LinkPtr link;
 
     std::string mass;
 
-    //  Select robot in Viewers
-    _posgWidget->SelectItemFromName(item->text(0).toAscii().data());
+    //  Select kinbody in Viewers
+    {
+        QTreeWidgetItem* itemKinBody = item;
+        for (;!!itemKinBody->parent();) itemKinBody = itemKinBody->parent();
+        _posgWidget->SelectItemFromName(itemKinBody->text(0).toAscii().data());
+    }
 
     //  Clears details
     if (!!_qdetailsTree) {
@@ -840,8 +843,8 @@ void QtOSGViewer::_OnObjectTreeClick(QTreeWidgetItem* item,int num)
                 _qdetailsTree->setHeaderLabel(item->text(0).toAscii().data());
             }
 
-            robot = GetEnv()->GetRobot(item->parent()->parent()->text(0).toAscii().data());
-            link  = robot->GetLink(item->text(0).toAscii().data());
+            kinbody = GetEnv()->GetKinBody(item->parent()->parent()->text(0).toAscii().data());
+            link  = kinbody->GetLink(item->text(0).toAscii().data());
 
             //  Clears output string
             strs.clear();


### PR DESCRIPTION
On clicking object tree (other than KinBody), KinBodyPtr(NULL)->GetUserData was called.

Already reviewed (briefly) by Binbin.