### PR TITLE
Fix memory leak in Python converter

### DIFF
--- a/python/bindings/convexdecompositionpy.cpp
+++ b/python/bindings/convexdecompositionpy.cpp
@@ -115,7 +115,7 @@ BOOST_PYTHON_MODULE(convexdecompositionpy)
 {
     import_array();
     numeric::array::set_module_and_type("numpy", "ndarray");
-    int_from_int();
+    T_from_number<int>();
     T_from_number<float>();
     T_from_number<double>();
 

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -2138,8 +2138,8 @@ BOOST_PYTHON_MODULE(openravepy_int)
 #endif
     import_array();
     numeric::array::set_module_and_type("numpy", "ndarray");
-    int_from_int();
-    uint8_from_int();
+    T_from_number<int>();
+    T_from_number<uint8_t>();
     T_from_number<float>();
     T_from_number<double>();
     init_python_bindings();

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -961,13 +961,13 @@ public:
         return _probot->SetController(openravepy::GetController(pController),dofindices,1);
     }
 
-    void SetActiveDOFs(object dofindices) {
+    void SetActiveDOFs(const object& dofindices) {
         _probot->SetActiveDOFs(ExtractArray<int>(dofindices));
     }
-    void SetActiveDOFs(object dofindices, int nAffineDOsBitmask) {
+    void SetActiveDOFs(const object& dofindices, int nAffineDOsBitmask) {
         _probot->SetActiveDOFs(ExtractArray<int>(dofindices), nAffineDOsBitmask);
     }
-    void SetActiveDOFs(object dofindices, int nAffineDOsBitmask, object rotationaxis) {
+    void SetActiveDOFs(const object& dofindices, int nAffineDOsBitmask, object rotationaxis) {
         _probot->SetActiveDOFs(ExtractArray<int>(dofindices), nAffineDOsBitmask, ExtractVector3(rotationaxis));
     }
 
@@ -1430,9 +1430,9 @@ void init_openravepy_robot()
     ;
 
     {
-        void (PyRobotBase::*psetactivedofs1)(object) = &PyRobotBase::SetActiveDOFs;
-        void (PyRobotBase::*psetactivedofs2)(object, int) = &PyRobotBase::SetActiveDOFs;
-        void (PyRobotBase::*psetactivedofs3)(object, int, object) = &PyRobotBase::SetActiveDOFs;
+        void (PyRobotBase::*psetactivedofs1)(const object&) = &PyRobotBase::SetActiveDOFs;
+        void (PyRobotBase::*psetactivedofs2)(const object&, int) = &PyRobotBase::SetActiveDOFs;
+        void (PyRobotBase::*psetactivedofs3)(const object&, int, object) = &PyRobotBase::SetActiveDOFs;
 
         bool (PyRobotBase::*pgrab1)(PyKinBodyPtr) = &PyRobotBase::Grab;
         bool (PyRobotBase::*pgrab2)(PyKinBodyPtr,object) = &PyRobotBase::Grab;

--- a/python/bindings/pyann.cpp
+++ b/python/bindings/pyann.cpp
@@ -292,7 +292,7 @@ BOOST_PYTHON_MODULE(pyANN_int)
 {
     import_array();
     numeric::array::set_module_and_type("numpy", "ndarray");
-    int_from_int();
+    T_from_number<int>();
     T_from_number<float>();
     T_from_number<double>();
 


### PR DESCRIPTION
For some reason PyObject* returned by PyNumber_Int and so won't get deleted even when Py_DECREF is called.

https://stackoverflow.com/questions/26595350/extracting-unsigned-char-from-array-of-numpy-uint8