### PR TITLE
PyObjects* returned by PyErr_Fetch have to be decref'd

### DIFF
--- a/python/bindings/bindings.h
+++ b/python/bindings/bindings.h
@@ -345,6 +345,11 @@ inline std::string GetPyErrorString()
             Py_DECREF(string);
         }
     }
+    // Does nothing when the ptr is nullptr
+    Py_DECREF(error);
+    Py_DECREF(value);
+    Py_DECREF(traceback);
+
     return s;
 }
 


### PR DESCRIPTION
From the official documentation:
Retrieve the error indicator into three variables whose addresses are passed. If the error indicator is not set, set all three variables to NULL. If it is set, it will be cleared and you own a reference to each object retrieved. The value and traceback object may be NULL even when the type object is not.