### PR TITLE
Round linkstatistics

### DIFF
--- a/python/databases/linkstatistics.py
+++ b/python/databases/linkstatistics.py
@@ -241,7 +241,7 @@ class LinkStatisticsModel(DatabaseGenerator):
                     newsphereradius = max(newsphereradius, linalg.norm(newspherepos - childpos) + childradius)
 
             # go through all the spheres and get the max radius
-            jointspheres[j.GetJointIndex()] = (newspherepos, newsphereradius)
+            jointspheres[j.GetJointIndex()] = (numpy.around(newspherepos, 8), numpy.around(newsphereradius, 8))
         return jointspheres
     
     def show(self,options=None):


### PR DESCRIPTION
there are some dae files (A and B) that are slightly different. They are similar enough to generate same kinematics geometry hash due to rounding at precision of 4 digits, but different enough to generate slightly different joint spheres.

This led me to an issue that planning result differed on two computers. Basically model A was first used before model B on computer 1 and model B was used before model A on computer 1. Then, two computer generated different link statistics file for same kinematics geometry hash. Later, using computer 2, I couldn't reproduce a problem happened on computer 1 for same program for model A.

This is caused by kinematics geometry hash being rounded while link statics is not. I'd like to make this more repeatable and predictable by rounding link statistics just like kinematics geometry hash so that same kinematics geometry hash always means same link statistics.

I can give you an example of such two dae's if interested.