### PR TITLE
Python converter that works with sympy types

### DIFF
--- a/python/bindings/bindings.h
+++ b/python/bindings/bindings.h
@@ -282,52 +282,48 @@ struct exception_translator
 //
 //boost::python::register_ptr_to_python< boost::shared_ptr<const my_class> >();
 
-// https://stackoverflow.com/questions/26595350/extracting-unsigned-char-from-array-of-numpy-uint8
 template<typename T>
-struct T_from_number
+struct float_from_number
 {
-    T_from_number()
+    float_from_number()
     {
         converter::registry::push_back(&convertible, &construct, type_id<T>());
     }
 
     static void* convertible( PyObject* obj)
     {
-        return (PyArray_IsScalar(obj, Float32) ||
-                PyArray_IsScalar(obj, Float64) ||
-                PyArray_IsScalar(obj, Int8)    ||
-                PyArray_IsScalar(obj, Int16)   ||
-                PyArray_IsScalar(obj, Int32)   ||
-                PyArray_IsScalar(obj, Int64)   ||
-                PyArray_IsScalar(obj, UInt8)   ||
-                PyArray_IsScalar(obj, UInt16)  ||
-                PyArray_IsScalar(obj, UInt32)  ||
-                PyArray_IsScalar(obj, UInt64)) ? obj : NULL;
+        return PyNumber_Check(obj) ? obj : NULL;
     }
 
     static void construct(PyObject* _obj, converter::rvalue_from_python_stage1_data* data)
     {
+        PyObject* tmp = PyNumber_Float(_obj);
         T* storage = (T*)((converter::rvalue_from_python_storage<T>*)data)->storage.bytes;
-        if (PyArray_IsScalar(_obj, Float32))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, Float32));
-        else if (PyArray_IsScalar(_obj, Float64))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, Float64));
-        else if (PyArray_IsScalar(_obj, Int8))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, Int8));
-        else if (PyArray_IsScalar(_obj, Int16))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, Int16));
-        else if (PyArray_IsScalar(_obj, Int32))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, Int32));
-        else if (PyArray_IsScalar(_obj, Int64))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, Int64));
-        else if (PyArray_IsScalar(_obj, UInt8))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, UInt8));
-        else if (PyArray_IsScalar(_obj, UInt16))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, UInt16));
-        else if (PyArray_IsScalar(_obj, UInt32))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, UInt32));
-        else if (PyArray_IsScalar(_obj, UInt64))
-            *storage = static_cast<T>(PyArrayScalar_VAL(_obj, UInt64));
+        *storage = boost::python::extract<T>(tmp);
+        Py_DECREF(tmp);
+        data->convertible = storage;
+    }
+};
+
+template<typename T>
+struct int_from_number
+{
+    int_from_number()
+    {
+        converter::registry::push_back(&convertible, &construct, type_id<T>());
+    }
+
+    static void* convertible( PyObject* obj)
+    {
+        return PyNumber_Check(obj) ? obj : NULL;
+    }
+
+    static void construct(PyObject* _obj, converter::rvalue_from_python_stage1_data* data)
+    {
+        PyObject* tmp = PyNumber_Long(_obj);
+        T* storage = (T*)((converter::rvalue_from_python_storage<T>*)data)->storage.bytes;
+        *storage = boost::python::extract<T>(tmp);
+        Py_DECREF(tmp);
         data->convertible = storage;
     }
 };

--- a/python/bindings/convexdecompositionpy.cpp
+++ b/python/bindings/convexdecompositionpy.cpp
@@ -115,9 +115,9 @@ BOOST_PYTHON_MODULE(convexdecompositionpy)
 {
     import_array();
     numeric::array::set_module_and_type("numpy", "ndarray");
-    T_from_number<int>();
-    T_from_number<float>();
-    T_from_number<double>();
+    int_from_number<int>();
+    float_from_number<float>();
+    float_from_number<double>();
 
     typedef return_value_policy< copy_const_reference > return_copy_const_ref;
     class_< cdpy_exception >( "_cdpy_exception_" )

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -2138,10 +2138,10 @@ BOOST_PYTHON_MODULE(openravepy_int)
 #endif
     import_array();
     numeric::array::set_module_and_type("numpy", "ndarray");
-    T_from_number<int>();
-    T_from_number<uint8_t>();
-    T_from_number<float>();
-    T_from_number<double>();
+    int_from_number<int>();
+    int_from_number<uint8_t>();
+    float_from_number<float>();
+    float_from_number<double>();
     init_python_bindings();
 
     typedef return_value_policy< copy_const_reference > return_copy_const_ref;

--- a/python/bindings/pyann.cpp
+++ b/python/bindings/pyann.cpp
@@ -292,9 +292,9 @@ BOOST_PYTHON_MODULE(pyANN_int)
 {
     import_array();
     numeric::array::set_module_and_type("numpy", "ndarray");
-    T_from_number<int>();
-    T_from_number<float>();
-    T_from_number<double>();
+    int_from_number<int>();
+    float_from_number<float>();
+    float_from_number<double>();
 
     typedef return_value_policy< copy_const_reference > return_copy_const_ref;
     class_< pyann_exception >( "_pyann_exception_" )


### PR DESCRIPTION
The memory leak is caused by PyNumber_Int, which is deprecated in Python 3. PyNumber_Float and PyNumber_Long are good. They are just like `float(x)` or `long(x)` in Python.