### PR TITLE
fixed boost_assert_failed new build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ if(NOT OPENRAVE_DISABLE_ASSERT_HANDLER)
   add_definitions("-DBOOST_ENABLE_ASSERT_HANDLER") # turns segfault into exception
 endif()
 add_library(boost_assertion_failed STATIC boost_assertion_failed.cpp)
+add_dependencies(boost_assertion_failed interfacehashes_target)
 add_subdirectory(libopenrave)
 add_subdirectory(libopenrave-core)
 


### PR DESCRIPTION
already-installed-environment were not affected.

----

already-installed-envioronment basically mean "dev machines".
we have seen that almost all teamcity builds are failing.