### PR TITLE
Fix memory leak of DAE read

### DIFF
--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -17,6 +17,7 @@
 #include "colladacommon.h"
 #include <boost/algorithm/string.hpp>
 #include <openrave/xmlreaders.h>
+#include <libxml/xmlversion.h>
 
 namespace OpenRAVE
 {
@@ -266,6 +267,16 @@ public:
         }
     }
     virtual ~ColladaReader() {
+        // If GlobalDAE is not resetted, there will be memory leak inside the
+        // Collada library because static daeStringTable in daeStringRef.cpp
+        // will only be cleaned by daeStringRef::releaseStringTable when
+        // the number of DAE instances alive becomes 0.
+        //
+        // There is no simple workaround for libxml2 before 2.9.0. Read
+        // the comments of GetGlobalDAE() in OpenRAVE for more details
+#if LIBXML_VERSION >= 20900
+        SetGlobalDAE(boost::shared_ptr<DAE>());
+#endif
     }
 
     bool InitFromURI(const string& uristr, const AttributesList& atts)


### PR DESCRIPTION
To reproduce the leak without this fix

```py
import openravepy
env = openravepy.Environment(0)
for i in range(10000):
    env.ReadKinBodyURI('test.mujin.dae')
```