### PR TITLE
Use shared_pointer_cast on the ptr returned by shared_from_this

### DIFF
--- a/plugins/basecontrollers/idealcontroller.cpp
+++ b/plugins/basecontrollers/idealcontroller.cpp
@@ -414,10 +414,10 @@ private:
     }
 
     inline boost::shared_ptr<IdealController> shared_controller() {
-        return boost::dynamic_pointer_cast<IdealController>(shared_from_this());
+        return boost::static_pointer_cast<IdealController>(shared_from_this());
     }
     inline boost::shared_ptr<IdealController const> shared_controller_const() const {
-        return boost::dynamic_pointer_cast<IdealController const>(shared_from_this());
+        return boost::static_pointer_cast<IdealController const>(shared_from_this());
     }
     inline boost::weak_ptr<IdealController> weak_controller() {
         return shared_controller();

--- a/plugins/bulletrave/bulletphysics.h
+++ b/plugins/bulletrave/bulletphysics.h
@@ -69,10 +69,10 @@ public:
     };
 
     inline boost::shared_ptr<BulletPhysicsEngine> shared_physics() {
-        return boost::dynamic_pointer_cast<BulletPhysicsEngine>(shared_from_this());
+        return boost::static_pointer_cast<BulletPhysicsEngine>(shared_from_this());
     }
     inline boost::shared_ptr<BulletPhysicsEngine const> shared_physics_const() const {
-        return boost::dynamic_pointer_cast<BulletPhysicsEngine const>(shared_from_this());
+        return boost::static_pointer_cast<BulletPhysicsEngine const>(shared_from_this());
     }
 
 class PhysicsPropertiesXMLReader : public BaseXMLReader

--- a/plugins/dualmanipulation/dualmanipulation.h
+++ b/plugins/dualmanipulation/dualmanipulation.h
@@ -94,10 +94,10 @@ public:
 protected:
 
     inline boost::shared_ptr<DualManipulation> shared_problem() {
-        return boost::dynamic_pointer_cast<DualManipulation>(shared_from_this());
+        return boost::static_pointer_cast<DualManipulation>(shared_from_this());
     }
     inline boost::shared_ptr<DualManipulation const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<DualManipulation const>(shared_from_this());
+        return boost::static_pointer_cast<DualManipulation const>(shared_from_this());
     }
 
     bool SetActiveManip(ostream& sout, istream& sinput)

--- a/plugins/fclrave/fclcollision.h
+++ b/plugins/fclrave/fclcollision.h
@@ -883,7 +883,7 @@ public:
 
 private:
     inline boost::shared_ptr<FCLCollisionChecker> shared_checker() {
-        return boost::dynamic_pointer_cast<FCLCollisionChecker>(shared_from_this());
+        return boost::static_pointer_cast<FCLCollisionChecker>(shared_from_this());
     }
 
     static bool CheckNarrowPhaseCollision(fcl::CollisionObject *o1, fcl::CollisionObject *o2, void *data) {

--- a/plugins/ikfastsolvers/ikfastmodule.cpp
+++ b/plugins/ikfastsolvers/ikfastmodule.cpp
@@ -308,10 +308,10 @@ private:
     };
 
     inline boost::shared_ptr<IkFastModule> shared_problem() {
-        return boost::dynamic_pointer_cast<IkFastModule>(shared_from_this());
+        return boost::static_pointer_cast<IkFastModule>(shared_from_this());
     }
     inline boost::shared_ptr<IkFastModule const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<IkFastModule const>(shared_from_this());
+        return boost::static_pointer_cast<IkFastModule const>(shared_from_this());
     }
 
 public:

--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -84,10 +84,10 @@ for numBacktraceLinksForSelfCollisionWithNonMoving numBacktraceLinksForSelfColli
     }
 
     inline boost::shared_ptr<IkFastSolver<IkReal> > shared_solver() {
-        return boost::dynamic_pointer_cast<IkFastSolver<IkReal> >(shared_from_this());
+        return boost::static_pointer_cast<IkFastSolver<IkReal> >(shared_from_this());
     }
     inline boost::shared_ptr<IkFastSolver<IkReal> const> shared_solver_const() const {
-        return boost::dynamic_pointer_cast<IkFastSolver<IkReal> const>(shared_from_this());
+        return boost::static_pointer_cast<IkFastSolver<IkReal> const>(shared_from_this());
     }
     inline boost::weak_ptr<IkFastSolver<IkReal> > weak_solver() {
         return shared_solver();

--- a/plugins/logging/viewerrecorder.cpp
+++ b/plugins/logging/viewerrecorder.cpp
@@ -81,10 +81,10 @@ static boost::shared_ptr<VideoGlobalState> s_pVideoGlobalState;
 class ViewerRecorder : public ModuleBase
 {
     inline boost::shared_ptr<ViewerRecorder> shared_module() {
-        return boost::dynamic_pointer_cast<ViewerRecorder>(shared_from_this());
+        return boost::static_pointer_cast<ViewerRecorder>(shared_from_this());
     }
     inline boost::shared_ptr<ViewerRecorder const> shared_module_const() const {
-        return boost::dynamic_pointer_cast<ViewerRecorder const>(shared_from_this());
+        return boost::static_pointer_cast<ViewerRecorder const>(shared_from_this());
     }
     struct VideoFrame
     {

--- a/plugins/mobyrave/mobycontroller.h
+++ b/plugins/mobyrave/mobycontroller.h
@@ -793,12 +793,12 @@ private:
 
     inline boost::shared_ptr<MobyController> shared_controller()
     {
-        return boost::dynamic_pointer_cast<MobyController>(shared_from_this());
+        return boost::static_pointer_cast<MobyController>(shared_from_this());
     }
 
     inline boost::shared_ptr<MobyController const> shared_controller_const() const
     {
-        return boost::dynamic_pointer_cast<MobyController const>(shared_from_this());
+        return boost::static_pointer_cast<MobyController const>(shared_from_this());
     }
 
     inline boost::weak_ptr<MobyController> weak_controller()

--- a/plugins/mobyrave/mobyphysics.h
+++ b/plugins/mobyrave/mobyphysics.h
@@ -26,11 +26,11 @@ class MobyPhysics : public PhysicsEngineBase
 {
 
     inline boost::shared_ptr<MobyPhysics> shared_physics() {
-        return boost::dynamic_pointer_cast<MobyPhysics>(shared_from_this());
+        return boost::static_pointer_cast<MobyPhysics>(shared_from_this());
     }
 
     inline boost::shared_ptr<MobyPhysics const> shared_physics_const() const {
-        return boost::dynamic_pointer_cast<MobyPhysics const>(shared_from_this());
+        return boost::static_pointer_cast<MobyPhysics const>(shared_from_this());
     }
 
     class PhysicsPropertiesXMLReader : public BaseXMLReader

--- a/plugins/mobyrave/mobyreplaycontroller.h
+++ b/plugins/mobyrave/mobyreplaycontroller.h
@@ -817,12 +817,12 @@ private:
 
     inline boost::shared_ptr<MobyReplayController> shared_controller()
     {
-        return boost::dynamic_pointer_cast<MobyReplayController>(shared_from_this());
+        return boost::static_pointer_cast<MobyReplayController>(shared_from_this());
     }
 
     inline boost::shared_ptr<MobyReplayController const> shared_controller_const() const
     {
-        return boost::dynamic_pointer_cast<MobyReplayController const>(shared_from_this());
+        return boost::static_pointer_cast<MobyReplayController const>(shared_from_this());
     }
 
     inline boost::weak_ptr<MobyReplayController> weak_controller()

--- a/plugins/oderave/odecollision.h
+++ b/plugins/oderave/odecollision.h
@@ -104,10 +104,10 @@ private:
     };
 
     inline boost::shared_ptr<ODECollisionChecker> shared_checker() {
-        return boost::dynamic_pointer_cast<ODECollisionChecker>(shared_from_this());
+        return boost::static_pointer_cast<ODECollisionChecker>(shared_from_this());
     }
     inline boost::shared_ptr<ODECollisionChecker const> shared_checker_const() const {
-        return boost::dynamic_pointer_cast<ODECollisionChecker const>(shared_from_this());
+        return boost::static_pointer_cast<ODECollisionChecker const>(shared_from_this());
     }
 
 public:

--- a/plugins/oderave/odephysics.h
+++ b/plugins/oderave/odephysics.h
@@ -59,10 +59,10 @@ class ODEPhysicsEngine : public OpenRAVE::PhysicsEngineBase
     }
 
     inline boost::shared_ptr<ODEPhysicsEngine> shared_physics() {
-        return boost::dynamic_pointer_cast<ODEPhysicsEngine>(shared_from_this());
+        return boost::static_pointer_cast<ODEPhysicsEngine>(shared_from_this());
     }
     inline boost::shared_ptr<ODEPhysicsEngine const> shared_physics_const() const {
-        return boost::dynamic_pointer_cast<ODEPhysicsEngine const>(shared_from_this());
+        return boost::static_pointer_cast<ODEPhysicsEngine const>(shared_from_this());
     }
 
     class PhysicsPropertiesXMLReader : public BaseXMLReader

--- a/plugins/qtcoinrave/item.h
+++ b/plugins/qtcoinrave/item.h
@@ -126,7 +126,7 @@ protected:
     };
 
     inline boost::shared_ptr<KinBodyItem> shared_kinbody() {
-        return boost::dynamic_pointer_cast<KinBodyItem>(shared_from_this());
+        return boost::static_pointer_cast<KinBodyItem>(shared_from_this());
     }
     inline boost::weak_ptr<KinBodyItem> weak_kinbody() {
         return shared_kinbody();

--- a/plugins/qtcoinrave/qtcoinviewer.h
+++ b/plugins/qtcoinrave/qtcoinviewer.h
@@ -276,13 +276,13 @@ public:
     };
 
     inline QtCoinViewerPtr shared_viewer() {
-        return boost::dynamic_pointer_cast<QtCoinViewer>(shared_from_this());
+        return boost::static_pointer_cast<QtCoinViewer>(shared_from_this());
     }
     inline QtCoinViewerWeakPtr weak_viewer() {
         return QtCoinViewerWeakPtr(shared_viewer());
     }
     inline QtCoinViewerConstPtr shared_viewer_const() const {
-        return boost::dynamic_pointer_cast<QtCoinViewer const>(shared_from_this());
+        return boost::static_pointer_cast<QtCoinViewer const>(shared_from_this());
     }
 
     static void mousemove_cb(void * userdata, SoEventCallback * node);

--- a/plugins/rmanipulation/basemanipulation.cpp
+++ b/plugins/rmanipulation/basemanipulation.cpp
@@ -131,10 +131,10 @@ Method wraps the WorkspaceTrajectoryTracker planner. For more details on paramet
 protected:
 
     inline boost::shared_ptr<BaseManipulation> shared_problem() {
-        return boost::dynamic_pointer_cast<BaseManipulation>(shared_from_this());
+        return boost::static_pointer_cast<BaseManipulation>(shared_from_this());
     }
     inline boost::shared_ptr<BaseManipulation const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<BaseManipulation const>(shared_from_this());
+        return boost::static_pointer_cast<BaseManipulation const>(shared_from_this());
     }
 
     bool Traj(ostream& sout, istream& sinput)

--- a/plugins/rmanipulation/taskcaging.cpp
+++ b/plugins/rmanipulation/taskcaging.cpp
@@ -744,10 +744,10 @@ private:
     };
 
     inline boost::shared_ptr<TaskCaging> shared_problem() {
-        return boost::dynamic_pointer_cast<TaskCaging>(shared_from_this());
+        return boost::static_pointer_cast<TaskCaging>(shared_from_this());
     }
     inline boost::shared_ptr<TaskCaging const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<TaskCaging const>(shared_from_this());
+        return boost::static_pointer_cast<TaskCaging const>(shared_from_this());
     }
 
 public:

--- a/plugins/rmanipulation/taskmanipulation.cpp
+++ b/plugins/rmanipulation/taskmanipulation.cpp
@@ -1512,10 +1512,10 @@ protected:
 
 protected:
     inline boost::shared_ptr<TaskManipulation> shared_problem() {
-        return boost::dynamic_pointer_cast<TaskManipulation>(shared_from_this());
+        return boost::static_pointer_cast<TaskManipulation>(shared_from_this());
     }
     inline boost::shared_ptr<TaskManipulation const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<TaskManipulation const>(shared_from_this());
+        return boost::static_pointer_cast<TaskManipulation const>(shared_from_this());
     }
 
     /// \brief grasps using the list of grasp goals. Removes all the goals that the planner planned with

--- a/plugins/rmanipulation/visualfeedback.cpp
+++ b/plugins/rmanipulation/visualfeedback.cpp
@@ -137,10 +137,10 @@ class VisualFeedback : public ModuleBase
 {
 public:
     inline boost::shared_ptr<VisualFeedback> shared_problem() {
-        return boost::dynamic_pointer_cast<VisualFeedback>(shared_from_this());
+        return boost::static_pointer_cast<VisualFeedback>(shared_from_this());
     }
     inline boost::shared_ptr<VisualFeedback const> shared_problem_const() const {
-        return boost::dynamic_pointer_cast<VisualFeedback const>(shared_from_this());
+        return boost::static_pointer_cast<VisualFeedback const>(shared_from_this());
     }
     friend class VisibilityConstraintFunction;
 

--- a/plugins/rplanners/rrt.h
+++ b/plugins/rplanners/rrt.h
@@ -256,10 +256,10 @@ protected:
     std::vector< NodeBase* > _vecInitialNodes;
 
     inline boost::shared_ptr<RrtPlanner> shared_planner() {
-        return boost::dynamic_pointer_cast<RrtPlanner>(shared_from_this());
+        return boost::static_pointer_cast<RrtPlanner>(shared_from_this());
     }
     inline boost::shared_ptr<RrtPlanner const> shared_planner_const() const {
-        return boost::dynamic_pointer_cast<RrtPlanner const>(shared_from_this());
+        return boost::static_pointer_cast<RrtPlanner const>(shared_from_this());
     }
 };
 

--- a/plugins/textserver/textserver.h
+++ b/plugins/textserver/textserver.h
@@ -472,10 +472,10 @@ public:
 private:
 
     inline boost::shared_ptr<SimpleTextServer> shared_server() {
-        return boost::dynamic_pointer_cast<SimpleTextServer>(shared_from_this());
+        return boost::static_pointer_cast<SimpleTextServer>(shared_from_this());
     }
     inline boost::shared_ptr<SimpleTextServer const> shared_server_const() const {
-        return boost::dynamic_pointer_cast<SimpleTextServer const>(shared_from_this());
+        return boost::static_pointer_cast<SimpleTextServer const>(shared_from_this());
     }
 
     // called from threads other than the main worker to wait until

--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -831,7 +831,7 @@ public:
     virtual UserDataPtr RegisterBodyCallback(const BodyCallbackFn& callback)
     {
         boost::timed_mutex::scoped_lock lock(_mutexInterfaces);
-        BodyCallbackDataPtr pdata(new BodyCallbackData(callback,boost::dynamic_pointer_cast<Environment>(shared_from_this())));
+        BodyCallbackDataPtr pdata(new BodyCallbackData(callback,boost::static_pointer_cast<Environment>(shared_from_this())));
         pdata->_iterator = _listRegisteredBodyCallbacks.insert(_listRegisteredBodyCallbacks.end(),pdata);
         return pdata;
     }
@@ -903,7 +903,7 @@ public:
     virtual UserDataPtr RegisterCollisionCallback(const CollisionCallbackFn& callback)
     {
         boost::timed_mutex::scoped_lock lock(_mutexInterfaces);
-        CollisionCallbackDataPtr pdata(new CollisionCallbackData(callback,boost::dynamic_pointer_cast<Environment>(shared_from_this())));
+        CollisionCallbackDataPtr pdata(new CollisionCallbackData(callback,boost::static_pointer_cast<Environment>(shared_from_this())));
         pdata->_iterator = _listRegisteredCollisionCallbacks.insert(_listRegisteredCollisionCallbacks.end(),pdata);
         return pdata;
     }


### PR DESCRIPTION
dynamic_pointer_cast is not needed when you know for sure the pointer is of the desired type.