### PR TITLE
Add if-guard for newly added JSON command

### DIFF
--- a/include/openrave/interface.h
+++ b/include/openrave/interface.h
@@ -131,8 +131,12 @@ public:
     /// \brief return true if the command is supported
     virtual bool SupportsCommand(const std::string& cmd);
 
+#if OPENRAVE_RAPIDJSON
+
     /// \brief return true if the command is supported
     virtual bool SupportsJSONCommand(const std::string& cmd);
+
+#endif // OPENRAVE_RAPIDJSON
 
     /** \brief Used to send special commands to the interface and receive output.
 


### PR DESCRIPTION
Link step crashes if rapidjson is not found. This is a follow-up of https://github.com/rdiankov/openrave/commit/2bcc051254e2a76340db39bad56839fd77139a3f.