### PR TITLE
Add missing header, fix unresolved 'slice'

### DIFF
--- a/python/bindings/openravepy_trajectory.cpp
+++ b/python/bindings/openravepy_trajectory.cpp
@@ -17,6 +17,8 @@
 #define NO_IMPORT_ARRAY
 #include "openravepy_int.h"
 
+#include <boost/python/slice.hpp> // slice objects
+
 namespace openravepy {
 
 class PyTrajectoryBase : public PyInterfaceBase


### PR DESCRIPTION
Getting a *‘slice’ has not been declared* error since https://github.com/rdiankov/openrave/commit/849abeace83aa91d450c3d51f9c2bbe53b238c5b (Ubuntu Xenial). Docs: https://www.boost.org/doc/libs/1_34_0/libs/python/doc/v2/slice.html.