### PR TITLE
Consume SampleInfo::itnode as a non-const iterator

### DIFF
--- a/plugins/rplanners/linearsmoother.cpp
+++ b/plugins/rplanners/linearsmoother.cpp
@@ -769,21 +769,21 @@ protected:
     {
         SampleInfo() : fabsnodedist(0), fdeltadist(0), inode(0) {
         }
-        SampleInfo(std::list< vector<dReal> >::const_iterator itnode, const vector<dReal>& vsample, dReal fabsnodedist, dReal fdeltadist, int inode) : itnode(itnode), vsample(vsample), fabsnodedist(fabsnodedist), fdeltadist(fdeltadist), inode(inode) {
+        SampleInfo(std::list< vector<dReal> >::iterator itnode, const vector<dReal>& vsample, dReal fabsnodedist, dReal fdeltadist, int inode) : itnode(itnode), vsample(vsample), fabsnodedist(fabsnodedist), fdeltadist(fdeltadist), inode(inode) {
         }
-        std::list< vector<dReal> >::const_iterator itnode;
+        std::list< vector<dReal> >::iterator itnode;
         vector<dReal> vsample; /// the interpolated data
         dReal fabsnodedist; // absolute distance of itnode
         dReal fdeltadist; // the delta distance between itnode and itnode+1
         int inode; /// index of the node from listpath.begin()
     };
 
-    SampleInfo _SampleBasedOnVelocity(const list< vector<dReal> >& listpath, dReal fsearchdist)
+    SampleInfo _SampleBasedOnVelocity(list< vector<dReal> >& listpath, dReal fsearchdist)
     {
         int inode = 0;
         dReal fcurdist = 0;
-        list< vector<dReal> >::const_iterator itprev = listpath.begin();
-        list< vector<dReal> >::const_iterator it = itprev; ++it;
+        list< vector<dReal> >::iterator itprev = listpath.begin();
+        list< vector<dReal> >::iterator it = itprev; ++it;
         while(it != listpath.end() ) {
             dReal fdeltadist = _ComputeExpectedVelocity(*itprev, *it);
             if( fsearchdist >= fcurdist && fsearchdist < fcurdist+fdeltadist ) {


### PR DESCRIPTION
Solves #631. All this boils down to avoiding a compile error in:

https://github.com/rdiankov/openrave/blob/737c4b1bbeb4d32f8aef1bf3a027eedb93854c26/plugins/rplanners/linearsmoother.cpp#L1211

Here, [`std::list::erase`](https://en.cppreference.com/w/cpp/container/list/erase) accepts a `const_iterator` and an `iterator` as first and second arguments, respectively. In C++11, this code would be OK due to an implicit cast from `iterator` to `const_iterator`. In this patch, `SampleInfo::itnode` is turned into a non-const `iterator`; some function internals and signatures have been updated accordingly.