### PR TITLE
Clamp acos in GetIkParameterization

### DIFF
--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -172,20 +172,20 @@ dReal RaveLog10(dReal f) {
 #endif
 #ifdef LIBM_ACOS_ACCURATE
 dReal RaveAcos(dReal f) {
-    return acos(utils::ClampOnRange(f,-1.0,1.0));
+    return acos(f);
 }
 #else
 dReal RaveAcos(dReal f) {
-    return acos_rn(utils::ClampOnRange(f,-1.0,1.0));
+    return acos_rn(f);
 }
 #endif
 #ifdef LIBM_ASIN_ACCURATE
 dReal RaveAsin(dReal f) {
-    return asin(utils::ClampOnRange(f,-1.0,1.0));
+    return asin(f);
 }
 #else
 dReal RaveAsin(dReal f) {
-    return asin_rn(utils::ClampOnRange(f,-1.0,1.0));
+    return asin_rn(f);
 }
 #endif
 #ifdef LIBM_ATAN2_ACCURATE
@@ -278,10 +278,10 @@ dReal RaveLog10(dReal f) {
     return log10f(f);
 }
 dReal RaveAcos(dReal f) {
-    return acosf(utils::ClampOnRange(f,-1.0,1.0));
+    return acosf(f);
 }
 dReal RaveAsin(dReal f) {
-    return asinf(utils::ClampOnRange(f,-1.0,1.0));
+    return asinf(f);
 }
 dReal RaveAtan2(dReal fy, dReal fx) {
     return atan2f(fy,fx);
@@ -327,10 +327,10 @@ dReal RaveLog10(dReal f) {
     return log10(f);
 }
 dReal RaveAcos(dReal f) {
-    return acos(utils::ClampOnRange(f,-1.0,1.0));
+    return acos(f);
 }
 dReal RaveAsin(dReal f) {
-    return asin(utils::ClampOnRange(f,-1.0,1.0));
+    return asin(f);
 }
 dReal RaveAtan2(dReal fy, dReal fx) {
     return atan2(fy,fx);

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -172,20 +172,20 @@ dReal RaveLog10(dReal f) {
 #endif
 #ifdef LIBM_ACOS_ACCURATE
 dReal RaveAcos(dReal f) {
-    return acos(f);
+    return acos(utils::ClampOnRange(f,-1.0,1.0));
 }
 #else
 dReal RaveAcos(dReal f) {
-    return acos_rn(f);
+    return acos_rn(utils::ClampOnRange(f,-1.0,1.0));
 }
 #endif
 #ifdef LIBM_ASIN_ACCURATE
 dReal RaveAsin(dReal f) {
-    return asin(f);
+    return asin(utils::ClampOnRange(f,-1.0,1.0));
 }
 #else
 dReal RaveAsin(dReal f) {
-    return asin_rn(f);
+    return asin_rn(utils::ClampOnRange(f,-1.0,1.0));
 }
 #endif
 #ifdef LIBM_ATAN2_ACCURATE
@@ -278,10 +278,10 @@ dReal RaveLog10(dReal f) {
     return log10f(f);
 }
 dReal RaveAcos(dReal f) {
-    return acosf(f);
+    return acosf(utils::ClampOnRange(f,-1.0,1.0));
 }
 dReal RaveAsin(dReal f) {
-    return asinf(f);
+    return asinf(utils::ClampOnRange(f,-1.0,1.0));
 }
 dReal RaveAtan2(dReal fy, dReal fx) {
     return atan2f(fy,fx);
@@ -327,10 +327,10 @@ dReal RaveLog10(dReal f) {
     return log10(f);
 }
 dReal RaveAcos(dReal f) {
-    return acos(f);
+    return acos(utils::ClampOnRange(f,-1.0,1.0));
 }
 dReal RaveAsin(dReal f) {
-    return asin(f);
+    return asin(utils::ClampOnRange(f,-1.0,1.0));
 }
 dReal RaveAtan2(dReal fy, dReal fx) {
     return atan2(fy,fx);

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -322,11 +322,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(IkParameterizat
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationXAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.x)));
+            ikp.SetTranslationXAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.x,-1.0,1.0)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationXAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.x)));
+            ikp.SetTranslationXAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.x,-1.0,1.0)));
         }
         break;
     }
@@ -334,11 +334,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(IkParameterizat
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationYAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.y)));
+            ikp.SetTranslationYAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.y,-1.0,1.0)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationYAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.y)));
+            ikp.SetTranslationYAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.y,-1.0,1.0)));
         }
         break;
     }
@@ -346,11 +346,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(IkParameterizat
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationZAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.z)));
+            ikp.SetTranslationZAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.z,-1.0,1.0)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationZAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.z)));
+            ikp.SetTranslationZAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.z,-1.0,1.0)));
         }
         break;
     }
@@ -464,15 +464,15 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(const IkParamet
         ikp.SetTranslationLocalGlobal6D(localtrans,t * localtrans);
         break;
     }
-     case IKP_TranslationXAxisAngle4D: {
+    case IKP_TranslationXAxisAngle4D: {
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationXAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.x)));
+            ikp.SetTranslationXAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.x,-1.0,1.0)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationXAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.x)));
+            ikp.SetTranslationXAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.x,-1.0,1.0)));
         }
         break;
     }
@@ -480,11 +480,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(const IkParamet
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationYAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.y)));
+            ikp.SetTranslationYAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.y,-1.0,1.0)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationYAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.y)));
+            ikp.SetTranslationYAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.y,-1.0,1.0)));
         }
         break;
     }
@@ -492,11 +492,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(const IkParamet
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationZAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.z)));
+            ikp.SetTranslationZAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.z,-1.0,1.0)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationZAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.z)));
+            ikp.SetTranslationZAxisAngle4D(t.trans,RaveAcos(OpenRAVE::utils::ClampOnRange(vlocaldirection.z,-1.0,1.0)));
         }
         break;
     }

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -322,11 +322,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(IkParameterizat
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationXAxisAngle4D(t.trans,RaveAcos(vlocaldirection.x));
+            ikp.SetTranslationXAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.x)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationXAxisAngle4D(t.trans,RaveAcos(vlocaldirection.x));
+            ikp.SetTranslationXAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.x)));
         }
         break;
     }
@@ -334,11 +334,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(IkParameterizat
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationYAxisAngle4D(t.trans,RaveAcos(vlocaldirection.y));
+            ikp.SetTranslationYAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.y)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationYAxisAngle4D(t.trans,RaveAcos(vlocaldirection.y));
+            ikp.SetTranslationYAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.y)));
         }
         break;
     }
@@ -346,11 +346,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(IkParameterizat
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationZAxisAngle4D(t.trans,RaveAcos(vlocaldirection.z));
+            ikp.SetTranslationZAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.z)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationZAxisAngle4D(t.trans,RaveAcos(vlocaldirection.z));
+            ikp.SetTranslationZAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.z)));
         }
         break;
     }
@@ -468,11 +468,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(const IkParamet
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationXAxisAngle4D(t.trans,RaveAcos(vlocaldirection.x));
+            ikp.SetTranslationXAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.x)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationXAxisAngle4D(t.trans,RaveAcos(vlocaldirection.x));
+            ikp.SetTranslationXAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.x)));
         }
         break;
     }
@@ -480,11 +480,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(const IkParamet
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationYAxisAngle4D(t.trans,RaveAcos(vlocaldirection.y));
+            ikp.SetTranslationYAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.y)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationYAxisAngle4D(t.trans,RaveAcos(vlocaldirection.y));
+            ikp.SetTranslationYAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.y)));
         }
         break;
     }
@@ -492,11 +492,11 @@ IkParameterization RobotBase::Manipulator::GetIkParameterization(const IkParamet
         if (inworld) {
             Transform localt = GetBase()->GetTransform().inverse()*t;
             const Vector vlocaldirection = localt.rotate(_info._vdirection);
-            ikp.SetTranslationZAxisAngle4D(t.trans,RaveAcos(vlocaldirection.z));
+            ikp.SetTranslationZAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.z)));
         }
         else {
             const Vector vlocaldirection = t.rotate(_info._vdirection);
-            ikp.SetTranslationZAxisAngle4D(t.trans,RaveAcos(vlocaldirection.z));
+            ikp.SetTranslationZAxisAngle4D(t.trans,OpenRAVE::utils::ClampOnRange(RaveAcos(vlocaldirection.z)));
         }
         break;
     }


### PR DESCRIPTION
For axis angle 4D ik parameterizations, the arccos of a component of a unit vector is used. This component should be constraint between -1 and 1 by definition, but can become over the limits because of a floating point error. This results in RaveAcos returning an invalid value for an otherwise well defined rotation angle. 