### PR TITLE
Fix acceleration checking

### DIFF
--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -479,7 +479,7 @@ public:
                 std::merge(vabstimes.begin(), vabstimes.begin()+trajectory->GetNumWaypoints(), vabstimes.begin()+trajectory->GetNumWaypoints(), vabstimes.end(), vsampletimes.begin());
 
                 // Check if the trajectory has all-linear interpolation
-                const ConfigurationSpecification& trajspec = _parameters->_configurationspecification;
+                ConfigurationSpecification trajspec = trajectory->GetConfigurationSpecification();
                 vector<ConfigurationSpecification::Group>::const_iterator itvaluesgroup = trajspec.FindCompatibleGroup("joint_values", false);
                 vector<ConfigurationSpecification::Group>::const_iterator itvelocitiesgroup = trajspec.FindCompatibleGroup("joint_velocities", false);
                 vector<ConfigurationSpecification::Group>::const_iterator itaccelerationsgroup = trajspec.FindCompatibleGroup("joint_accelerations", false);


### PR DESCRIPTION
- Assigned `_vtempaccelconfig` to `(dq1 - dq0)/timeelapsed` when having the option `IT_AllLinear`
- Modified `VerifyTrajectory` to support the new all-linear interpolation