### PR TITLE
Test for lib ends with .so, because debug symbols are at .so.debug.

### DIFF
--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -681,7 +681,9 @@ protected:
         if (dp != NULL) {
             while ( (ep = readdir (dp)) != NULL ) {
                 // check for a .so in every file
-                if( strstr(ep->d_name, PLUGIN_EXT) != NULL ) {
+                // check that filename ends with .so
+                if( strlen(ep->d_name) >= strlen(PLUGIN_EXT) &&
+                    strcmp(ep->d_name + strlen(ep->d_name) - strlen(PLUGIN_EXT), PLUGIN_EXT) == 0 ) {
                     string strplugin = pdir;
                     strplugin += "/";
                     strplugin += ep->d_name;


### PR DESCRIPTION
Currently, openrave finds any file that contains `.so` anywhere in the filename as loadable plugin, so things like:

- `libxxx.so~`
- `libxxx.so.debug`
- `libxxx.something`

will all be treated as plugin library.

This change makes it check for file that ends with `.so`. This change makes the logic same as that on windows.