### PR TITLE
preload readline

### DIFF
--- a/python/openrave.py.in
+++ b/python/openrave.py.in
@@ -18,6 +18,7 @@ __copyright__ = 'Copyright (C) 2009-2010 Rosen Diankov (rosen.diankov@gmail.com)
 __license__ = 'Apache License, Version 2.0'
 
 import sys,time
+import IPython.utils.rlineimpl # preload readline
 from types import ModuleType
 from numpy import *
 from OpenGL import GL


### PR DESCRIPTION
On rundocker.py envioronment, "ipython with viewer" will crash without this patch.