### PR TITLE
Remove RAPIDJSON_HAS_STDSTRING

### DIFF
--- a/include/openrave/json.h
+++ b/include/openrave/json.h
@@ -116,7 +116,7 @@ inline void RaveSerializeJSON(rapidjson::Value &value, rapidjson::Document::Allo
 /// \brief serialize a std::string as json, these functions are overloaded to allow for templates
 inline void RaveSerializeJSON(rapidjson::Value &value, rapidjson::Document::AllocatorType& allocator, const std::string& v)
 {
-    value = rapidjson::Value().SetString(v, allocator);
+    value = rapidjson::Value().SetString(v.c_str(), allocator);
 }
 
 /// \brief serialize a std::pair as json

--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -96,7 +96,6 @@ namespace OpenRAVE {
 }
 
 #if OPENRAVE_RAPIDJSON
-#define RAPIDJSON_HAS_STDSTRING 1
 #include <rapidjson/document.h>
 #endif
 


### PR DESCRIPTION
Because some projects import rapidjson before openrave and do not have RAPIDJSON_HAS_STDSTRING set.