### PR TITLE
Hotfix compute inner empty volume container

### DIFF
--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -372,7 +372,7 @@ public:
                 return _info._vGeomData;
             }
 
-            /// \brief compute the inner empty volume in the geometry coordinate system
+            /// \brief compute the inner empty volume in the parent link coordinate system
             ///
             /// \return bool true if the geometry has a concept of empty volume nad tInnerEmptyVolume/abInnerEmptyVolume are filled
             virtual bool ComputeInnerEmptyVolume(Transform& tInnerEmptyVolume, Vector& abInnerEmptyExtents) const;

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -350,7 +350,8 @@ bool KinBody::GeometryInfo::ComputeInnerEmptyVolume(Transform& tInnerEmptyVolume
     }
     case GT_Container: {
         Transform tempty;
-        tempty.trans.z = _vGeomData.z*2 + _vGeomData2.z;
+        // full outer extents - full inner extents + inner extents = _vGeomData.z - 0.5*_vGeomData2.z
+        tempty.trans.z = _vGeomData.z - 0.5 * _vGeomData2.z;
         tInnerEmptyVolume = _t*tempty;
         abInnerEmptyExtents = _vGeomData2;
         return true;

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -353,7 +353,7 @@ bool KinBody::GeometryInfo::ComputeInnerEmptyVolume(Transform& tInnerEmptyVolume
         // full outer extents - full inner extents + inner extents = _vGeomData.z - 0.5*_vGeomData2.z
         tempty.trans.z = _vGeomData.z - 0.5 * _vGeomData2.z;
         tInnerEmptyVolume = _t*tempty;
-        abInnerEmptyExtents = _vGeomData2;
+        abInnerEmptyExtents = 0.5*_vGeomData2;
         return true;
     }
     default:


### PR DESCRIPTION
hot fix for GT_Container copmutation of inner empty volume.
Also be noted that `KinBody::GeometryInfo::ComputeInnerEmptyVolume` return transformation in the parent link coordinate. 