### PR TITLE
Fixed external references are searched from root, not curdir

### DIFF
--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -66,10 +66,10 @@ public:
                     // remove first slash because we need relative file
                     std::string docurifull="file:";
                     if( uriNativePath.at(0) == '/' ) {
-                        docurifull += cdom::nativePathToUri(RaveFindLocalFile(uriNativePath.substr(1), "/"));
+                        docurifull += cdom::nativePathToUri(RaveFindLocalFile(uriNativePath.substr(1), ""));
                     }
                     else {
-                        docurifull += cdom::nativePathToUri(RaveFindLocalFile(uriNativePath, "/"));
+                        docurifull += cdom::nativePathToUri(RaveFindLocalFile(uriNativePath, ""));
                     }
                     if( docurifull.size() == 5 ) {
                         RAVELOG_WARN(str(boost::format("daeOpenRAVEURIResolver::resolveElement() - Failed to resolve %s ")%uri.str()));


### PR DESCRIPTION
(detail sent separately)