### PR TITLE
rosen bug fix non-unique external reference id

### DIFF
--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -668,7 +668,7 @@ private:
             iasout->vaxissids.resize(pcolladainfo->_bindingAxesSIDs.size());
             for(size_t idof = 0; idof < pcolladainfo->_bindingAxesSIDs.size(); ++idof) {
                 // there's no way to directly call a setparam on a SIDREF, so have to <bind>
-                std::string sparamref = str(boost::format("ias_extern_param%d")%idof);
+                std::string sparamref = str(boost::format("ias_extern_%s_param%d")%asid%idof);
                 domKinematics_newparamRef param = daeSafeCast<domKinematics_newparam>(ias_external->add(COLLADA_ELEMENT_NEWPARAM));
                 param->setSid(sparamref.c_str());
                 daeSafeCast<domKinematics_newparam::domSIDREF>(param->add(COLLADA_ELEMENT_SIDREF))->setValue(pcolladainfo->_bindingAxesSIDs[idof].kmodelaxissidref.c_str());
@@ -677,7 +677,7 @@ private:
                 if( pbody->IsDOFRevolute(idof) ) {
                     dofvalue *= 180/M_PI;
                 }
-                std::string sparamrefvalue = str(boost::format("ias_extern_param%d_value")%idof);
+                std::string sparamrefvalue = str(boost::format("ias_extern_%s_param%d_value")%asid%idof);
                 domKinematics_newparamRef paramvalue = daeSafeCast<domKinematics_newparam>(ias_external->add(COLLADA_ELEMENT_NEWPARAM));
                 paramvalue->setSid(sparamrefvalue.c_str());
                 paramvalue->add(COLLADA_TYPE_FLOAT)->setCharData(boost::lexical_cast<std::string>(dofvalue));
@@ -698,7 +698,7 @@ private:
             }
             size_t index = pcolladainfo->_bindingAxesSIDs.size();
             FOREACH(itpassive,pcolladainfo->_bindingPassiveAxesSIDs) {
-                std::string sparamref = str(boost::format("ias_extern_param%d")%index);
+                std::string sparamref = str(boost::format("ias_extern_%s_param%d")%asid%index);
                 domKinematics_newparamRef param = daeSafeCast<domKinematics_newparam>(ias_external->add(COLLADA_ELEMENT_NEWPARAM));
                 param->setSid(sparamref.c_str());
                 daeSafeCast<domKinematics_newparam::domSIDREF>(param->add(COLLADA_ELEMENT_SIDREF))->setValue(itpassive->kmodelaxissidref.c_str());


### PR DESCRIPTION
fix for not saving externally referenced object correctly