### PR TITLE
Fix: Initialise external self collision checker on KinBody addition to env

### DIFF
--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -679,6 +679,10 @@ public:
         }
         pbody->_ComputeInternalInformation();
         _pCurrentChecker->InitKinBody(pbody);
+        if( !!pbody->GetSelfCollisionChecker() && pbody->GetSelfCollisionChecker() != _pCurrentChecker ) {
+            // also initialize external collision checker if specified for this body
+            pbody->GetSelfCollisionChecker()->InitKinBody(pbody);
+        }
         _pPhysicsEngine->InitKinBody(pbody);
         // send all the changed callbacks of the body since anything could have changed
         pbody->_PostprocessChangedParameters(0xffffffff&~KinBody::Prop_JointMimic&~KinBody::Prop_LinkStatic&~KinBody::Prop_BodyRemoved);
@@ -715,6 +719,10 @@ public:
         }
         robot->_ComputeInternalInformation(); // have to do this after _vecrobots is added since SensorBase::SetName can call EnvironmentBase::GetSensor to initialize itself
         _pCurrentChecker->InitKinBody(robot);
+        if( !!robot->GetSelfCollisionChecker() && robot->GetSelfCollisionChecker() != _pCurrentChecker ) {
+            // also initialize external collision checker if specified for this body
+            robot->GetSelfCollisionChecker()->InitKinBody(robot);
+        }
         _pPhysicsEngine->InitKinBody(robot);
         // send all the changed callbacks of the body since anything could have changed
         robot->_PostprocessChangedParameters(0xffffffff&~KinBody::Prop_JointMimic&~KinBody::Prop_LinkStatic&~KinBody::Prop_BodyRemoved);


### PR DESCRIPTION
When a KinBody with an external self collision checker (i.e. _selfcollisionchecker is set) is removed from an Environment and re-added to an Environment, the self collision checker encounters an error because the checker is not initialised for the KinBody while the Environment's collision checker is initialised properly.

## How to reproduce

```
externalCollisionChecker = RaveCreateCollisionChecker(env, 'fcl_')
robot.SetSelfCollisionChecker(externalCollisionChecker)
env.Remove(robot)

env.Add(robot)
robot.CheckSelfCollision()
```

## Example output

```
2019-09-18 11:32:14,872 openrave [WARN] [fclspace.h:499 CollisionObjectPtr fclrave::FCLSpace::GetLinkBV] KinBody gp8l_picker is not initialized in fclspace fclcollision0x562f13d64650, env 1
openrave_exception: openrave (Assert): [/usr/include/boost/smart_ptr/shared_ptr.hpp:710] -> typename boost::detail::sp_member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = fclrave::FCLSpace::KinBodyInfo; typename boost::detail::sp_member_access<T>::type = fclrave::FCLSpace::KinBodyInfo*], expr: px != 0
openrave_exception()
```

## Possible solutions

- Initialise external collision checker (KinBody._selfcollisionchecker) along with Environment's collision checker on KinBody addition to an Environment

or

- Reset KinBody._selfcollisionchecker to nullptr on KinBody addition or removal to/from an Environment

This request contains a patch for the former solution.