### PR TITLE
Update _pDummyJointCache properly on cloning of a robot

### DIFF
--- a/src/libopenrave/robotconnectedbody.cpp
+++ b/src/libopenrave/robotconnectedbody.cpp
@@ -79,6 +79,7 @@ RobotBase::ConnectedBody::ConnectedBody(OpenRAVE::RobotBasePtr probot, const Ope
 RobotBase::ConnectedBody::ConnectedBody(OpenRAVE::RobotBasePtr probot, const ConnectedBody &connectedBody, int cloningoptions)
 {
     *this = connectedBody;
+    _pDummyJointCache = probot->GetJoint(_dummyPassiveJointName);
     FOREACH(itinfo, _vResolvedLinkNames) {
         itinfo->second = probot->GetLink(itinfo->first);
     }
@@ -558,6 +559,7 @@ void RobotBase::_DeinitializeConnectedBodiesInformation()
                 vConnectedPassiveJoints[ijointindex] = 1;
             }
         }
+        connectedBody._dummyPassiveJointName.clear();
     }
 
     int iwritelink = 0;


### PR DESCRIPTION
Without this patch a cloned robot's `_pDummyJointCache` points to a link of the original robot instance, which leads to taking over the link from the original robot on `_ComputeConnectedBodiesInformation()` call.

cc @ziyan 
