### PR TITLE
fix undefined name in boost_assertion_failed

### DIFF
--- a/src/boost_assertion_failed.cpp
+++ b/src/boost_assertion_failed.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2018 Rosen Diankov
 #if !defined(OPENRAVE_DISABLE_ASSERT_HANDLER) && (defined(BOOST_ENABLE_ASSERT_HANDLER))
 
+#define BOOST_SYSTEM_NO_DEPRECATED
 #include <openrave/openrave.h>
 #include <boost/format.hpp>
 


### PR DESCRIPTION
libboost_assertion_failed.a has following undefined names:

```
root@ubuntu-xenial:/openrave/python/bindings# nm ../../src/libboost_assertion_failed.a|grep category
                 U _ZN5boost6system15system_categoryEv
                 U _ZN5boost6system16generic_categoryEv
```

We have coped with the situation with specifying Boost_THREAD_LIBRARY in python/bindings/CMakeLists. However, this does not work on Ubuntu as https://wiki.ubuntu.com/ToolChain/CompilerFlags#A-Wl.2C--as-needed .
So we need to resolve those undefined names in source level, or it cannot be link safely in bindings.

I found defining BOOST_SYSTEM_NO_DEPRECATED would solve the issue as https://stackoverflow.com/questions/9723793/undefined-reference-to-boostsystemsystem-category-when-compiling .
I tested the (fixed) behavior with updated version of https://github.com/cielavenir/mujin_recruiting .

\# well, I don't know why I was "working" at home...

#678 