### PR TITLE
partially reverted 57a832ba44fe20f2d8824b6a7207bfd98d077545

### DIFF
--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -4410,7 +4410,7 @@ private:
             daeMetaAttribute* pmeta = elt->getAttributeObject(i);
             buffer.str("");  buffer.clear();
             pmeta->memoryToString(elt, buffer);
-            atts.emplace_back(pmeta->getName(),  buffer.str());
+            atts.emplace_back(string(pmeta->getName()),  buffer.str());
         }
     }
 


### PR DESCRIPTION
daeMetaAttribute::getName returns daeStringRef, which needs to be explicitly converted to daeString(`const char*`).
(I reverted this time, but If I should cast to daeString rather than std::string, please tell me)

I checked the compilation changed from red from green using Debian jessie and Ubuntu xenial.