### PR TITLE
serialize _vGeomData2~4 when geometry type is container or cage

### DIFF
--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -823,6 +823,14 @@ void KinBody::Link::Geometry::serialize(std::ostream& o, int options) const
     }
     else {
         SerializeRound3(o,_info._vGeomData);
+        if( _info._type == GT_Cage ) {
+            SerializeRound3(o,_info._vGeomData2);
+        }
+        else if( _info._type == GT_Container ) {
+            SerializeRound3(o,_info._vGeomData2);
+            SerializeRound3(o,_info._vGeomData3);
+            SerializeRound3(o,_info._vGeomData4);
+        }
     }
 }
 

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -825,6 +825,12 @@ void KinBody::Link::Geometry::serialize(std::ostream& o, int options) const
         SerializeRound3(o,_info._vGeomData);
         if( _info._type == GT_Cage ) {
             SerializeRound3(o,_info._vGeomData2);
+            for (size_t iwall = 0; iwall < _info._vSideWalls.size(); ++iwall) {
+                const GeometryInfo::SideWall &s = _info._vSideWalls[iwall];
+                SerializeRound(o,s.transf);
+                SerializeRound3(o,s.vExtents);
+                o << (uint32_t)s.type;
+            }
         }
         else if( _info._type == GT_Container ) {
             SerializeRound3(o,_info._vGeomData2);


### PR DESCRIPTION
for correct KinematicsGeometryHash for container and cage.  i don't have any real problem with this yet but i've noticed this while investigating the other KinematicsGeometryHash related issue.