### PR TITLE
Increase test ray length for calibration visibility checking

### DIFF
--- a/plugins/rmanipulation/visualfeedback.cpp
+++ b/plugins/rmanipulation/visualfeedback.cpp
@@ -415,7 +415,7 @@ private:
         {
             RAY r;
             dReal filen = 1/RaveSqrt(v.lengthsqr3());
-            r.dir = tcamera.rotate((2.0f*filen)*v);
+            r.dir = tcamera.rotate((200.0f*filen)*v);                     // hardcoded test ray length of 200 meters
             r.pos = tcamera.trans + 0.5f*_vf->_fRayMinDist*r.dir;         // move the rays a little forward
             if( !_vf->_robot->GetEnv()->CheckCollision(r,_report) ) {
                 return true;         // not supposed to happen, but it is OK
@@ -481,7 +481,7 @@ private:
         bool _TestRayRigid(const Vector& v, const TransformMatrix& tcamera, const vector<KinBody::LinkPtr>& vattachedlinks)
         {
             dReal filen = 1/RaveSqrt(v.lengthsqr3());
-            RAY r((_vf->_fRayMinDist*filen)*v,(2.0f*filen)*v);
+            RAY r((_vf->_fRayMinDist*filen)*v,(200.0f*filen)*v);           // hardcoded test ray length of 200 meters
             if( _vf->_robot->GetEnv()->CheckCollision(r,KinBodyConstPtr(_vf->_robot),_report) ) {
                 //RAVELOG_INFO(str(boost::format("ray col: %s\n")%_report->__str__()));
                 return false;


### PR DESCRIPTION
In openrave, the visibility checking done for calibration uses test rays with a hardcoded length of 2 meters. This is why the calibration board used to get occluded when we calibrated using large robots. Although we fixed this in planning common, in openrave this problem still exists. This PR changes the hardcoded length from 2 meters to 200 meters. It's just a quick fix that reduces the likelihood of running into this problem.

This isn't for Mujin, it's for people outside of Mujin who are using openrave for calibration or visibility checking in general. I think this will save them a headache.