### PR TITLE
Add include boost/python/slice when not using pybind11

### DIFF
--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -46,6 +46,7 @@
 #include <boost/python.hpp>
 #include <boost/python/exception_translator.hpp>
 #include <boost/python/docstring_options.hpp>
+#include <boost/python/slice.hpp>
 #endif // USE_PYBIND11_PYTHON_BINDINGS
 #include <pyconfig.h>
 #include <numpy/arrayobject.h>


### PR DESCRIPTION
Fixed compilation error
```
openrave/python/bindings/include/openravepy/openravepy_trajectorybase.h:68:28: error: ‘openravepy::py::slice’ has not been declared
     object __getitem__(py::slice indices) const;
```