### PR TITLE
use Size instead of MemberCount for array elements

### DIFF
--- a/src/libopenrave-core/jsonparser/jsonwriter.cpp
+++ b/src/libopenrave-core/jsonparser/jsonwriter.cpp
@@ -241,10 +241,10 @@ protected:
                 objectsValue.PushBack(objectValue, _doc.GetAllocator());
             }
 
-            if (bodiesValue.MemberCount() > 0) {
+            if (bodiesValue.Size() > 0) {
                 _doc.AddMember("bodies", bodiesValue, _doc.GetAllocator());
             }
-            if (objectsValue.MemberCount() > 0) {
+            if (objectsValue.Size() > 0) {
                 _doc.AddMember("objects", objectsValue, _doc.GetAllocator());
             }
         }


### PR DESCRIPTION
MemberCount seems failed on IsObject test

(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff6d2542a in __GI_abort () at abort.c:89
#2  0x00007ffff6d1ce67 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x7fffe87eeb02 "IsObject()", 
