### PR TITLE
Post command to GUIThread to avoid segfault

### DIFF
--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1146,12 +1146,17 @@ bool QtOSGViewer::_SetItemVisualizationCommand(ostream& sout, istream& sinput)
     std::string itemname, visualizationmode;
     sinput >> itemname >> visualizationmode;
 
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_SetItemVisualization, this, itemname, visualizationmode));
+    return !!sinput;
+}
+
+void QtOSGViewer::_SetItemVisualization(std::string& itemname, std::string& visualizationmode)
+{
     FOREACH(it, _mapbodies) {
         if( it->second->GetName() == itemname ) {
             it->second->SetVisualizationMode(visualizationmode);
         }
     }
-    return !!sinput;
 }
 
 bool QtOSGViewer::_ShowWorldAxesCommand(ostream& sout, istream& sinput)

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -332,7 +332,7 @@ public:
 
     virtual void _SetCamera(RaveTransform<float> trans, float focalDistance);
     virtual void _SetCameraDistanceToFocus(float focalDistance);
-
+    virtual void _SetItemVisualization(std::string& itemname, std::string& visualizationmode);
     virtual void _SetProjectionMode(const std::string& projectionMode);
     virtual void _SetBkgndColor(const RaveVector<float>& color);
 


### PR DESCRIPTION
Fix calling SetItemVisualization from other thread causes segmentation fault

How to reproduce
```py
# open any dae with openrave.py -i
viewer = env.GetViewer()
for i in range(10000):
    viewer.SendCommand('SetItemVisualization %s selected' % 'body1')
    viewer.SendCommand('SetItemVisualization %s' % 'body1')
```