### PR TITLE
assign a new variable when load json value

### DIFF
--- a/include/openrave/openravejson.h
+++ b/include/openrave/openravejson.h
@@ -422,8 +422,8 @@ inline void LoadJsonValue(const rapidjson::Value& v, std::map<std::string, T>& t
         }
     } else if (v.IsObject()) {
         t.clear();
-        T value;
         for (rapidjson::Value::ConstMemberIterator it = v.MemberBegin(); it != v.MemberEnd(); ++it) {
+            T value;
             LoadJsonValue(it->value, value);
             t[it->name.GetString()] = value;
         }


### PR DESCRIPTION
Things like Ikparams' transform can be deserialized with partially setting translation or rotation.  Previous way may keep some old value.