### PR TITLE
Make each OPENRAVE_PLUGINS recognized only once

### DIFF
--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -441,12 +441,16 @@ protected:
         if( pOPENRAVE_PLUGINS != NULL ) {
             utils::TokenizeString(pOPENRAVE_PLUGINS, delim, vplugindirs);
         }
-        for(int i=vplugindirs.size()-1;i>0;i--){
-            int j=0;
-            for(;j<i;j++){
-                if(vplugindirs[i]==vplugindirs[j])break;
+        for(int iplugindir=vplugindirs.size()-1;iplugindir>0;iplugindir--){
+            int jplugindir=0;
+            for(;jplugindir<iplugindir;jplugindir++){
+                if(vplugindirs[iplugindir]==vplugindirs[jplugindir]){
+                    break;
+                }
             }
-            if(j<i)vplugindirs.erase(vplugindirs.begin()+i);
+            if(jplugindir<iplugindir){
+                vplugindirs.erase(vplugindirs.begin()+iplugindir);
+            }
         }
         bool bExists=false;
         string installdir = OPENRAVE_PLUGINS_INSTALL_DIR;

--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -441,6 +441,13 @@ protected:
         if( pOPENRAVE_PLUGINS != NULL ) {
             utils::TokenizeString(pOPENRAVE_PLUGINS, delim, vplugindirs);
         }
+        for(int i=vplugindirs.size()-1;i>0;i--){
+            int j=0;
+            for(;j<i;j++){
+                if(vplugindirs[i]==vplugindirs[j])break;
+            }
+            if(j<i)vplugindirs.erase(vplugindirs.begin()+i);
+        }
         bool bExists=false;
         string installdir = OPENRAVE_PLUGINS_INSTALL_DIR;
 #ifdef HAVE_BOOST_FILESYSTEM


### PR DESCRIPTION
In some cases (mostly due to bad Python code), plugindatabase.h Destroy's `_listplugins.clear()` might not cause destroying plugins. However this does not mean those plugins can be destroyed safely.
Now, what happens when the same entry is written multiple times in OPENRAVE_PLUGINS?
AddDirectory and LoadPlugin is called for multiple times for the same entry.
In LoadPlugin second call, _listplugins are updated and Plugin destructor will be called. **DestroyPlugin() will be called for existing plugin.** Now accessing remaining plugin instances is undefined behavior.

Although `_listplugins.clear()` should always clear plugin instances, we should limit loading each plugins only once.