### PR TITLE
Fix binary trajectory startwith space in command

### DIFF
--- a/python/bindings/openravepy_trajectory.cpp
+++ b/python/bindings/openravepy_trajectory.cpp
@@ -387,7 +387,6 @@ void PyTrajectoryBase::deserialize(const string& s)
 object PyTrajectoryBase::serialize(object options)
 {
     std::stringstream ss;
-    ss.clear();
     ss << std::setprecision(std::numeric_limits<dReal>::digits10+1);
     _ptrajectory->serialize(ss,pyGetIntFromPy(options, 0));
     return py::to_object(ss.str());

--- a/python/bindings/openravepy_trajectory.cpp
+++ b/python/bindings/openravepy_trajectory.cpp
@@ -387,6 +387,7 @@ void PyTrajectoryBase::deserialize(const string& s)
 object PyTrajectoryBase::serialize(object options)
 {
     std::stringstream ss;
+    ss.clear();
     ss << std::setprecision(std::numeric_limits<dReal>::digits10+1);
     _ptrajectory->serialize(ss,pyGetIntFromPy(options, 0));
     return py::to_object(ss.str());

--- a/src/libopenrave-core/generictrajectory.cpp
+++ b/src/libopenrave-core/generictrajectory.cpp
@@ -69,7 +69,12 @@ inline void WriteBinaryVector(std::ostream&f, const std::vector<dReal>& v)
 /* Helper functions for binary trajectory file reading */
 inline bool ReadBinaryUInt16(std::istream& f, uint16_t& value)
 {
-    f.read((char*) &value, sizeof(value));
+    while (f.peek() == ' ') {
+        f.ignore(1);
+    }
+    if (!!f) {
+        f.read((char*) &value, (unsigned int)sizeof(value));
+    }
     return !!f;
 }
 
@@ -477,6 +482,8 @@ public:
         // Check whether binary or XML file
         stringstream::streampos pos = I.tellg();  // Save old position
         uint16_t binaryFileHeader = 0;
+
+
         if( !ReadBinaryUInt16(I, binaryFileHeader) ) {
             throw OPENRAVE_EXCEPTION_FORMAT0(_("cannot read first 2 bytes for deserializing traj, stream might be empty "),ORE_InvalidArguments);
         }

--- a/src/libopenrave-core/generictrajectory.cpp
+++ b/src/libopenrave-core/generictrajectory.cpp
@@ -482,8 +482,6 @@ public:
         // Check whether binary or XML file
         stringstream::streampos pos = I.tellg();  // Save old position
         uint16_t binaryFileHeader = 0;
-
-
         if( !ReadBinaryUInt16(I, binaryFileHeader) ) {
             throw OPENRAVE_EXCEPTION_FORMAT0(_("cannot read first 2 bytes for deserializing traj, stream might be empty "),ORE_InvalidArguments);
         }

--- a/src/libopenrave-core/generictrajectory.cpp
+++ b/src/libopenrave-core/generictrajectory.cpp
@@ -69,12 +69,7 @@ inline void WriteBinaryVector(std::ostream&f, const std::vector<dReal>& v)
 /* Helper functions for binary trajectory file reading */
 inline bool ReadBinaryUInt16(std::istream& f, uint16_t& value)
 {
-    while (f.peek() == ' ') {
-        f.ignore(1);
-    }
-    if (!!f) {
-        f.read((char*) &value, (unsigned int)sizeof(value));
-    }
+    f.read((char*) &value, (unsigned int)sizeof(value));
     return !!f;
 }
 
@@ -481,6 +476,12 @@ public:
     {
         // Check whether binary or XML file
         stringstream::streampos pos = I.tellg();  // Save old position
+
+        // try to remove the leading whitespace
+        while (I.peek() == ' ') {
+            I.ignore(1);
+        }
+
         uint16_t binaryFileHeader = 0;
         if( !ReadBinaryUInt16(I, binaryFileHeader) ) {
             throw OPENRAVE_EXCEPTION_FORMAT0(_("cannot read first 2 bytes for deserializing traj, stream might be empty "),ORE_InvalidArguments);

--- a/src/libopenrave-core/generictrajectory.cpp
+++ b/src/libopenrave-core/generictrajectory.cpp
@@ -69,7 +69,7 @@ inline void WriteBinaryVector(std::ostream&f, const std::vector<dReal>& v)
 /* Helper functions for binary trajectory file reading */
 inline bool ReadBinaryUInt16(std::istream& f, uint16_t& value)
 {
-    f.read((char*) &value, (unsigned int)sizeof(value));
+    f.read((char*) &value, sizeof(value));
     return !!f;
 }
 

--- a/src/libopenrave/trajectory.cpp
+++ b/src/libopenrave/trajectory.cpp
@@ -65,7 +65,7 @@ void TrajectoryBase::deserialize(std::istream& I)
         I.seekg((size_t)pos+ppsize);
     }
     else {
-        throw OPENRAVE_EXCEPTION_FORMAT(_("error, failed to find </trajectory> in [%s]"), buf.str(), ORE_InvalidArguments);
+        throw OPENRAVE_EXCEPTION_FORMAT(_("error, failed to find </trajectory> in %s"), buf.str(), ORE_InvalidArguments);
     }
     xmlreaders::TrajectoryReader readerdata(GetEnv(),shared_trajectory());
     xmlreaders::ParseXMLData(readerdata, pbuf.c_str(), ppsize);

--- a/src/libopenrave/trajectory.cpp
+++ b/src/libopenrave/trajectory.cpp
@@ -65,7 +65,7 @@ void TrajectoryBase::deserialize(std::istream& I)
         I.seekg((size_t)pos+ppsize);
     }
     else {
-        throw OPENRAVE_EXCEPTION_FORMAT(_("error, failed to find </trajectory> in %s"),buf.str(),ORE_InvalidArguments);
+        throw OPENRAVE_EXCEPTION_FORMAT(_("error, failed to find </trajectory> in [%s]"), buf.str(), ORE_InvalidArguments);
     }
     xmlreaders::TrajectoryReader readerdata(GetEnv(),shared_trajectory());
     xmlreaders::ParseXMLData(readerdata, pbuf.c_str(), ppsize);


### PR DESCRIPTION
there is a whitespace when combining binary trajectory with commands, like `worktraj`, which caused deserialization failed.