### PR TITLE
Release all grabbed bodies

### DIFF
--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -2099,6 +2099,7 @@ protected:
             }
         }
 
+        (*it)->ReleaseAllGrabbed();
         if( (*it)->IsRobot() ) {
             vector<RobotBasePtr>::iterator itrobot = std::find(_vecrobots.begin(), _vecrobots.end(), RaveInterfaceCast<RobotBase>(*it));
             if( itrobot != _vecrobots.end() ) {


### PR DESCRIPTION
Release all grabbed bodies when removing a kinbody from environment, otherwise the grabbed bodies can hold references to the removed/invalidated robot