### PR TITLE
Clone _selfcollisionchecker when cloning KinBody

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -4703,6 +4703,21 @@ void KinBody::Clone(InterfaceBaseConstPtr preference, int cloningoptions)
         }
     }
 
+    // Clone self-collision checker
+    _selfcollisionchecker.reset();
+    if( !!r->_selfcollisionchecker ) {
+        _selfcollisionchecker = RaveCreateCollisionChecker(GetEnv(), r->_selfcollisionchecker->GetXMLId());
+        _selfcollisionchecker->SetCollisionOptions(r->_selfcollisionchecker->GetCollisionOptions());
+        _selfcollisionchecker->SetGeometryGroup(r->_selfcollisionchecker->GetGeometryGroup());
+        if( GetEnvironmentId() != 0 ) {
+            // This body has been added to the environment already so can call InitKinBody.
+            _selfcollisionchecker->InitKinBody(shared_kinbody());
+        }
+        else {
+            // InitKinBody will be called when the body is added to the environment.
+        }
+    }
+
     _nUpdateStampId++; // update the stamp instead of copying
 }
 
@@ -4977,7 +4992,7 @@ void KinBody::_InitAndAddJoint(JointPtr pjoint)
             if( !!plink1 ) {
                 break;
             }
-            }
+        }
         if( (*itlink)->_info._name == info._linkname1 ) {
             plink1 = *itlink;
             if( !!plink0 ) {

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -2013,10 +2013,6 @@ void RobotBase::Clone(InterfaceBaseConstPtr preference, int cloningoptions)
 {
     KinBody::Clone(preference,cloningoptions);
     RobotBaseConstPtr r = RaveInterfaceConstCast<RobotBase>(preference);
-    _selfcollisionchecker.reset();
-    if( !!r->_selfcollisionchecker ) {
-        // TODO clone the self collision checker?
-    }
     __hashrobotstructure = r->__hashrobotstructure;
     _vecManipulators.clear();
     _pManipActive.reset();


### PR DESCRIPTION
When cloning KinBody, also clone `_selfcollisionchecker`.