### PR TITLE
fix rapidjson

### DIFF
--- a/include/openrave/openravejson.h
+++ b/include/openrave/openravejson.h
@@ -163,7 +163,7 @@ inline void ParseJson(rapidjson::Document& d, const std::string& str) {
         }
         throw openravejson::OpenRAVEJSONException((boost::format("Json string is invalid (offset %u) %s str=%s")%((unsigned)d.GetErrorOffset())%GetParseError_En(d.GetParseError())%substr).str(), openravejson::ORJE_InvalidArguments);
     }
-    d.Swap(tempDoc);
+    tempDoc.Swap(d);
 }
 
 inline void ParseJson(rapidjson::Document& d, std::istream& is) {
@@ -174,7 +174,7 @@ inline void ParseJson(rapidjson::Document& d, std::istream& is) {
     if (tempDoc.HasParseError()) {
         throw openravejson::OpenRAVEJSONException((boost::format("Json stream is invalid (offset %u) %s")%((unsigned)tempDoc.GetErrorOffset())%GetParseError_En(tempDoc.GetParseError())).str(), openravejson::ORJE_InvalidArguments);
     }
-    d.Swap(tempDoc);
+    tempDoc.Swap(d);
 }
 
 class JsonSerializable {
@@ -872,7 +872,7 @@ inline void SetJsonValueByKey(rapidjson::Document& d, const char* key, const T& 
 {
     rapidjson::Value v;
     SetJsonValueByKey(v, key, t, d.GetAllocator());
-    d.Swap(v);
+    v.Swap(d);
 }
 
 template<class T>
@@ -880,7 +880,7 @@ inline void SetJsonValueByKey(rapidjson::Document& d, const std::string& key, co
 {
     rapidjson::Value v;
     SetJsonValueByKey(v, key.c_str(), t, d.GetAllocator());
-    d.Swap(v);
+    v.Swap(d);
 }
 
 template<class T>

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -24,7 +24,7 @@ void RobotBase::GripperInfo::SerializeJSON(rapidjson::Value &value, rapidjson::D
     value.SetObject();
     if( !!_pdocument ) {
         BOOST_ASSERT(_pdocument->IsObject());
-        value.CopyFrom(*_pdocument, allocator, true);
+        value.CopyFrom(*_pdocument, allocator);
     }
     openravejson::SetJsonValueByKey(value, "id", gripperid, allocator);
     openravejson::SetJsonValueByKey(value, "grippertype", grippertype, allocator);
@@ -39,7 +39,7 @@ void RobotBase::GripperInfo::DeserializeJSON(const rapidjson::Value& value, dRea
 
     // should always create a new _pdocument in case an old one is initialized and copied
     _pdocument.reset(new rapidjson::Document());
-    _pdocument->CopyFrom(value, _pdocument->GetAllocator(), true);
+    _pdocument->CopyFrom(value, _pdocument->GetAllocator());
 }
 
 void RobotBase::AttachedSensorInfo::SerializeJSON(rapidjson::Value &value, rapidjson::Document::AllocatorType& allocator, dReal fUnitScale, int options) const


### PR DESCRIPTION
as discussed in https://github.com/Tencent/rapidjson/issues/1712
the rapisjson versions installed using `apt-get` will face compile error. 
so, to compile without using master version rapidjson, we need some fix.