### PR TITLE
Fix smoother accel scaling

### DIFF
--- a/plugins/rplanners/parabolicsmoother.cpp
+++ b/plugins/rplanners/parabolicsmoother.cpp
@@ -1,5 +1,5 @@
 // -*- coding: utf-8 -*-
-// Copyright (C) 2012-2019 Rosen Diankov <rosen.diankov@gmail.com>
+// Copyright (C) 2012-2020 Rosen Diankov <rosen.diankov@gmail.com>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Lesser General Public License as published by
@@ -2136,7 +2136,8 @@ protected:
                     }
                 }
 
-                size_t islowdowntry = 0;
+                size_t islowdowntry = 0; // counting how many times we slow down vellimits/accellimits in this shortcut iteration
+                size_t islowdowntryduetomanip = 0; // counting how many times we slow down vellimits/accellimits due to tool speed/accel constraints
                 for (islowdowntry = 0; islowdowntry < maxSlowdowns; ++islowdowntry) {
 #ifdef SMOOTHER1_TIMING_DEBUG
                     _nCallsInterpolator += 1;
@@ -2313,55 +2314,59 @@ protected:
                         break;
                     }
                     else if (retcheck.retcode == CFO_CheckTimeBasedConstraints) {
-                        // CFO_CheckTimeBasedConstraints can be returned becasue of two things: torque limit violation and manipulator constraint violation.
+                        // CFO_CheckTimeBasedConstraints can be caused by the following
+                        // - torque limit violation
+                        // - manipulator speed/accel constraint violation
+                        // - joint velocity adjustment done in SegmentFeasible2
                         dReal fOverallTimeMult = 1.0; ///< overall time mult change. use it to estimate the next possible ramp duration so can quick prune this solution
                         nNumTimeBasedConstraintsFailed++;
 
-                        // Modifiy vellimits and accellimits
+                        // Scale down vellimits and/or accellimits based on which constraints are violated.
+                        // In case manip speed is exceeded, only vellimits is scaled down. Otherwise, both vellimits and accellimits are scaled down.
                         if (_bmanipconstraints && !!_manipconstraintchecker) {
                             // Manipulator constraints is enabled. Time-based constraint violation is likely because manipulator constraints.
-                            if (islowdowntry == 0) {
+                            if (islowdowntryduetomanip == 0 && (retcheck.fMaxManipAccel > _parameters->maxmanipaccel || retcheck.fMaxManipSpeed > _parameters->maxmanipspeed)) {
+                                ++islowdowntryduetomanip;
                                 // Try computing estimates of velocity and acceleration first before scaling down
-                                {
-                                    // Use the original GetMaxVelocitiesAccelerations
-                                    if (_parameters->SetStateValues(x0) != 0) {
-                                        RAVELOG_WARN_FORMAT("env=%d, state setting error", GetEnv()->GetId());
-                                        break;
-                                    }
-                                    vellimits2 = vellimits;
-                                    accellimits2 = accellimits;
-                                    _manipconstraintchecker->GetMaxVelocitiesAccelerations(dx0, vellimits, accellimits);
-                                    if (_parameters->SetStateValues(x1) != 0) {
-                                        RAVELOG_WARN_FORMAT("env=%d, state setting error", GetEnv()->GetId());
-                                        break;
-                                    }
-                                    _manipconstraintchecker->GetMaxVelocitiesAccelerations(dx1, vellimits, accellimits);
+                                // Use the original GetMaxVelocitiesAccelerations
+                                if (_parameters->SetStateValues(x0) != 0) {
+                                    RAVELOG_WARN_FORMAT("env=%d, state setting error", GetEnv()->GetId());
+                                    break;
+                                }
+                                vellimits2 = vellimits;
+                                accellimits2 = accellimits;
+                                _manipconstraintchecker->GetMaxVelocitiesAccelerations(dx0, vellimits, accellimits);
+                                if (_parameters->SetStateValues(x1) != 0) {
+                                    RAVELOG_WARN_FORMAT("env=%d, state setting error", GetEnv()->GetId());
+                                    break;
+                                }
+                                _manipconstraintchecker->GetMaxVelocitiesAccelerations(dx1, vellimits, accellimits);
 
-                                    for (size_t j = 0; j < _parameters->_vConfigVelocityLimit.size(); ++j) {
-                                        dReal fminvel = max(RaveFabs(dx0[j]), RaveFabs(dx1[j]));
-                                        if (vellimits[j] < fminvel) {
-                                            vellimits[j] = fminvel;
-                                        }
+                                for (size_t j = 0; j < _parameters->_vConfigVelocityLimit.size(); ++j) {
+                                    dReal fminvel = max(RaveFabs(dx0[j]), RaveFabs(dx1[j]));
+                                    if (vellimits[j] < fminvel) {
+                                        vellimits[j] = fminvel;
+                                    }
 
-                                        dReal fv = vellimits[j]/vellimits2[j];
-                                        if( fOverallTimeMult > fv ) {
-                                            fOverallTimeMult = fv;
-                                        }
-                                        dReal fa = RaveSqrt(accellimits[j]/accellimits2[j]);
-                                        if( fOverallTimeMult > fa ) {
-                                            fOverallTimeMult = fa;
-                                        }
+                                    dReal fv = vellimits[j]/vellimits2[j];
+                                    if( fOverallTimeMult > fv ) {
+                                        fOverallTimeMult = fv;
+                                    }
+                                    dReal fa = RaveSqrt(accellimits[j]/accellimits2[j]);
+                                    if( fOverallTimeMult > fa ) {
+                                        fOverallTimeMult = fa;
                                     }
                                 }
                             }
                             else {
                                 // After computing the new velocity and acceleration limits and it doesn't work, we gradually scale dof velocities/accelerations down.
                                 if (retcheck.fMaxManipAccel > _parameters->maxmanipaccel) {
+                                    ++islowdowntryduetomanip;
                                     dReal faccelmult = retcheck.fTimeBasedSurpassMult*retcheck.fTimeBasedSurpassMult;
                                     fcuraccelmult *= faccelmult;
                                     if (fcuraccelmult < 0.0001) {
 #ifdef SMOOTHER1_PROGRESS_DEBUG
-                                        RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter = %d/%d: fcurACCELmult (%.15e) is too small. continue to the next iteration", GetEnv()->GetId()%iters%numIters%fcuraccelmult);
+                                        RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter = %d/%d: fcuraccelmult (%.15e) is too small. continue to the next iteration", GetEnv()->GetId()%iters%numIters%fcuraccelmult);
 #endif
                                         break;
                                     }
@@ -2385,7 +2390,8 @@ protected:
                                     }
                                     fOverallTimeMult = retcheck.fTimeBasedSurpassMult;
                                 }
-                                else if (retcheck.fMaxManipSpeed > _parameters->maxmanipspeed ) {
+                                else if (retcheck.fMaxManipSpeed > _parameters->maxmanipspeed) {
+                                    ++islowdowntryduetomanip;
                                     // If the velocity limit is violated, we don't scale down dof accelerations
                                     dReal fvelmult = retcheck.fTimeBasedSurpassMult;
                                     fcurvelmult *= fvelmult;
@@ -2403,16 +2409,25 @@ protected:
                                 }
                                 else {
                                     dReal fvelmult = retcheck.fTimeBasedSurpassMult;
+                                    dReal faccelmult = retcheck.fTimeBasedSurpassMult*retcheck.fTimeBasedSurpassMult;
                                     fcurvelmult *= fvelmult;
+                                    fcuraccelmult *= faccelmult;
                                     if (fcurvelmult < 0.01) {
 #ifdef SMOOTHER1_PROGRESS_DEBUG
                                         RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter = %d/%d: fcurvelmult (%.15e) is too small. continue to the next iteration", GetEnv()->GetId()%iters%numIters%fcurvelmult);
 #endif
                                         break;
                                     }
+                                    if (fcuraccelmult < 0.0001) {
+#ifdef SMOOTHER1_PROGRESS_DEBUG
+                                        RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter = %d/%d: faccelmult (%.15e) is too small. continue to the next iteration", GetEnv()->GetId()%iters%numIters%fcuraccelmult);
+#endif
+                                        break;
+                                    }
                                     for (size_t j = 0; j < accellimits.size(); ++j) {
                                         dReal fminvel = max(RaveFabs(dx0[j]), RaveFabs(dx1[j]));
                                         vellimits[j] = max(fminvel, fvelmult * vellimits[j]);
+                                        accellimits[j] *= faccelmult;
                                     }
                                     fOverallTimeMult = retcheck.fTimeBasedSurpassMult;
                                 }
@@ -2434,7 +2449,7 @@ protected:
                             }
                             if (fcuraccelmult < 0.0001) {
 #ifdef SMOOTHER1_PROGRESS_DEBUG
-                                RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter = %d/%d: fcurACCELmult (%.15e) is too small. continue to the next iteration", GetEnv()->GetId()%iters%numIters%fcuraccelmult);
+                                RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter = %d/%d: fcuraccelmult (%.15e) is too small. continue to the next iteration", GetEnv()->GetId()%iters%numIters%fcuraccelmult);
 #endif
                                 break;
                             }
@@ -2624,12 +2639,13 @@ protected:
         dReal tshortcuttotal = 0.000001f*(float)(tshortcutend - tshortcutstart);
 #endif
         if (iters == numIters) {
-            RAVELOG_DEBUG_FORMAT("env=%d, finished at shortcut iter=%d (normal exit), successful=%d, slowdowns=%d, nCutoffIters=%d, endTime: %.15e -> %.15e; diff = %.15e",GetEnv()->GetId()%iters%shortcuts%numslowdowns%originalEndTime%nCutoffIters%endTime%(originalEndTime - endTime));
+            RAVELOG_DEBUG_FORMAT("env=%d, finished at shortcut iter=%d (normal exit), successful=%d, slowdowns=%d, nCutoffIters=%d, endTime: %.15e -> %.15e; diff = %.15e",GetEnv()->GetId()%iters%shortcuts%numslowdowns%nCutoffIters%originalEndTime%endTime%(originalEndTime - endTime));
         }
         else if (score/currentBestScore < cutoffRatio) {
             RAVELOG_DEBUG_FORMAT("env=%d, finished at shortcut iter=%d (current score %.15e falls below %.15e), successful=%d, slowdowns=%d, nCutoffIters=%d, endTime: %.15e -> %.15e; diff = %.15e",GetEnv()->GetId()%iters%(score/currentBestScore)%cutoffRatio%shortcuts%numslowdowns%nCutoffIters%originalEndTime%endTime%(originalEndTime - endTime));
         }
-        else if (nItersFromPrevSuccessful > nCutoffIters) {
+        else {
+            // terminating reason: nItersFromPrevSuccessful + nNumTimeBasedConstraintsFailed > nCutoffIters
             RAVELOG_DEBUG_FORMAT("env=%d, finished at shortcut iter=%d (did not make progress in the last %d iterations), successful=%d, slowdowns=%d, nCutoffIters=%d, endTime: %.15e -> %.15e; diff = %.15e",GetEnv()->GetId()%iters%nCutoffIters%shortcuts%numslowdowns%nCutoffIters%originalEndTime%endTime%(originalEndTime - endTime));
         }
 

--- a/plugins/rplanners/parabolicsmoother2.cpp
+++ b/plugins/rplanners/parabolicsmoother2.cpp
@@ -1,5 +1,5 @@
 // -*- coding: utf-8 -*-
-// Copyright (C) 2016-2019 Puttichai Lertkultanon & Rosen DianKov
+// Copyright (C) 2016-2020 Puttichai Lertkultanon & Rosen DianKov
 //
 // This program is free software: you can redistribute it and/or modify it under the terms of the
 // GNU Lesser General Public License as published by the Free Software Foundation, either version 3
@@ -2033,10 +2033,14 @@ protected:
                         break;
                     }
                     else if( retcheck.retcode == CFO_CheckTimeBasedConstraints ) {
-                        // CFO_CheckTimeBasedConstraints can be returned because of two things: torque limit violation and manip constraint violation
+                        // CFO_CheckTimeBasedConstraints can be caused by the following
+                        // - torque limit violation
+                        // - manipulator speed/accel constraint violation
+                        // - joint velocity adjustment done in SegmentFeasible2
                         nTimeBasedConstraintsFailed++;
 
-                        // Scale down vellimits and/or accellimits
+                        // Scale down vellimits and/or accellimits based on which constraints are violated.
+                        // In case manip speed is exceeded, only vellimits is scaled down. Otherwise, both vellimits and accellimits are scaled down.
                         if( _bmanipconstraints && _manipconstraintchecker ) {
                             // Scale down vellimits and accellimits independently according to the violated constraint (manipspeed/manipaccel)
                             if( iSlowDown == 0 && !_bUseNewHeuristic ) {
@@ -2648,6 +2652,7 @@ protected:
                 size_t maxSlowDownTries = 100;
                 std::fill(velReductionFactors.begin(), velReductionFactors.end(), 1); // Reset reductionfactors
                 std::fill(accelReductionFactors.begin(), accelReductionFactors.end(), 1); // Reset reductionfactors
+                size_t iSlowDownDueToManip = 0;
                 for (size_t iSlowDown = 0; iSlowDown < maxSlowDownTries; ++iSlowDown) {
 #ifdef SMOOTHER2_TIMING_DEBUG
                     _nCallsInterpolator += 1;
@@ -2872,7 +2877,8 @@ protected:
                         // Scale down vellimits and/or accellimits
                         if( _bmanipconstraints && _manipconstraintchecker ) {
                             // Scale down vellimits and accellimits independently according to the violated constraint (manipspeed/manipaccel)
-                            if( iSlowDown == 0 && !_bUseNewHeuristic ) {
+                            if( iSlowDownDueToManip == 0 && (retcheck.fMaxManipAccel > _parameters->maxmanipaccel || retcheck.fMaxManipSpeed > _parameters->maxmanipspeed) && !_bUseNewHeuristic ) {
+                                ++iSlowDownDueToManip;
                                 // Try computing estimates of vellimits and accellimits before scaling down
 
                                 {// Need to make sure that x0, x1, v0, v1 hold the correct values
@@ -2917,6 +2923,7 @@ protected:
                                 dReal fVelMult, fAccelMult;
                                 bool maxManipSpeedViolated = false, maxManipAccelViolated = false;
                                 if( retcheck.fMaxManipAccel > _parameters->maxmanipaccel ) {
+                                    ++iSlowDownDueToManip;
                                     // Manipaccel is violated. We scale both vellimits and accellimits down.
                                     maxManipAccelViolated = true;
                                     if( _bUseNewHeuristic && retcheck.vReductionFactors.size() > 0 ) {
@@ -2994,6 +3001,7 @@ protected:
                                     }
                                 }
                                 else if( retcheck.fMaxManipSpeed > _parameters->maxmanipspeed ) {
+                                    ++iSlowDownDueToManip;
                                     // Manipspeed is violated. We don't scale down accellimits.
                                     maxManipSpeedViolated = true;
                                     if( _bUseNewHeuristic && retcheck.vReductionFactors.size() > 0 && !(retcheck.fMaxManipAccel > _parameters->maxmanipaccel)) {
@@ -3092,10 +3100,20 @@ protected:
                                     }
                                     else {
                                         fVelMult = retcheck.fTimeBasedSurpassMult;
+                                        fAccelMult = retcheck.fTimeBasedSurpassMult*retcheck.fTimeBasedSurpassMult;
                                         fCurVelMult *= fVelMult;
+                                        fCurAccelMult *= fAccelMult;
                                         if( fCurVelMult < 0.01 ) {
 #ifdef SMOOTHER2_PROGRESS_DEBUG
-                                            RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter=%d/%d: modified ramps exceed vellimits but fCurVelMult is too small (%.15e). continue to the next iteration", _environmentid%iters%numIters%fCurVelMult);
+                                            RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter=%d/%d: modified ramps exceed vellimits/accellimits but fCurVelMult is too small (%.15e). continue to the next iteration", _environmentid%iters%numIters%fCurVelMult);
+                                            ++vShortcutStats[SS_Check2Failed];
+                                            shortcutprogress << SS_Check2Failed << "\n";
+#endif
+                                            break;
+                                        }
+                                        if( fCurAccelMult < 0.0001 ) {
+#ifdef SMOOTHER2_PROGRESS_DEBUG
+                                            RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter=%d/%d: modified ramps exceed vellimits/accellimits but fCurAccelMult is too small (%.15e). continue to the next iteration", _environmentid%iters%numIters%fCurAccelMult);
                                             ++vShortcutStats[SS_Check2Failed];
                                             shortcutprogress << SS_Check2Failed << "\n";
 #endif
@@ -3104,6 +3122,7 @@ protected:
                                         for (size_t j = 0; j < vellimits.size(); ++j) {
                                             dReal fMinVel = max(RaveFabs(v0Vect[j]), RaveFabs(v1Vect[j]));
                                             vellimits[j] = max(fMinVel, fVelMult * vellimits[j]);
+                                            accellimits[j] *= fAccelMult;
                                         }
                                     }
                                 }
@@ -3249,7 +3268,8 @@ protected:
         else if( score*iCurrentBestScore < cutoffRatio ) {
             RAVELOG_DEBUG_FORMAT("env=%d, finished at shortcut iter=%d (current score falls below %.15e), successful=%d, slowdowns=%d, endTime: %.15e -> %.15e; diff = %.15e", _environmentid%iters%cutoffRatio%numShortcuts%numSlowDowns%tOriginal%tTotal%(tOriginal - tTotal));
         }
-        else if( nItersFromPrevSuccessful + nTimeBasedConstraintsFailed > nCutoffIters ) {
+        else {
+            // terminating reason: nItersFromPrevSuccessful + nTimeBasedConstraintsFailed > nCutoffIters
             RAVELOG_DEBUG_FORMAT("env=%d, finished at shortcut iter=%d (did not make progress in the last %d iterations and time-based constraints failed %d times), successful=%d, slowdowns=%d, endTime: %.15e -> %.15e; diff = %.15e", _environmentid%iters%nItersFromPrevSuccessful%nTimeBasedConstraintsFailed%numShortcuts%numSlowDowns%tOriginal%tTotal%(tOriginal - tTotal));
         }
         _DumpParabolicPath(parabolicpath, _dumplevel, fileindex, 1);


### PR DESCRIPTION
When trajectory segment checking fails with `CFO_CheckTimeBasedConstraints` but not because of tool velocity/acceleration violation, previously only velocity limits are scaled down. (This velocity limit scaling was added in commit 2d9336001be576aa87202697ce247c3510b5d82f.)

However, I think acceleration limits should also be scaled down in such cases since the failures can also be due to torque limits violation.