### PR TITLE
SetActiveTrajectory: serialize trajectory in XML form

### DIFF
--- a/plugins/rmanipulation/commonmanipulation.h
+++ b/plugins/rmanipulation/commonmanipulation.h
@@ -373,10 +373,10 @@ protected:
         if( strsavetraj.size() || !!pout ) {
             if( strsavetraj.size() > 0 ) {
                 ofstream f(strsavetraj.c_str());
-                pActiveTraj->serialize(f);
+                pActiveTraj->serialize(f, 0x8000);
             }
             if( !!pout ) {
-                pActiveTraj->serialize(*pout);
+                pActiveTraj->serialize(*pout, 0x8000);
             }
         }
 


### PR DESCRIPTION
otherwise, ChuckGripper() will cause SIGFPE:

```
Thread 9 "python" received signal SIGFPE, Arithmetic exception.
[Switching to Thread 0x7fff8db47700 (LWP 32279)]
0x00007fffc8ebde7c in OpenRAVE::GenericTrajectory::GetNumWaypoints (this=0x7fff8402eea0)
    at /home/mujin/mujin/checkoutroot/openrave/src/libopenrave-core/generictrajectory.cpp:367
367	        return _vtrajdata.size()/_spec.GetDOF();
```