### PR TITLE
Fix: Add c++11 flag to inversekinematics.py

### DIFF
--- a/python/databases/inversekinematics.py
+++ b/python/databases/inversekinematics.py
@@ -1079,6 +1079,7 @@ class InverseKinematicsModel(DatabaseGenerator):
             if compiler.compiler_type == 'unix':
                 compile_flags.append('-O3')
                 compile_flags.append('-fPIC')
+                compile_flags.append('-std=c++11')
         return compiler,compile_flags
     
     @staticmethod


### PR DESCRIPTION
Fix an error that breaks ikfast compilation, due to missing C++11 flag which is required by the array header introduced in 374297b26c6007ad54431df33dc60274d3881874

Reported in #808 