### PR TITLE
Allow `ComputePostureValues` APIs for more convenient studying

### DIFF
--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -20,7 +20,6 @@
 #include <boost/lexical_cast.hpp>
 
 #include <openrave/posturedescriber.h>
-#include "openraveplugindefs.h" // SerializeValues
 
 #ifdef OPENRAVE_HAS_LAPACK
 #include "jacobianinverse.h"
@@ -1458,7 +1457,12 @@ protected:
             }
             else {
                 std::stringstream ss;
-                SerializeValues(ss, vravesol);
+                if(!vravesol.empty()) {
+                    ss << vravesol.at(0);
+                    for(size_t i = 1; i < vravesol.size(); ++i) {
+                        ss << ", " << vravesol.at(i);
+                    }
+                }
                 RAVELOG_ERROR_FORMAT("Cannot compute posture states for vravesol [%s] of size %d; use solutionIndicesNameLocal %s", 
                                      ss.str() % vravesol.size() % solutionIndicesNameLocal);
             }

--- a/plugins/posturedescriber/CMakeLists.txt
+++ b/plugins/posturedescriber/CMakeLists.txt
@@ -2,8 +2,9 @@
 # posture describer openrave plugin
 ###################################
 
-set(POSTUREDESCRIBER_CLASS_NAME "posturedescriber")
+set(POSTUREDESCRIBER_CLASS_NAME  "posturedescriber")
 set(POSTUREDESCRIBER_MODULE_NAME "posturedescriber")
+set(POSTUREDESCRIBER_STATE_NAME  "posturestates"   )
 
 configure_file(plugindefs.h.in
 			   "${CMAKE_CURRENT_SOURCE_DIR}/plugindefs.h"

--- a/plugins/posturedescriber/plugindefs.h.in
+++ b/plugins/posturedescriber/plugindefs.h.in
@@ -19,5 +19,6 @@
 
 #define POSTUREDESCRIBER_CLASS_NAME   "@POSTUREDESCRIBER_CLASS_NAME@"  // PostureDescriber
 #define POSTUREDESCRIBER_MODULE_NAME  "@POSTUREDESCRIBER_MODULE_NAME@" // PostureDescriberModule
+#define POSTUREDESCRIBER_STATE_NAME   "@POSTUREDESCRIBER_STATE_NAME@"  // key in std::map<std::string, std::vector<dReal> > IkReturn::_mapdata
 
 #endif // PLUGINS_POSTUREDESCRIBER_PLUGINDEFS_H

--- a/plugins/posturedescriber/posturedescriberinterface.cpp
+++ b/plugins/posturedescriber/posturedescriberinterface.cpp
@@ -53,6 +53,10 @@ PostureDescriber::PostureDescriber(const EnvironmentBasePtr& penv,
                           boost::bind(&PostureDescriber::_GetSupportTypeCommand, this, _1, _2),
                           "Gets the robot posture support type");
 
+    this->RegisterCommand("ComputePostureValues",
+                          boost::bind(&PostureDescriber::_ComputePostureValuesCommand, this, _1, _2),
+                          "Compute the posture values for all features");
+
     // `SendJSONCommand` APIs
     this->RegisterJSONCommand("Interpret",
                               boost::bind(&PostureDescriber::_InterpretJSONCommand, this, _1, _2, _3),
@@ -435,6 +439,16 @@ bool PostureDescriber::_GetArmIndicesCommand(std::ostream& ssout, std::istream& 
 bool PostureDescriber::_GetSupportTypeCommand(std::ostream& ssout, std::istream& ssin) const {
     ssout << static_cast<int>(_supporttype);
     return _supporttype != RobotPostureSupportType::RPST_NoSupport;
+}
+
+bool PostureDescriber::_ComputePostureValuesCommand(std::ostream& ssout, std::istream& ssin) const {
+    if(!_posturefn) {
+        RAVELOG_WARN("No supported posture describer; _posturefn is not set");
+        return false;
+    }
+    _posturefn(_joints, _fTol, _posturevalues, _featurestates, _posturestates); // compute using all cached variables
+    SerializeValues(ssout, _posturevalues);
+    return !_posturestates.empty();
 }
 
 bool PostureDescriber::_InterpretJSONCommand(const rapidjson::Value& input,

--- a/plugins/posturedescriber/posturedescriberinterface.cpp
+++ b/plugins/posturedescriber/posturedescriberinterface.cpp
@@ -17,7 +17,6 @@
 #include <openrave/openrave.h>
 #include <openrave/openravejson.h> // openravejson
 #include "posturedescriberinterface.h" // PostureDescriber
-#include "plugindefs.h" // POSTUREDESCRIBER_CLASS_NAME
 #include "openraveplugindefs.h" // SerializeValues
 
 // #define POSTUREDESCRIBER_DEBUG
@@ -245,10 +244,10 @@ void ComputePostureStates6RGeneral(const std::vector<JointPtr>& joints,
     const Vector anchor0 = joints[0]->GetAnchor();
     const Vector anchor1 = joints[1]->GetAnchor();
     const Vector anchor2 = joints[2]->GetAnchor();
-    const Vector anchor4 = joints[4]->GetAnchor();
-
-    // project anchor2 onto axis3, and move along axis3 by one unit
-
+    const Vector anchor3 = joints[3]->GetAnchor();
+    // instead of using J5's anchor (anchor4) directly, we project it onto J4's axis (axis3)
+    const Vector anchor4 = anchor3 + (joints[4]->GetAnchor() - anchor3).dot(axis3) * axis3;
+    
     posturevalues.at(0) = axis0.cross(axis1).dot(anchor4-anchor0);           ///< shoulder: {{0, -1}, {1, -1}, {0,  4}}
     posturevalues.at(1) = axis1.cross(anchor2-anchor1).dot(anchor4-anchor2); ///<    elbow: {{1, -1}, {1,  2}, {2,  4}}
     posturevalues.at(2) = axis3.cross(axis4).dot(axis5);                     ///<    wrist: {{3, -1}, {4, -1}, {5, -1}}

--- a/plugins/posturedescriber/posturedescriberinterface.cpp
+++ b/plugins/posturedescriber/posturedescriberinterface.cpp
@@ -405,7 +405,7 @@ bool PostureDescriber::SetPostureValueThreshold(double fTol) {
 }
 
 std::string PostureDescriber::GetMapDataKey() const {
-    return std::string(POSTUREDESCRIBER_CLASS_NAME);
+    return _posturestatename;
 }
 
 const LinkPair& PostureDescriber::GetEssentialKinematicsChain() const {

--- a/plugins/posturedescriber/posturedescriberinterface.cpp
+++ b/plugins/posturedescriber/posturedescriberinterface.cpp
@@ -249,8 +249,6 @@ void ComputePostureStates6RGeneral(const std::vector<JointPtr>& joints,
 
     // project anchor2 onto axis3, and move along axis3 by one unit
 
-    posturevalues.resize(3);
-    featurestates.resize(3);
     posturevalues.at(0) = axis0.cross(axis1).dot(anchor4-anchor0);           ///< shoulder: {{0, -1}, {1, -1}, {0,  4}}
     posturevalues.at(1) = axis1.cross(anchor2-anchor1).dot(anchor4-anchor2); ///<    elbow: {{1, -1}, {1,  2}, {2,  4}}
     posturevalues.at(2) = axis3.cross(axis4).dot(axis5);                     ///<    wrist: {{3, -1}, {4, -1}, {5, -1}}
@@ -269,8 +267,6 @@ void ComputePostureStates4RTypeA(const std::vector<JointPtr>& joints,
     const Vector anchor2 = joints[2]->GetAnchor();
     const Vector anchor3 = joints[3]->GetAnchor();
 
-    posturevalues.resize(2);
-    featurestates.resize(2);
     posturevalues.at(0) = axis0.cross(axis1).dot(anchor3-anchor1);           ///< shoulder: {{0, -1}, {1, -1}, {1, 3}}
     posturevalues.at(1) = axis1.cross(anchor2-anchor1).dot(anchor3-anchor2); ///<    elbow: {{1, -1}, {1,  2}, {2, 3}}
     ComputeRobotPostureStates(fTol, posturestates, featurestates, posturevalues);
@@ -287,8 +283,6 @@ void ComputePostureStatesRRRParallel(const std::vector<JointPtr>& joints,
     const Vector anchor1 = joints[1]->GetAnchor();
     const Vector anchor2 = joints[2]->GetAnchor();
 
-    posturevalues.resize(1);
-    featurestates.resize(1);
     posturevalues.at(0) = axis0.cross(anchor1-anchor0).dot(anchor2-anchor1); ///< elbow: {{0, -1}, {0, 1}, {1, 2}}
     ComputeRobotPostureStates(fTol, posturevalues, featurestates, posturestates);
 }
@@ -311,14 +305,20 @@ bool PostureDescriber::Init(const LinkPair& kinematicsChain) {
     switch(_supporttype) {
     case RobotPostureSupportType::RPST_6R_General: {
         _posturefn = ComputePostureStates6RGeneral;
+        _posturevalues.resize(3);
+        _featurestates.resize(3);        
         break;
     }
     case RobotPostureSupportType::RPST_4R_Type_A: {
         _posturefn = ComputePostureStates4RTypeA;
+        _posturevalues.resize(2);
+        _featurestates.resize(2);        
         break;
     }
     case RobotPostureSupportType::RPST_RRR_Parallel: {
         _posturefn = ComputePostureStatesRRRParallel;
+        _posturevalues.resize(1);
+        _featurestates.resize(1);
         break;
     }
     default: {

--- a/plugins/posturedescriber/posturedescriberinterface.cpp
+++ b/plugins/posturedescriber/posturedescriberinterface.cpp
@@ -269,7 +269,7 @@ void ComputePostureStates4RTypeA(const std::vector<JointPtr>& joints,
 
     posturevalues.at(0) = axis0.cross(axis1).dot(anchor3-anchor1);           ///< shoulder: {{0, -1}, {1, -1}, {1, 3}}
     posturevalues.at(1) = axis1.cross(anchor2-anchor1).dot(anchor3-anchor2); ///<    elbow: {{1, -1}, {1,  2}, {2, 3}}
-    ComputeRobotPostureStates(fTol, posturestates, featurestates, posturevalues);
+    ComputeRobotPostureStates(fTol, posturevalues, featurestates, posturestates);
 }
 
 void ComputePostureStatesRRRParallel(const std::vector<JointPtr>& joints,
@@ -441,7 +441,7 @@ bool PostureDescriber::_GetSupportTypeCommand(std::ostream& ssout, std::istream&
     return _supporttype != RobotPostureSupportType::RPST_NoSupport;
 }
 
-bool PostureDescriber::_ComputePostureValuesCommand(std::ostream& ssout, std::istream& ssin) const {
+bool PostureDescriber::_ComputePostureValuesCommand(std::ostream& ssout, std::istream& ssin) {
     if(!_posturefn) {
         RAVELOG_WARN("No supported posture describer; _posturefn is not set");
         return false;

--- a/plugins/posturedescriber/posturedescriberinterface.h
+++ b/plugins/posturedescriber/posturedescriberinterface.h
@@ -128,6 +128,9 @@ protected:
     /// \brief Gets robot posture support type cast into int
     bool _GetSupportTypeCommand(std::ostream& ssout, std::istream& ssin) const;
 
+    /// \brief Computes posture values
+    bool _ComputePostureValuesCommand(std::ostream& ssout, std::istream& ssin) const;
+
     /* ========== `SendJSONCommand` APIs ========== */
     /// \brief `SendJSONCommand` API
     bool _InterpretJSONCommand(const rapidjson::Value& input, rapidjson::Value& output, rapidjson::Document::AllocatorType& allocator);
@@ -140,7 +143,7 @@ protected:
     RobotPostureSupportType _supporttype = RobotPostureSupportType::RPST_NoSupport;
 
     /* ========== cached values ========== */
-    std::vector<double> _posturevalues; ///< cached posture values
+    std::vector<double>          _posturevalues; ///< cached posture values
     std::vector<PostureStateInt> _featurestates; ///< cached feature states
     std::vector<PostureStateInt> _posturestates; ///< cached posture states
 };

--- a/plugins/posturedescriber/posturedescriberinterface.h
+++ b/plugins/posturedescriber/posturedescriberinterface.h
@@ -18,6 +18,7 @@
 #define PLUGINS_POSTUREDESCRIBER_POSTUREDESCRIBERINTERFACE_H
 
 #include <openrave/posturedescriber.h> // PostureDescriberBasePtr
+#include "plugindefs.h" // POSTUREDESCRIBER_CLASS_NAME, POSTUREDESCRIBER_MODULE_NAME, POSTUREDESCRIBER_STATE_NAME
 
 namespace OpenRAVE {
 

--- a/plugins/posturedescriber/posturedescriberinterface.h
+++ b/plugins/posturedescriber/posturedescriberinterface.h
@@ -65,9 +65,12 @@ inline T operator|=(T& x, T y)
     return x = x | y;
 }
 
-using PostureValueFn = std::function<void(const std::vector<KinBody::JointPtr>& vjoints,
+using PostureValueFn = std::function<void(const std::vector<KinBody::JointPtr>& joints,
                                           const double fTol,
-                                          std::vector<PostureStateInt>& posturestates)>;
+                                          std::vector<double>& posturevalues,
+                                          std::vector<PostureStateInt>& featurestates,
+                                          std::vector<PostureStateInt>& posturestates ///< most needed
+                                          )>;
 
 class OPENRAVE_API PostureDescriber : public PostureDescriberBase
 {
@@ -122,6 +125,7 @@ protected:
     /// \brief Gets the dof indices along a kinematics chain from baselink to eelink
     bool _GetArmIndicesCommand(std::ostream& ssout, std::istream& ssin) const;
 
+    /// \brief Gets robot posture support type cast into int
     bool _GetSupportTypeCommand(std::ostream& ssout, std::istream& ssin) const;
 
     /* ========== `SendJSONCommand` APIs ========== */
@@ -134,6 +138,11 @@ protected:
     double _fTol = 1e-6; ///< tolerance for determining if a robot posture value is considered 0
     PostureValueFn _posturefn; ///< function that computes posture values and states for a kinematics chain
     RobotPostureSupportType _supporttype = RobotPostureSupportType::RPST_NoSupport;
+
+    /* ========== cached values ========== */
+    std::vector<double> _posturevalues; ///< cached posture values
+    std::vector<PostureStateInt> _featurestates; ///< cached feature states
+    std::vector<PostureStateInt> _posturestates; ///< cached posture states
 };
 
 using PostureDescriberPtr = boost::shared_ptr<PostureDescriber>;

--- a/plugins/posturedescriber/posturedescriberinterface.h
+++ b/plugins/posturedescriber/posturedescriberinterface.h
@@ -129,7 +129,7 @@ protected:
     bool _GetSupportTypeCommand(std::ostream& ssout, std::istream& ssin) const;
 
     /// \brief Computes posture values
-    bool _ComputePostureValuesCommand(std::ostream& ssout, std::istream& ssin) const;
+    bool _ComputePostureValuesCommand(std::ostream& ssout, std::istream& ssin);
 
     /* ========== `SendJSONCommand` APIs ========== */
     /// \brief `SendJSONCommand` API

--- a/plugins/posturedescriber/posturedescriberinterface.h
+++ b/plugins/posturedescriber/posturedescriberinterface.h
@@ -141,6 +141,7 @@ protected:
     double _fTol = 1e-6; ///< tolerance for determining if a robot posture value is considered 0
     PostureValueFn _posturefn; ///< function that computes posture values and states for a kinematics chain
     RobotPostureSupportType _supporttype = RobotPostureSupportType::RPST_NoSupport;
+    std::string _posturestatename = POSTUREDESCRIBER_STATE_NAME;
 
     /* ========== cached values ========== */
     std::vector<double>          _posturevalues; ///< cached posture values

--- a/python/bindings/openravepy_posturedescriber.cpp
+++ b/python/bindings/openravepy_posturedescriber.cpp
@@ -125,7 +125,7 @@ PyPostureDescriberBasePtr GeneratePostureDescriber(const PyManipulatorPtr& pyman
     const RobotBasePtr probot = pmanip->GetRobot();
     const EnvironmentBasePtr penv = probot->GetEnv();
     const LinkPair linkpair = ExtractEssentialKinematicsChain(pmanip); // if extraction fails, i.e. no revolute joint, then linkpair is {nullptr, nullptr}
-    if(linkpair.first == nullptr || linkpair.second == nullptr) {
+    if(linkpair[0] == nullptr || linkpair[1] == nullptr) {
         RAVELOG_WARN_FORMAT("The essential kinematics chain is not valid (linkpair contains nullptr) for manpulator %s of robot %s",
                             pmanip->GetName() % probot->GetName());
         return PyPostureDescriberBasePtr();


### PR DESCRIPTION
- Instead of using `std::array` for `posturevalues`, `featurestates` inside a `PostureValueFn`, we cache `_posturevalues`, `_featurestates`, `_posturestates` inside the class `PostureDescriber`, and set size properly for `_posturevalues` and `_featurestates` in `PostureDescriber::Init`, so that later we can allow user to compute posture values and feature states.