### PR TITLE
Fix RapidJSON SetString call without allocator

### DIFF
--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -220,11 +220,11 @@ void toRapidJSONValue(const object &obj, rapidjson::Value &value, rapidjson::Doc
 #endif
     else if (PyString_Check(obj.ptr()))
     {
-        value.SetString(PyString_AsString(obj.ptr()), PyString_GET_SIZE(obj.ptr()));
+        value.SetString(PyString_AsString(obj.ptr()), PyString_GET_SIZE(obj.ptr()), allocator);
     }
     else if (PyUnicode_Check(obj.ptr()))
     {
-        value.SetString(PyBytes_AsString(obj.ptr()), PyBytes_GET_SIZE(obj.ptr()));
+        value.SetString(PyBytes_AsString(obj.ptr()), PyBytes_GET_SIZE(obj.ptr()), allocator);
     }
     else if (PyTuple_Check(obj.ptr()))
     {


### PR DESCRIPTION
Fix RapidJSON SetString call without allocator, which is dangerous if caller memory gets modified.

Before the fix:

```
      "confidence": "\u001c\u007f\u0000\u0000��K�\u001c\u007f\u0000\u0000`���\u001c\u007f\u0000\u0000�\u0019R\u001c\u001d\u007f\u0000\u0000\u0000\u0005\u0000\u00001974\u0000\u0000\u0000\u0000",
```

After the fix:

```
      "confidence": "{\"global_confidence\":1.0}",
```