### PR TITLE
robust manipulator restore

### DIFF
--- a/include/openrave/robot.h
+++ b/include/openrave/robot.h
@@ -738,6 +738,7 @@ protected:
         std::vector<Vector> _vvManipsLocalDirection;
         std::vector<IkSolverBasePtr> _vpManipsIkSolver;
         std::vector<int8_t> _vConnectedBodyActiveStates; ///< GetConnectedBodyActiveStates
+        std::vector<std::string> _vManipsName; ///< name of manipulators in the order other states are stored.
 private:
         virtual void _RestoreRobot(boost::shared_ptr<RobotBase> robot);
     };

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -235,12 +235,14 @@ RobotBase::RobotStateSaver::RobotStateSaver(RobotBasePtr probot, int options) : 
         _vtManipsLocalTool.resize(vmanips.size());
         _vvManipsLocalDirection.resize(vmanips.size());
         _vpManipsIkSolver.resize(vmanips.size());
+        _vManipsName.resize(vmanips.size());
         for(int imanip = 0; imanip < (int)vmanips.size(); ++imanip) {
             RobotBase::ManipulatorPtr pmanip = vmanips[imanip];
             if( !!pmanip ) {
                 _vtManipsLocalTool[imanip] = pmanip->GetLocalToolTransform();
                 _vvManipsLocalDirection[imanip] = pmanip->GetLocalToolDirection();
                 _vpManipsIkSolver[imanip] = pmanip->GetIkSolver();
+                _vManipsName[imanip] = pmanip->GetName();
             }
         }
     }
@@ -370,10 +372,20 @@ void RobotBase::RobotStateSaver::_RestoreRobot(boost::shared_ptr<RobotBase> prob
             if(vmanips.size() == _vtManipsLocalTool.size()) {
                 for(int imanip = 0; imanip < (int)vmanips.size(); ++imanip) {
                     RobotBase::ManipulatorPtr pmanip = vmanips[imanip];
+                    const std::string manipName = pmanip->GetName();
+                    const vector<string>::const_iterator it = find(_vManipsName.begin(), _vManipsName.end(), manipName);
+                    if (it == _vManipsName.end()) {
+                        RAVELOG_WARN_FORMAT("manip %s is not found in saved state. Maybe newly added?", manipName);
+                        continue;
+                    }
+                    int manipIndex = distance(_vManipsName.cbegin(), it);
+                    if (manipIndex != imanip) {
+                        RAVELOG_INFO_FORMAT("manip %s was previously at index %d, but changed to index %d.", manipName%imanip%manipIndex);
+                    }
                     if( !!pmanip ) {
-                        pmanip->SetLocalToolTransform(_vtManipsLocalTool.at(imanip));
-                        pmanip->SetLocalToolDirection(_vvManipsLocalDirection.at(imanip));
-                        pmanip->SetIkSolver(_vpManipsIkSolver.at(imanip));
+                        pmanip->SetLocalToolTransform(_vtManipsLocalTool.at(manipIndex));
+                        pmanip->SetLocalToolDirection(_vvManipsLocalDirection.at(manipIndex));
+                        pmanip->SetIkSolver(_vpManipsIkSolver.at(manipIndex));
                     }
                 }
             }

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -378,14 +378,14 @@ void RobotBase::RobotStateSaver::_RestoreRobot(boost::shared_ptr<RobotBase> prob
                         RAVELOG_WARN_FORMAT("manip %s is not found in saved state. Maybe newly added?", manipName);
                         continue;
                     }
-                    int manipIndex = distance(_vManipsName.cbegin(), it);
-                    if (manipIndex != imanip) {
-                        RAVELOG_INFO_FORMAT("manip %s was previously at index %d, but changed to index %d.", manipName%imanip%manipIndex);
+                    int indexAtSaveTime = distance(_vManipsName.cbegin(), it);
+                    if (indexAtSaveTime != imanip) {
+                        RAVELOG_INFO_FORMAT("manip %s was previously at index %d, but changed to index %d.", manipName%imanip%indexAtSaveTime);
                     }
                     if( !!pmanip ) {
-                        pmanip->SetLocalToolTransform(_vtManipsLocalTool.at(manipIndex));
-                        pmanip->SetLocalToolDirection(_vvManipsLocalDirection.at(manipIndex));
-                        pmanip->SetIkSolver(_vpManipsIkSolver.at(manipIndex));
+                        pmanip->SetLocalToolTransform(_vtManipsLocalTool.at(indexAtSaveTime));
+                        pmanip->SetLocalToolDirection(_vvManipsLocalDirection.at(indexAtSaveTime));
+                        pmanip->SetIkSolver(_vpManipsIkSolver.at(indexAtSaveTime));
                     }
                 }
             }

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -380,7 +380,7 @@ void RobotBase::RobotStateSaver::_RestoreRobot(boost::shared_ptr<RobotBase> prob
                     }
                     int indexAtSaveTime = distance(_vManipsName.cbegin(), it);
                     if (indexAtSaveTime != imanip) {
-                        RAVELOG_INFO_FORMAT("manip %s was previously at index %d, but changed to index %d.", manipName%imanip%indexAtSaveTime);
+                        RAVELOG_DEBUG_FORMAT("manip %s was previously at index %d, but changed to index %d.", manipName%imanip%indexAtSaveTime);
                     }
                     if( !!pmanip ) {
                         pmanip->SetLocalToolTransform(_vtManipsLocalTool.at(indexAtSaveTime));


### PR DESCRIPTION
before this patch, if someone does following, restoring could shuffle manipulators.

```
assert len(robot.GetManipulators()) > 1
manip = robot.GetManipulators()[0]
info = manip.GetInfo()
robot.RemoveManipulator(manip)
robot.AddManipulator(info) # now manip is the last in manipulators
```

with this patch, above code does not cause problem as long as manipulator name does not change.