### PR TITLE
check ptempreport is not null before printing

### DIFF
--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -1649,7 +1649,7 @@ protected:
                 if( paramnewglobal.GetType() == IKP_Transform6D ) {// || (int)pmanip->GetArmIndices().size() <= paramnewglobal.GetDOF() ) {
                     // if gripper is colliding, solutions will always fail, so completely stop solution process
                     if( pmanip->CheckEndEffectorCollision(pmanip->GetTransform(), ptempreport) ) {
-                        if( IS_DEBUGLEVEL(Level_Verbose) ) {
+                        if( !!ptempreport ) {
                             stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
                             ss << "ikfast collision " << report.__str__() << " colvalues=[";
                             std::vector<dReal> vallvalues;
@@ -1707,7 +1707,7 @@ protected:
                     }
                 }
 
-                if( IS_DEBUGLEVEL(Level_Verbose) ) {
+                if( !!ptempreport ) {
                     stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
                     ss << "env=" << GetEnv()->GetId() << ", ikfast collision " << probot->GetName() << ":" << pmanip->GetName() << " " << report.__str__() << " colvalues=[";
                     std::vector<dReal> vallvalues;
@@ -2083,7 +2083,7 @@ protected:
                 // only check if the end-effector position is fully determined from the ik
                 if( paramnewglobal.GetType() == IKP_Transform6D ) {// || (int)pmanip->GetArmIndices().size() <= paramnewglobal.GetDOF() ) {
                     if( pmanip->CheckEndEffectorCollision(pmanip->GetTransform(), ptempreport) ) {
-                        if( IS_DEBUGLEVEL(Level_Verbose) ) {
+                        if( !!ptempreport ) {
                             stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
                             ss << "env=" << GetEnv()->GetId() << ", ikfast collision " << ptempreport->__str__() << " ";
                             if( !!ptempreport->plink1 ) {
@@ -2123,7 +2123,7 @@ protected:
                 }
             }
             if( GetEnv()->CheckCollision(KinBodyConstPtr(probot), ptempreport) ) {
-                if( IS_DEBUGLEVEL(Level_Verbose) ) {
+                if( !!ptempreport ) {
                     stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
                     ss << "ikfast collision " << report.__str__() << " colvalues=[";
                     std::vector<dReal> vallvalues;


### PR DESCRIPTION
The debug level can change. We should not rely on the checking of `IS_DEBUGLEVEL(...)` to imply that `ptempreport` is initialized previously or not.
If the debug level changes in the middle from the level higher than verbose to verbose, `report.__str__()` will be called, causing segfault.