### PR TITLE
Get static joint value directly from it's dof limit; use _tLeft* as the transform from parent link to child link

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -1837,7 +1837,7 @@ void KinBody::SetDOFValues(const std::vector<dReal>& vJointValues, uint32_t chec
                 break;
             }
         }
-        else {
+        else if ( !pjoint->IsStatic() ) {
             if( pjoint->GetType() == JointRevolute ) {
                 tjoint.rot = quatFromAxisAngle(pjoint->GetInternalHierarchyAxis(0), pvalues[0]);
                 pjoint->_doflastsetvalues[0] = pvalues[0];
@@ -1860,6 +1860,7 @@ void KinBody::SetDOFValues(const std::vector<dReal>& vJointValues, uint32_t chec
             }
         }
 
+        // if pjoint->IsStatic(), then pjoint->_info._tRightNoOffset and tjoint are assigned identities
         Transform t = pjoint->GetInternalHierarchyLeftTransform() * tjoint * pjoint->GetInternalHierarchyRightTransform();
         if( !pjoint->GetHierarchyParentLink() ) {
             t = _veclinks.at(0)->GetTransform() * t;

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -1048,13 +1048,24 @@ void KinBody::Joint::_ComputeInternalInformation(LinkPtr plink0, LinkPtr plink1,
 
     if(IsStatic()) {
         for(int idof = 0; idof < GetDOF(); ++idof) {
-            BOOST_ASSERT(_info._vlowerlimit[idof] == 0 && _info._vupperlimit[idof] == 0);
+            if( _info._vlowerlimit[idof] != 0 ) {
+                if( _info._vlowerlimit[idof] > g_fEpsilon || _info._vlowerlimit[idof] < -g_fEpsilon ) {
+                    RAVELOG_WARN_FORMAT("static joint %s has non-zero lower limit %e, setting to 0", _info._name%_info._vlowerlimit[idof]);
+                }
+                _info._vlowerlimit[idof] = 0;
+            }
+            if( _info._vupperlimit[idof] != 0 ) {
+                if( _info._vupperlimit[idof] > g_fEpsilon || _info._vupperlimit[idof] < -g_fEpsilon ) {
+                    RAVELOG_WARN_FORMAT("static joint %s has non-zero upper limit %e, setting to 0", _info._name%_info._vupperlimit[idof]);
+                }
+                _info._vupperlimit[idof] = 0;
+            }
         }
         _tLeftNoOffset *= _tRightNoOffset;
         _tLeft *= _tRight;
-        _tRightNoOffset = _tRight = Transform();
+        _tRightNoOffset = _tRight = _tinvRight = Transform();
+        _tinvLeft = _tLeft.inverse();
     }
-
 }
 
 KinBody::LinkPtr KinBody::Joint::GetHierarchyParentLink() const


### PR DESCRIPTION
- If between a parent link (L0) and a child link (L1) is a static joint, then its joint value is always 0 by convention, and we store the complete transform from L0 to L1 in `_tLeft*`, and let `_tRight*` be identity.