### PR TITLE
Fix computing DOF velocities

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -3131,7 +3131,7 @@ void KinBody::_ComputeDOFLinkVelocities(std::vector<dReal>& dofvelocities, std::
         if( !!(*it)->_attachedbodies[0] ) {
             parentindex = (*it)->_attachedbodies[0]->GetIndex();
         }
-        int childindex = (*it)->_attachedbodies[0]->GetIndex();
+        int childindex = (*it)->_attachedbodies[1]->GetIndex();
         (*it)->_GetVelocities(dofvelocities,true,vLinkVelocities.at(parentindex),vLinkVelocities.at(childindex));
     }
 }

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -768,7 +768,7 @@ void KinBody::Joint::_GetVelocities(std::vector<dReal>& pVelocities, bool bAppen
         pVelocities.resize(0);
     }
     if( GetDOF() == 1 ) {
-        pVelocities.push_back(GetVelocity(0));
+        pVelocities.push_back(_GetVelocity(0, linkparentvelocity, linkchildvelocity));
         return;
     }
     const Transform& linkparenttransform = _attachedbodies[0]->_info._t;


### PR DESCRIPTION
there were two mistakes related to computing DOF velocities.
1. `childindex` was wrongly computed
2. given link velocities were not used for one dof joint