### PR TITLE
add cylinder mesh discretization parameter

### DIFF
--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -160,6 +160,12 @@ public:
         inline dReal GetCylinderHeight() const {
             return _vGeomData.y;
         }
+        inline dReal GetCylinderNumCircleDiscretiazationPoints() const {
+            if (_vGeomData.z <= 4) { // cannot discretize with less than 4 points
+                return 53; // default value for backwards compatibility
+            }
+            return _vGeomData.z;
+        }
         inline const Vector& GetBoxExtents() const {
             return _vGeomData;
         }
@@ -182,6 +188,7 @@ public:
 
         /// for boxes, first 3 values are half extents. For containers, the first 3 values are the full outer extents.
         /// For GT_Cage, this is the base box extents with the origin being at the -Z center.
+        /// For GT_Cylinder, cylinder radius, cylinder height, circle discretization points (will be affected by fTessellation) 
         Vector _vGeomData;
 
         ///< For GT_Container, the first 3 values are the full inner extents.

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -160,12 +160,14 @@ public:
         inline dReal GetCylinderHeight() const {
             return _vGeomData.y;
         }
-        inline dReal GetCylinderNumCircleDiscretiazationPoints() const {
-            if (_vGeomData.z <= 4) { // cannot discretize with less than 4 points
-                return 53; // default value for backwards compatibility
+        /// gets number of points circle face of cylinder should be approximated
+        inline dReal GetCylinderNumCircleApproximate() const {
+            if (_vGeomData[2] <= 4) { // cannot discretize with less than 4 points
+                return 51; // default value for backwards compatibility
             }
-            return _vGeomData.z;
+            return _vGeomData[2];
         }
+
         inline const Vector& GetBoxExtents() const {
             return _vGeomData;
         }
@@ -188,7 +190,8 @@ public:
 
         /// for boxes, first 3 values are half extents. For containers, the first 3 values are the full outer extents.
         /// For GT_Cage, this is the base box extents with the origin being at the -Z center.
-        /// For GT_Cylinder, cylinder radius, cylinder height, circle discretization points (will be affected by fTessellation) 
+        /// For GT_Cylinder, cylinder radius, cylinder height, number of points circle face of cylinder should be approximated
+
         Vector _vGeomData;
 
         ///< For GT_Container, the first 3 values are the full inner extents.
@@ -371,6 +374,13 @@ public:
             }
             inline dReal GetCylinderHeight() const {
                 return _info._vGeomData.y;
+            }
+            /// gets number of points circle face of cylinder should be approximated
+            inline dReal GetCylinderNumCircleApproximate() const {
+                if (_info._vGeomData[2] <= 4) { // cannot discretize with less than 4 points
+                    return 54; // default value for backwards compatibility
+                }
+                return _info._vGeomData[2];
             }
             inline const Vector& GetBoxExtents() const {
                 return _info._vGeomData;

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -2905,12 +2905,21 @@ public:
                         else if( name == "cylinder" ) {
                             daeElementRef pradius = children[i]->getChild("radius");
                             daeElementRef pheight = children[i]->getChild("height");
+                            daeElementRef pnumapproximate = children[i]->getChild("numapproximate");
+
                             if( !!pradius && !!pheight ) {
                                 Vector vGeomData;
                                 stringstream ss(pradius->getCharData());
                                 ss >> vGeomData.x;
                                 stringstream ss2(pheight->getCharData());
                                 ss2 >> vGeomData.y;
+                                if ( !!pnumapproximate ) {
+                                    stringstream ss3(pnumapproximate->getCharData());
+                                    ss3 >> vGeomData.z;
+                                    if (!(ss3.eof() || !!ss3) ) {
+                                        vGeomData.z = 0; // reset if invalid number and use default one
+                                    }
+                                }
                                 if( (ss.eof() || !!ss) && (ss2.eof() || !!ss2) ) {
                                     Transform trot(quatRotateDirection(Vector(0,0,1),Vector(0,1,0)),Vector());
                                     tlocalgeom = tlocalgeom * trot;
@@ -2924,12 +2933,21 @@ public:
                         else if( name == "cylinderz" ) {
                             daeElementRef pradius = children[i]->getChild("radius");
                             daeElementRef pheight = children[i]->getChild("height");
+                            daeElementRef pnumapproximate = children[i]->getChild("numapproximate");
+
                             if( !!pradius && !!pheight ) {
                                 Vector vGeomData;
                                 stringstream ss(pradius->getCharData());
                                 ss >> vGeomData.x;
                                 stringstream ss2(pheight->getCharData());
                                 ss2 >> vGeomData.y;
+                                if ( !!pnumapproximate ) {
+                                    stringstream ss3(pnumapproximate->getCharData());
+                                    ss3 >> vGeomData.z;
+                                    if (!(ss3.eof() || !!ss3) ) {
+                                        vGeomData.z = 0; // reset if invalid number and use default one
+                                    }
+                                }
                                 if( (ss.eof() || !!ss) && (ss2.eof() || !!ss2) ) {
                                     geominfo._type = GT_Cylinder;
                                     geominfo._vGeomData = vGeomData;

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -1997,6 +1997,7 @@ private:
                 ss << geom->GetCylinderRadius() << " " << geom->GetCylinderRadius();
                 pcylinder->add("radius")->setCharData(ss.str());
                 pcylinder->add("height")->setCharData(boost::lexical_cast<std::string>(geom->GetCylinderHeight()));
+                pcylinder->add("numapproximate")->setCharData(boost::lexical_cast<std::string>(geom->GetCylinderNumCircleApproximate()));
                 break;
             }
             case GT_None:

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -234,14 +234,15 @@ bool KinBody::GeometryInfo::InitCollisionMesh(float fTessellation)
     case GT_Cylinder: {
         // cylinder is on z axis
         dReal rad = GetCylinderRadius(), len = GetCylinderHeight()*0.5f;
-        int numverts = (int)(fTessellation*GetCylinderNumCircleDiscretiazationPoints());
-        // TODO: we should make collision obstacle bigger than cylinder, treat circle as inscribed circle not as circumscribed  
+        // int numverts = (int)(fTessellation*48.0f) + 3;
+        int numverts = max((int)(fTessellation*GetCylinderNumCircleApproximate()), 3); // should not be less than 3 to maintain backwards compatibility  (numverts = (int)(fTessellation*48.0f) + 3;)
+        // TODO: we should make collision obstacle bigger than cylinder, treat circle as inscribed circle not as circumscribed
         dReal dtheta = 2 * PI / (dReal)numverts;
         _meshcollision.vertices.push_back(Vector(0,0,len));
         _meshcollision.vertices.push_back(Vector(0,0,-len));
         _meshcollision.vertices.push_back(Vector(rad,0,len));
         _meshcollision.vertices.push_back(Vector(rad,0,-len));
-        for(int i = 0; i < numverts+1; ++i) {
+        for(int i = 1; i < numverts+1; ++i) {
             dReal s = rad * RaveSin(dtheta * (dReal)i);
             dReal c = rad * RaveCos(dtheta * (dReal)i);
             int off = (int)_meshcollision.vertices.size();
@@ -509,6 +510,7 @@ void KinBody::GeometryInfo::SerializeJSON(rapidjson::Value& value, rapidjson::Do
         openravejson::SetJsonValueByKey(value, "type", "cylinder", allocator);
         openravejson::SetJsonValueByKey(value, "radius", _vGeomData.x*fUnitScale, allocator);
         openravejson::SetJsonValueByKey(value, "height", _vGeomData.y*fUnitScale, allocator);
+        openravejson::SetJsonValueByKey(value, "numapproximate", (int)_vGeomData.z, allocator);
         break;
 
     case GT_TriMesh:
@@ -586,6 +588,7 @@ void KinBody::GeometryInfo::DeserializeJSON(const rapidjson::Value &value, const
         _type = GT_Cylinder;
         openravejson::LoadJsonValueByKey(value, "radius", _vGeomData.x);
         openravejson::LoadJsonValueByKey(value, "height", _vGeomData.y);
+        openravejson::LoadJsonValueByKey(value, "numapproximate", _vGeomData.z);
 
         _vGeomData.x *= fUnitScale;
         _vGeomData.y *= fUnitScale;

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -234,7 +234,8 @@ bool KinBody::GeometryInfo::InitCollisionMesh(float fTessellation)
     case GT_Cylinder: {
         // cylinder is on z axis
         dReal rad = GetCylinderRadius(), len = GetCylinderHeight()*0.5f;
-        int numverts = (int)(fTessellation*48.0f) + 3;
+        int numverts = (int)(fTessellation*GetCylinderNumCircleDiscretiazationPoints());
+        // TODO: we should make collision obstacle bigger than cylinder, treat circle as inscribed circle not as circumscribed  
         dReal dtheta = 2 * PI / (dReal)numverts;
         _meshcollision.vertices.push_back(Vector(0,0,len));
         _meshcollision.vertices.push_back(Vector(0,0,-len));

--- a/src/libopenrave/xmlreaders.cpp
+++ b/src/libopenrave/xmlreaders.cpp
@@ -427,6 +427,9 @@ bool GeometryInfoReader::endElement(const std::string& xmlname)
             else if( xmlname == "height" ) {
                 _ss >> _pgeom->_vGeomData.y;
             }
+            else if( xmlname == "numapproximate" ) {
+                _ss >> _pgeom->_vGeomData.z;
+            }
             break;
         case GT_TriMesh:
             if(( xmlname == "data") ||( xmlname == "collision") ) {


### PR DESCRIPTION
adding a parameter to the ginfo to change the mesh accuracy for cylinders. 
I don't know what is a good name for such a parameter . For now it is ` numapproximate` 
I also noticed another issue with mesh generation for cylinders. We are replacing a cylinder with a mesh which is smaller than cylinder. We have to treat treat circle as inscribed into the mesh which we generate not as circumscribed.