### PR TITLE
fix Joint::IsStatic()

### DIFF
--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -1083,7 +1083,6 @@ public:
         boost::array<uint8_t, 3> _bIsCircular = {0, 0, 0};
 
         bool _bIsActive = true;                 ///< if true, should belong to the DOF of the body, unless it is a mimic joint (_ComputeInternalInformation decides this)
-        bool _bStatic = false; ///< IsStatic with both lower and upper limits equal 0
 
         /// \brief _controlMode specifies how this joint is controlled. For possible control modes, see enum JointControlMode.
         JointControlMode _controlMode = JCM_None;
@@ -1607,7 +1606,7 @@ private:
         Transform _tRightNoOffset, _tLeftNoOffset;         ///< same as _tLeft and _tRight except it doesn't not include the offset
         Transform _tinvRight, _tinvLeft;         ///< the inverse transformations of tRight and tLeft
         bool _bInitialized;
-
+        bool _bStatic; ///< IsStatic with both lower and upper limits equal 0
         //@}
 #ifdef RAVE_PRIVATE
 #ifdef _MSC_VER

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -73,7 +73,6 @@ void KinBody::JointInfo::Reset()
     _infoElectricMotor.reset();
     _bIsCircular = {0, 0, 0};
     _bIsActive = true;
-    _bStatic = false;
     _controlMode = JCM_None;
     _jci_robotcontroller.reset();
     _jci_io.reset();

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -572,7 +572,7 @@ KinBody::Joint::Joint(KinBodyPtr parent, KinBody::JointType type)
     jointindex=-1;
     dofindex = -1; // invalid index
     _bInitialized = false;
-    _info._bStatic = false;
+    _bStatic = false;
     _info._type = type;
     _info._controlMode = JCM_None;
 }
@@ -620,7 +620,7 @@ bool KinBody::Joint::IsPrismatic(int iaxis) const
 bool KinBody::Joint::IsStatic() const
 {
     if(_bInitialized) {
-        return _info._bStatic;
+        return _bStatic;
     }
     
     if( IsMimic() ) {
@@ -1304,7 +1304,7 @@ void KinBody::Joint::_ComputeInternalInformation(LinkPtr plink0, LinkPtr plink1,
                 _info._vupperlimit[idof] = 0;
             }
         }
-        _info._bStatic = true;
+        _bStatic = true;
         _tLeftNoOffset *= _tRightNoOffset;
         _tLeft *= _tRight;
         _tRightNoOffset = _tRight = _tinvRight = Transform();


### PR DESCRIPTION
cloned robot didn't return correct IsStatic() because _bStatic was moved to JointInfo and it was missed from assignment operator of JointInfo.

i think regarding the fact that _bStatic is determined by seeing joint range, it should be moved back to Joint class