### PR TITLE
(ManipulatorInfo, AttachedSensorInfo, GrabbedInfo) Check if members are None or not

### DIFF
--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -2089,10 +2089,18 @@ RobotBase::GrabbedInfoPtr PyKinBody::PyGrabbedInfo::GetGrabbedInfo() const
     pinfo->_trelative = ExtractTransform(_trelative);
     pinfo->_setRobotLinksToIgnore = std::set<int>(begin(_setRobotLinksToIgnore), end(_setRobotLinksToIgnore));
 #else
-    pinfo->_id = py::extract<std::string>(_id);
-    pinfo->_grabbedname = py::extract<std::string>(_grabbedname);
-    pinfo->_robotlinkname = py::extract<std::string>(_robotlinkname);
-    pinfo->_trelative = ExtractTransform(_trelative);
+    if( !IS_PYTHONOBJECT_NONE(_id) ) {
+        pinfo->_id = py::extract<std::string>(_id);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_grabbedname) ) {
+        pinfo->_grabbedname = py::extract<std::string>(_grabbedname);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_robotlinkname) ) {
+        pinfo->_robotlinkname = py::extract<std::string>(_robotlinkname);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_trelative) ) {
+        pinfo->_trelative = ExtractTransform(_trelative);
+    }
     pinfo->_setRobotLinksToIgnore.clear();
 
     if( !IS_PYTHONOBJECT_NONE(_setRobotLinksToIgnore) ) {

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -84,13 +84,27 @@ void PyManipulatorInfo::_Update(const RobotBase::ManipulatorInfo& info) {
 RobotBase::ManipulatorInfoPtr PyManipulatorInfo::GetManipulatorInfo() const
 {
     RobotBase::ManipulatorInfoPtr pinfo(new RobotBase::ManipulatorInfo());
-    pinfo->_id = py::extract<std::string>(_id);
-    pinfo->_name = py::extract<std::string>(_name);
-    pinfo->_sBaseLinkName = py::extract<std::string>(_sBaseLinkName);
-    pinfo->_sEffectorLinkName = py::extract<std::string>(_sEffectorLinkName);
-    pinfo->_tLocalTool = ExtractTransform(_tLocalTool);
-    pinfo->_vChuckingDirection = ExtractArray<dReal>(_vChuckingDirection);
-    pinfo->_vdirection = ExtractVector3(_vdirection);
+    if( !IS_PYTHONOBJECT_NONE(_id) ) {
+        pinfo->_id = py::extract<std::string>(_id);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_name) ) {
+        pinfo->_name = py::extract<std::string>(_name);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_sBaseLinkName) ) {
+        pinfo->_sBaseLinkName = py::extract<std::string>(_sBaseLinkName);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_sEffectorLinkName) ) {
+        pinfo->_sEffectorLinkName = py::extract<std::string>(_sEffectorLinkName);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_tLocalTool) ) {
+        pinfo->_tLocalTool = ExtractTransform(_tLocalTool);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_vChuckingDirection) ) {
+        pinfo->_vChuckingDirection = ExtractArray<dReal>(_vChuckingDirection);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_vdirection) ) {
+        pinfo->_vdirection = ExtractVector3(_vdirection);
+    }
     pinfo->_sIkSolverXMLId = _sIkSolverXMLId;
     if( !IS_PYTHONOBJECT_NONE(_vGripperJointNames) ) {
         pinfo->_vGripperJointNames = ExtractArray<std::string>(_vGripperJointNames);

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -170,11 +170,21 @@ void PyAttachedSensorInfo::_Update(const RobotBase::AttachedSensorInfo& info) {
 RobotBase::AttachedSensorInfoPtr PyAttachedSensorInfo::GetAttachedSensorInfo() const
 {
     RobotBase::AttachedSensorInfoPtr pinfo(new RobotBase::AttachedSensorInfo());
-    pinfo->_id = py::extract<std::string>(_id);
-    pinfo->_name = py::extract<std::string>(_name);
-    pinfo->_linkname = py::extract<std::string>(_linkname);
-    pinfo->_trelative = ExtractTransform(_trelative);
-    pinfo->_sensorname = py::extract<std::string>(_sensorname);
+    if( !IS_PYTHONOBJECT_NONE(_id) ) {
+        pinfo->_id = py::extract<std::string>(_id);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_name) ) {
+        pinfo->_name = py::extract<std::string>(_name);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_linkname) ) {
+        pinfo->_linkname = py::extract<std::string>(_linkname);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_trelative) ) {
+        pinfo->_trelative = ExtractTransform(_trelative);
+    }
+    if( !IS_PYTHONOBJECT_NONE(_sensorname) ) {
+        pinfo->_sensorname = py::extract<std::string>(_sensorname);
+    }
     rapidjson::Document docSensorGeometry;
     if(!!_sensorgeometry) {
         SensorBase::SensorGeometryPtr sensorGeometry = _sensorgeometry->GetGeometry();


### PR DESCRIPTION
These members are initialized to None (py_none) which is failed to convert to std::string and so on, and following code fails

```
p = ManipulatorInfo()
p.SerializeJSON()
```