### PR TITLE
Update gripperInfo in pnewgripperInfo

### DIFF
--- a/src/libopenrave/robotconnectedbody.cpp
+++ b/src/libopenrave/robotconnectedbody.cpp
@@ -1026,7 +1026,9 @@ void RobotBase::_ComputeConnectedBodiesInformation()
                 RecursivePrefixMatchingField(connectedBody._nameprefix, boost::bind(MatchFieldsCaseInsensitive, _1, std::string("linkname")), newGripperInfoDoc, newGripperInfoDoc.GetAllocator(), false);
                 RecursivePrefixMatchingField(connectedBody._nameprefix, boost::bind(MatchFieldsCaseInsensitive, _1, std::string("linknames")), newGripperInfoDoc, newGripperInfoDoc.GetAllocator(), false);
                 RecursivePrefixMatchingField(connectedBody._nameprefix, boost::bind(MatchFieldsCaseInsensitive, _1, std::string("links")), newGripperInfoDoc, newGripperInfoDoc.GetAllocator(), false);
-                connectedBodyInfo._vGripperInfos[iGripperInfo]->_docGripperInfo.Swap(newGripperInfoDoc);
+
+                // no need to update gripperInfo in ConnectedBodyInfo?
+                pnewgripperInfo->_docGripperInfo.Swap(newGripperInfoDoc);
             }
 
             _vecGripperInfos.push_back(pnewgripperInfo);


### PR DESCRIPTION
Currently `robot.GerGripperInfos` does not have `useLinkNames` with prefix.

I wonder if we should update gripeprInfo in connectedBodyInfo too. For now, I only update `pnewgripeprInfo`.