### PR TITLE
Fix copying gripperInfo 

### DIFF
--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -22,6 +22,7 @@ namespace OpenRAVE {
 
 RobotBase::GripperInfo& RobotBase::GripperInfo::operator=(const RobotBase::GripperInfo& other)
 {
+    _id = other._id;
     name = other.name;
     grippertype = other.grippertype;
     gripperJointNames = other.gripperJointNames;


### PR DESCRIPTION
`id` was missed from copying. this was causing unnecessary re-generation of cache because cloned robot returned different `id`.