### PR TITLE
Fix pybind11

### DIFF
--- a/python/bindings/docstrings.cpp
+++ b/python/bindings/docstrings.cpp
@@ -15,9 +15,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /// Auto-generated using build_openravepy_internal.py from ../python/bindings/*.cpp file
+#include <openrave/config.h>
 #include <openravepy/docstrings.h>
 namespace openravepy {
-void InitializeComments(std::map<std::string,std::string>& m)
+OPENRAVE_API void InitializeComments(std::map<std::string,std::string>& m)
 {m["en function RaveCreateSensorSystem"] = "\n\nOPENRAVE_API   SensorSystemBasePtr  **RaveCreateSensorSystem**\\(EnvironmentBasePtr penv, const std::string & name)\n    \n            ";
 m["en function KinBody::KinBodyStateSaver  GetBody"] = "\n\nKinBodyPtr  **GetBody**\\()\n    \n            ";
 m["en function KinBody::KinBodyStateSaver  Restore"] = "\n\nvoid  **Restore**\\(OPENRAVE_SHARED_PTR<  KinBody  > body = OPENRAVE_SHARED_PTR<  KinBody  >() )\n    \n    restore the state\n    \n    *Parameters*\n     ``body`` - \n      if set, will attempt to restore the stored state to the passed in body, otherwise will restore it for the original body. \\ *Exceptions*\n     ``openrave_exception`` - \n      if the passed in body is not compatible with the saved state, will throw\n    \n            ";

--- a/python/bindings/openravepy_global.cpp
+++ b/python/bindings/openravepy_global.cpp
@@ -1598,7 +1598,7 @@ void init_openravepy_global()
 #endif
     .def("GetXMLId", &PyReadable::GetXMLId, DOXY_FN(eadable, GetXMLId))
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-    .def("Serialize", &PyReadable::Serialize,
+    .def("SerializeXML", &PyReadable::SerializeXML,
          "options"_a = 0,
          DOXY_FN(eadable, Serialize)
          )

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -176,8 +176,11 @@ std::map<std::string, ReadablePtr> ExtractReadableInterfaces(object pyReadableIn
     py::dict pyReadableInterfacesDict = (py::dict)pyReadableInterfaces;
     std::map<std::string, ReadablePtr> mReadableInterfaces;
     try {
-
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        py::list keys = py::list(pyReadableInterfacesDict);
+#else
         py::list keys = py::list(pyReadableInterfacesDict.keys());
+#endif
         size_t numkeys = len(keys);
         for(size_t iKey = 0; iKey < numkeys; iKey++) {
             std::string name = py::extract<std::string>(keys[iKey]);


### PR DESCRIPTION
1. controllercommon imports InitializeComments, so it needs to be declared as OPENRAVE_API.
2. fix leftover of https://github.com/rdiankov/openrave/commit/fb0dc5cdb7a5fabb91cd86e300236fe39786483a
3. py::dict does not have keys() method. I'm not convinced of the fix though. #867 