### PR TITLE
stabilize sort for groups not in _maporder

### DIFF
--- a/src/libopenrave-core/generictrajectory.cpp
+++ b/src/libopenrave-core/generictrajectory.cpp
@@ -147,10 +147,17 @@ public:
         if( index2 == string::npos ) {
             index2 = g2.name.size();
         }
-        std::map<string,int>::iterator it1 = _maporder.find(g1.name.substr(0,index1));
-        std::map<string,int>::iterator it2 = _maporder.find(g2.name.substr(0,index2));
+
+        const string g1prefix =  g1.name.substr(0,index1);
+        const string g2prefix =  g2.name.substr(0,index2);
+        std::map<string,int>::iterator it1 = _maporder.find(g1prefix);
+        std::map<string,int>::iterator it2 = _maporder.find(g2prefix);
+        
+        if( it1 == _maporder.end() && it2 == _maporder.end()) {
+            return g1prefix < g2prefix;
+        }
         if( it1 == _maporder.end() ) {
-            return it2 == _maporder.end();
+            return false;
         }
         if( it2 == _maporder.end()) {
             return true;


### PR DESCRIPTION
with the snippet below, current production branch outputs different result for ``traj`` and ``traj2`` due to unstable sorting of groups not in ``_maporder``

This leads to trajectory hash to jump back and forth for same trajectory.

- https://github.com/rdiankov/openrave/blob/master/src/libopenrave-core/generictrajectory.cpp#L124

```
traj = RaveCreateTrajectory(env,'')
spec=ConfigurationSpecification()
for name in ['a'*10, 'b'*10]:
    group = ConfigurationSpecification.Group()
    group.name = name
    group.dof = 1
    group.interpolation = 'quadratic'
    spec.AddGroup(group)
    traj.Init(spec)
traj2 = RaveCreateTrajectory(env, '')
traj2.deserialize(traj.serialize())
print '-'*30
print traj.serialize()
print '-'*30
print traj2.serialize()
print '-'*30
print traj.serialize() == traj2.serialize()
```