### PR TITLE
should specify checking options to check all constraints in _InitPlan…

### DIFF
--- a/plugins/rplanners/rrt.h
+++ b/plugins/rplanners/rrt.h
@@ -73,7 +73,7 @@ Uses the Rapidly-Exploring Random Trees Algorithm.\n\
         for(size_t index = 0; index < params->vinitialconfig.size(); index += params->GetDOF()) {
             std::copy(params->vinitialconfig.begin()+index,params->vinitialconfig.begin()+index+params->GetDOF(),vinitialconfig.begin());
             _filterreturn->Clear();
-            if( params->CheckPathAllConstraints(vinitialconfig,vinitialconfig, std::vector<dReal>(), std::vector<dReal>(), 0, IT_OpenStart, CFO_FillCollisionReport, _filterreturn) != 0 ) {
+            if( params->CheckPathAllConstraints(vinitialconfig,vinitialconfig, std::vector<dReal>(), std::vector<dReal>(), 0, IT_OpenStart, 0xffff|CFO_FillCollisionReport, _filterreturn) != 0 ) {
                 RAVELOG_DEBUG_FORMAT("env=%d, initial configuration for rrt does not satisfy constraints: %s", GetEnv()->GetId()%_filterreturn->_report.__str__());
                 continue;
             }


### PR DESCRIPTION
Explicitly specify constraint options `0xffff` when checking the initial configuration(s) of RRT.