### PR TITLE
Include header dir for rapidjson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,7 @@ endif()
 
 find_package(RapidJSON)
 if( RAPIDJSON_FOUND )
+  include_directories(${RAPIDJSON_INCLUDES})
 else()
   message(FATAL_ERROR "rapidjson library not found")
 endif()


### PR DESCRIPTION
Enables custom installation paths (other than `/usr` or `/usr/local`).