### PR TITLE
Bug fixes for #820: (1) restored a section of code accidentally deleted in #820; (2) resolved two semicolons after common subexpressions

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -2313,7 +2313,7 @@ void KinBody::ComputeJacobianTranslation(const int linkindex,
 
                 int index = -1;
                 if( !dofindices.empty() ) {
-                    const std::vector<int>::const_iterator itindex = find(dofindices.begin(), dofindices.end(), dofindex + idof);
+                    const std::vector<int>::const_iterator itindex = std::find(dofindices.begin(), dofindices.end(), dofindex + idof);
                     if( itindex == dofindices.end() ) {
                         continue;
                     }
@@ -2356,7 +2356,7 @@ void KinBody::ComputeJacobianTranslation(const int linkindex,
                         int index = -1;
                         const int dofindex = dofindexDerivativePair.first;
                         if( !dofindices.empty() ) {
-                            const std::vector<int>::const_iterator itindex = find(dofindices.begin(), dofindices.end(), dofindex);
+                            const std::vector<int>::const_iterator itindex = std::find(dofindices.begin(), dofindices.end(), dofindex);
                             if( itindex == dofindices.end() ) {
                                 continue;
                             }
@@ -2568,7 +2568,7 @@ void KinBody::ComputeJacobianAxisAngle(const int linkindex,
                     vColumn = pjoint->GetAxis(dof);
                     int index = -1;
                     if( !dofindices.empty() ) {
-                        const std::vector<int>::const_iterator itindex = find(dofindices.begin(),dofindices.end(),dofindex+dof);
+                        const std::vector<int>::const_iterator itindex = std::find(dofindices.begin(),dofindices.end(),dofindex+dof);
                         if( itindex == dofindices.end() ) {
                             continue;
                         }
@@ -2608,7 +2608,7 @@ void KinBody::ComputeJacobianAxisAngle(const int linkindex,
                         int index = -1;
                         const int dofindex = dofindexDerivativePair.first;
                         if( !dofindices.empty() ) {
-                            const std::vector<int>::const_iterator itindex = find(dofindices.begin(), dofindices.end(), dofindex);
+                            const std::vector<int>::const_iterator itindex = std::find(dofindices.begin(), dofindices.end(), dofindex);
                             if( itindex == dofindices.end() ) {
                                 continue;
                             }

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2066,7 +2066,7 @@ void KinBody::Joint::SetMimicEquations(int iaxis, const std::string& poseq, cons
             }
 
             // ensure varname is indeed in the variable list
-            std::vector<string>::iterator itnameindex = find(resultVars.begin(), resultVars.end(), varname);
+            std::vector<string>::iterator itnameindex = std::find(resultVars.begin(), resultVars.end(), varname);
             OPENRAVE_ASSERT_FORMAT(itnameindex != resultVars.end(), "variable %s from velocity equation is not referenced in the position, skipping...", mapinvnames[varname],ORE_InvalidArguments);
 
             OpenRAVEFunctionParserRealPtr fn = CreateJointFunctionParser();
@@ -2123,7 +2123,7 @@ void KinBody::Joint::_ComputePartialVelocities(std::vector<std::pair<int, dReal>
         const size_t nActiveJoints = vActiveJoints.size();
         const std::vector<JointPtr>& vPassiveJoints = parent->GetPassiveJoints();
         // this is the *generalized* joint index for a mimic joint
-        thisdofformat.jointindex = nActiveJoints + (find(begin(vPassiveJoints), end(vPassiveJoints), shared_from_this()) - begin(vPassiveJoints));
+        thisdofformat.jointindex = nActiveJoints + (std::find(begin(vPassiveJoints), end(vPassiveJoints), shared_from_this()) - begin(vPassiveJoints));
     }
 
     for(const std::pair<const std::pair<Mimic::DOFFormat, int>, dReal>& keyvalue : mTotalderivativepairValue) {

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2120,24 +2120,17 @@ void KinBody::Joint::_ComputePartialVelocities(std::vector<std::pair<int, dReal>
         thisdofformat.jointindex = nActiveJoints + (std::find(begin(vPassiveJoints), end(vPassiveJoints), shared_from_this()) - begin(vPassiveJoints));
     }
 
-    bool bCached = false;
     for(const std::pair<const std::pair<Mimic::DOFFormat, int>, dReal>& keyvalue : mTotalderivativepairValue) {
         if( keyvalue.first.first == thisdofformat ) {
             if( IS_DEBUGLEVEL(Level_Verbose) ) {
                 RAVELOG_VERBOSE_FORMAT("Found cached derivatives of jointindex %d with respect to others", thisdofformat.jointindex);
             }
-            bCached = true;
-            break;
+            const int dependedJointIndex = keyvalue.first.second;
+            const dReal partialDerivative = keyvalue.second;
+            vDofindexDerivativePairs.emplace_back(dependedJointIndex, partialDerivative); // collect all dz/dx
         }
     }
-    if(bCached) {
-        for(const std::pair<const std::pair<Mimic::DOFFormat, int>, dReal> &keyvalue : mTotalderivativepairValue) {
-            if(keyvalue.first.first == thisdofformat) {
-                const int dependedJointIndex = keyvalue.first.second;
-                const dReal partialDerivative = keyvalue.second;
-                vDofindexDerivativePairs.emplace_back(dependedJointIndex, partialDerivative); // collect all dz/dx
-            }
-        }
+    if(!vDofindexDerivativePairs.empty()) {
         return;
     }
 

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2126,16 +2126,25 @@ void KinBody::Joint::_ComputePartialVelocities(std::vector<std::pair<int, dReal>
         thisdofformat.jointindex = nActiveJoints + (std::find(begin(vPassiveJoints), end(vPassiveJoints), shared_from_this()) - begin(vPassiveJoints));
     }
 
+    bool bCached = false;
     for(const std::pair<const std::pair<Mimic::DOFFormat, int>, dReal>& keyvalue : mTotalderivativepairValue) {
         if( keyvalue.first.first == thisdofformat ) {
             if( IS_DEBUGLEVEL(Level_Verbose) ) {
                 RAVELOG_VERBOSE_FORMAT("Found cached derivatives of jointindex %d with respect to others", thisdofformat.jointindex);
             }
-            const int dependedJointIndex = keyvalue.first.second;
-            const dReal partialDerivative = keyvalue.second;
-            vDofindexDerivativePairs.emplace_back(dependedJointIndex, partialDerivative); // collect all dz/dx
-            return;
+            bCached = true;
+            break;
         }
+    }
+    if(bCached) {
+        for(const std::pair<const std::pair<Mimic::DOFFormat, int>, dReal> &keyvalue : mTotalderivativepairValue) {
+            if(keyvalue.first.first == thisdofformat) {
+                const int dependedJointIndex = keyvalue.first.second;
+                const dReal partialDerivative = keyvalue.second;
+                vDofindexDerivativePairs.emplace_back(dependedJointIndex, partialDerivative); // collect all dz/dx
+            }
+        }
+        return;
     }
 
     /* ========== Collect values of joints on which joint z depends ========== */

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2033,13 +2033,7 @@ void KinBody::Joint::SetMimicEquations(int iaxis, const std::string& poseq, cons
          */
         utils::SearchAndReplace(eq, pmimic->_equations[itype], jointnamepairs);
         size_t index = eq.find('|');
-        std::string sCommonSubexpressions = (index != std::string::npos) ? eq.substr(0, index) : ""; ///< common subexpressions
-        if( !sCommonSubexpressions.empty() ) {
-            const size_t semicolonindex = sCommonSubexpressions.find_last_of(";"); // avoid double semicolons
-            if(semicolonindex != std::string::npos) {
-                sCommonSubexpressions += sCommonSubexpressions.substr(0, semicolonindex) + ';'; // just in case, separate out the equations
-            }
-        }
+        const std::string sCommonSubexpressions = (index != std::string::npos) ? eq.substr(0, index) : ""; ///< common subexpressions
 
         while(index != std::string::npos) {
             size_t startindex = index + 1;

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2035,7 +2035,10 @@ void KinBody::Joint::SetMimicEquations(int iaxis, const std::string& poseq, cons
         size_t index = eq.find('|');
         std::string sCommonSubexpressions = (index != std::string::npos) ? eq.substr(0, index) : ""; ///< common subexpressions
         if( !sCommonSubexpressions.empty() ) {
-            sCommonSubexpressions += ';'; // just in case, separate out the equations
+            const size_t semicolonindex = sCommonSubexpressions.find_last_of(";"); // avoid double semicolons
+            if(semicolonindex != std::string::npos) {
+                sCommonSubexpressions += sCommonSubexpressions.substr(0, semicolonindex) + ';'; // just in case, separate out the equations
+            }
         }
 
         while(index != std::string::npos) {


### PR DESCRIPTION
(1) Restored a section deleted in

https://github.com/rdiankov/openrave/commit/0537a3f3f5a585b70ceba1d4e911ae956a7787f8#diff-778da77d60fa92688d81b31bc756abdbL2131

(2) Resolved a case where we append `;` after an existing `;`.

https://github.com/rdiankov/openrave/pull/820/files#diff-778da77d60fa92688d81b31bc756abdbR2037

These two issues were introduced in #820, and were revealed by the ikfastcpp unit test.