### PR TITLE
Calibration board geometry type, visualization, and serialization for openrave viewer

### DIFF
--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -44,6 +44,7 @@ enum GeometryType {
     GT_TriMesh = 4,
     GT_Container=5, ///< a container shaped geometry that has inner and outer extents. container opens on +Z. The origin is at the bottom of the base.
     GT_Cage=6, ///< a container shaped geometry with removable side walls. The side walls can be on any of the four sides. The origin is at the bottom of the base. The inner volume of the cage is measured from the base to the highest wall.
+    GT_CalibrationBoard=7, ///< a box shaped geometry with grid of cylindrical dots of two sizes. The dots are always on the +z side of the box and are oriented towards z-axis.
 };
 
 enum DynamicsConstraintsType {

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -332,21 +332,21 @@ public:
         bool _bVisible = true; ///< if true, geometry is visible as part of the 3d model (default is true)
         bool _bModifiable = true; ///< if true, object geometry can be dynamically modified (default is true)
 
-        struct CalibrationBoardParams { ///< used by GT_CalibrationBoard
+        struct CalibrationBoardParameters { ///< used by GT_CalibrationBoard
             int numDotsX; ///< number of dots in x direction, minimum 3
             int numDotsY; ///< number of dots in y direction, minimum 3
-            float dotsDistanceX; ///< distance between center of dots in x direction
-            float dotsDistanceY; ///< distance between center of dots in y direction
-            RaveVector<float> dotColor; ///< color of dot mesh, which can differ from the color of the board mesh
+            dReal dotsDistanceX; ///< distance between center of dots in x direction
+            dReal dotsDistanceY; ///< distance between center of dots in y direction
+            RaveVector<dReal> dotColor; ///< color of dot mesh, which can differ from the color of the board mesh
             std::string patternName; ///< string that determines pattern of big and normal dots
                                      /// currently, the only supported type is "threeBigDotsDotGrid"
                                      /// any unsupported pattern will generate a full grid of normal dots
-            float dotDiameterDistanceRatio; ///< dot diameter divided by minimum of dot distances x and y
-            float bigDotDiameterDistanceRatio; ///< big dot diameter divided by minimum of dot distances x and y
+            dReal dotDiameterDistanceRatio; ///< dot diameter divided by minimum of dot distances x and y
+            dReal bigDotDiameterDistanceRatio; ///< big dot diameter divided by minimum of dot distances x and y
             ///< trimesh representation of the collision data of calibration board dot grid in this local coordinate system
             /// Shares the same caveats as _meshcollision.
             TriMesh _dotmeshcollision;
-            bool operator==(const CalibrationBoardParams& other) const {
+            bool operator==(const CalibrationBoardParameters& other) const {
                 return numDotsX == other.numDotsX
                        && numDotsY == other.numDotsY
                        && dotsDistanceX - other.dotsDistanceX < dotsDistanceX*g_fEpsilon
@@ -356,11 +356,11 @@ public:
                        && dotDiameterDistanceRatio - other.dotDiameterDistanceRatio < dotDiameterDistanceRatio*g_fEpsilon
                        && bigDotDiameterDistanceRatio - other.bigDotDiameterDistanceRatio < bigDotDiameterDistanceRatio*g_fEpsilon;
             }
-            bool operator!=(const CalibrationBoardParams& other) const {
+            bool operator!=(const CalibrationBoardParameters& other) const {
                 return !operator==(other);
             }
         };
-        CalibrationBoardParams _calibrationBoardParams;
+        CalibrationBoardParameters _calibrationBoardParams;
 
         /// \brief Generates the calibration board's dot grid mesh based on calibration board settings
         void GenerateCalibrationBoardDotMesh(float fTessellation=1);
@@ -607,7 +607,7 @@ public:
                 return _info._calibrationBoardParams._dotmeshcollision;
             }
             /// \brief returns the color of the calibration board's dot mesh
-            inline const RaveVector<float>& GetCalibrationBoardDotColor() const {
+            inline const RaveVector<dReal>& GetCalibrationBoardDotColor() const {
                 return _info._calibrationBoardParams.dotColor;
             }
             /// \brief returns x dimension (in dots) of the calibration board dot grid 
@@ -619,11 +619,11 @@ public:
                 return _info._calibrationBoardParams.numDotsY;
             }
             /// \brief returns x dot distance of the calibration board dot grid 
-            inline const float& GetCalibrationBoardDotsDistanceX() const {
+            inline const dReal& GetCalibrationBoardDotsDistanceX() const {
                 return _info._calibrationBoardParams.dotsDistanceX;
             }
             /// \brief returns y dot distance of the calibration board dot grid 
-            inline const float& GetCalibrationBoardDotsDistanceY() const {
+            inline const dReal& GetCalibrationBoardDotsDistanceY() const {
                 return _info._calibrationBoardParams.dotsDistanceY;
             }
             /// \brief returns pattern name of the calibration board dot grid 
@@ -631,11 +631,11 @@ public:
                 return _info._calibrationBoardParams.patternName;
             }
             /// \brief returns x dot distance of the calibration board dot grid 
-            inline const float& GetCalibrationBoardDotDiameterDistanceRatio() const {
+            inline const dReal& GetCalibrationBoardDotDiameterDistanceRatio() const {
                 return _info._calibrationBoardParams.dotDiameterDistanceRatio;
             }
             /// \brief returns x dot distance of the calibration board dot grid 
-            inline const float& GetCalibrationBoardBigDotDiameterDistanceRatio() const {
+            inline const dReal& GetCalibrationBoardBigDotDiameterDistanceRatio() const {
                 return _info._calibrationBoardParams.bigDotDiameterDistanceRatio;
             }
 

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -610,6 +610,34 @@ public:
             inline const RaveVector<float>& GetCalibrationBoardDotColor() const {
                 return _info._calibrationBoardParams.dotColor;
             }
+            /// \brief returns x dimension (in dots) of the calibration board dot grid 
+            inline const int& GetCalibrationBoardNumDotsX() const {
+                return _info._calibrationBoardParams.numDotsX;
+            }
+            /// \brief returns y dimension (in dots) of the calibration board dot grid 
+            inline const int& GetCalibrationBoardNumDotsY() const {
+                return _info._calibrationBoardParams.numDotsY;
+            }
+            /// \brief returns x dot distance of the calibration board dot grid 
+            inline const float& GetCalibrationBoardDotsDistanceX() const {
+                return _info._calibrationBoardParams.dotsDistanceX;
+            }
+            /// \brief returns y dot distance of the calibration board dot grid 
+            inline const float& GetCalibrationBoardDotsDistanceY() const {
+                return _info._calibrationBoardParams.dotsDistanceY;
+            }
+            /// \brief returns pattern name of the calibration board dot grid 
+            inline const std::string& GetCalibrationBoardPattern() const {
+                return _info._calibrationBoardParams.patternName;
+            }
+            /// \brief returns x dot distance of the calibration board dot grid 
+            inline const float& GetCalibrationBoardDotDiameterDistanceRatio() const {
+                return _info._calibrationBoardParams.dotDiameterDistanceRatio;
+            }
+            /// \brief returns x dot distance of the calibration board dot grid 
+            inline const float& GetCalibrationBoardBigDotDiameterDistanceRatio() const {
+                return _info._calibrationBoardParams.bigDotDiameterDistanceRatio;
+            }
 
 protected:
             boost::weak_ptr<Link> _parent;

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -337,8 +337,10 @@ public:
             int numDotsY; ///< number of dots in y direction, minimum 3
             float dotsDistanceX; ///< distance between center of dots in x direction
             float dotsDistanceY; ///< distance between center of dots in y direction
-            RaveVector<float> dotColor;
-            std::string patternName;
+            RaveVector<float> dotColor; ///< color of dot mesh, which can differ from the color of the board mesh
+            std::string patternName; ///< string that determines pattern of big and normal dots
+                                     /// currently, the only supported type is "threeBigDotsDotGrid"
+                                     /// any unsupported pattern will generate a full grid of normal dots
             float dotDiameterDistanceRatio; ///< dot diameter divided by minimum of dot distances x and y
             float bigDotDiameterDistanceRatio; ///< big dot diameter divided by minimum of dot distances x and y
             ///< trimesh representation of the collision data of calibration board dot grid in this local coordinate system
@@ -347,12 +349,12 @@ public:
             bool operator==(const CalibrationBoardParams& other) const {
                 return numDotsX == other.numDotsX
                        && numDotsY == other.numDotsY
-                       && dotsDistanceX == other.dotsDistanceX
-                       && dotsDistanceY == other.dotsDistanceY
+                       && dotsDistanceX - other.dotsDistanceX < dotsDistanceX*1e-7
+                       && dotsDistanceY - other.dotsDistanceY < dotsDistanceY*1e-7
                        && dotColor == other.dotColor
                        && patternName == other.patternName
-                       && dotDiameterDistanceRatio == other.dotDiameterDistanceRatio
-                       && bigDotDiameterDistanceRatio == other.bigDotDiameterDistanceRatio;
+                       && dotDiameterDistanceRatio - other.dotDiameterDistanceRatio < dotDiameterDistanceRatio*1e-7
+                       && bigDotDiameterDistanceRatio - other.bigDotDiameterDistanceRatio < bigDotDiameterDistanceRatio*1e-7;
             }
             bool operator!=(const CalibrationBoardParams& other) const {
                 return !operator==(other);
@@ -600,9 +602,11 @@ public:
             /// \brief sets the name of the geometry
             virtual void SetName(const std::string& name);
 
+            /// \brief returns the dot mesh of a calibration board
             inline const TriMesh& GetCalibrationBoardDotMesh() const {
                 return _info._calibrationBoardParams._dotmeshcollision;
             }
+            /// \brief returns the color of the calibration board's dot mesh
             inline const RaveVector<float>& GetCalibrationBoardDotColor() const {
                 return _info._calibrationBoardParams.dotColor;
             }

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -349,12 +349,12 @@ public:
             bool operator==(const CalibrationBoardParams& other) const {
                 return numDotsX == other.numDotsX
                        && numDotsY == other.numDotsY
-                       && dotsDistanceX - other.dotsDistanceX < dotsDistanceX*1e-7
-                       && dotsDistanceY - other.dotsDistanceY < dotsDistanceY*1e-7
+                       && dotsDistanceX - other.dotsDistanceX < dotsDistanceX*g_fEpsilon
+                       && dotsDistanceY - other.dotsDistanceY < dotsDistanceY*g_fEpsilon
                        && dotColor == other.dotColor
                        && patternName == other.patternName
-                       && dotDiameterDistanceRatio - other.dotDiameterDistanceRatio < dotDiameterDistanceRatio*1e-7
-                       && bigDotDiameterDistanceRatio - other.bigDotDiameterDistanceRatio < bigDotDiameterDistanceRatio*1e-7;
+                       && dotDiameterDistanceRatio - other.dotDiameterDistanceRatio < dotDiameterDistanceRatio*g_fEpsilon
+                       && bigDotDiameterDistanceRatio - other.bigDotDiameterDistanceRatio < bigDotDiameterDistanceRatio*g_fEpsilon;
             }
             bool operator!=(const CalibrationBoardParams& other) const {
                 return !operator==(other);

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -205,7 +205,7 @@ public:
                    && _fTransparency == other._fTransparency
                    && _bVisible == other._bVisible
                    && _bModifiable == other._bModifiable
-                   && _calibrationBoardParams == other._calibrationBoardParams;
+                   && _calibrationBoardParameters == other._calibrationBoardParameters;
         }
         bool operator!=(const GeometryInfo& other) const {
             return !operator==(other);
@@ -359,7 +359,7 @@ public:
                 return !operator==(other);
             }
         };
-        std::vector<CalibrationBoardParameters> _calibrationBoardParams;
+        std::vector<CalibrationBoardParameters> _calibrationBoardParameters;
 
         /// \brief Generates the calibration board's dot grid mesh based on calibration board settings
         void GenerateCalibrationBoardDotMesh(TriMesh& tri, float fTessellation=1);
@@ -607,57 +607,57 @@ public:
             }
             /// \brief returns the color of the calibration board's dot mesh
             inline const RaveVector<float>& GetCalibrationBoardDotColor() const {
-                if (_info._calibrationBoardParams.size() != 0) {
-                    return _info._calibrationBoardParams[0].dotColor;
+                if (_info._calibrationBoardParameters.size() != 0) {
+                    return _info._calibrationBoardParameters[0].dotColor;
                 }
                 return Vector(0, 0, 0);
             }
             /// \brief returns x dimension (in dots) of the calibration board dot grid 
             inline const int& GetCalibrationBoardNumDotsX() const {
-                if (_info._calibrationBoardParams.size() != 0) {
-                    return _info._calibrationBoardParams[0].numDotsX;
+                if (_info._calibrationBoardParameters.size() != 0) {
+                    return _info._calibrationBoardParameters[0].numDotsX;
                 }
                 return 0;
             }
             /// \brief returns y dimension (in dots) of the calibration board dot grid 
             inline const int& GetCalibrationBoardNumDotsY() const {
-                if (_info._calibrationBoardParams.size() != 0) {
-                    return _info._calibrationBoardParams[0].numDotsY;
+                if (_info._calibrationBoardParameters.size() != 0) {
+                    return _info._calibrationBoardParameters[0].numDotsY;
                 }
                 return 0;
             }
             /// \brief returns x dot distance of the calibration board dot grid 
             inline const dReal& GetCalibrationBoardDotsDistanceX() const {
-                if (_info._calibrationBoardParams.size() != 0) {
-                    return _info._calibrationBoardParams[0].dotsDistanceX;
+                if (_info._calibrationBoardParameters.size() != 0) {
+                    return _info._calibrationBoardParameters[0].dotsDistanceX;
                 }
                 return 0;
             }
             /// \brief returns y dot distance of the calibration board dot grid 
             inline const dReal& GetCalibrationBoardDotsDistanceY() const {
-                if (_info._calibrationBoardParams.size() != 0) {
-                    return _info._calibrationBoardParams[0].dotsDistanceY;
+                if (_info._calibrationBoardParameters.size() != 0) {
+                    return _info._calibrationBoardParameters[0].dotsDistanceY;
                 }
                 return 0;
             }
             /// \brief returns pattern name of the calibration board dot grid 
             inline const std::string& GetCalibrationBoardPatternName() const {
-                if (_info._calibrationBoardParams.size() != 0) {
-                    return _info._calibrationBoardParams[0].patternName;
+                if (_info._calibrationBoardParameters.size() != 0) {
+                    return _info._calibrationBoardParameters[0].patternName;
                 }
                 return "";
             }
             /// \brief returns x dot distance of the calibration board dot grid 
             inline const dReal& GetCalibrationBoardDotDiameterDistanceRatio() const {
-                if (_info._calibrationBoardParams.size() != 0) {
-                    return _info._calibrationBoardParams[0].dotDiameterDistanceRatio;
+                if (_info._calibrationBoardParameters.size() != 0) {
+                    return _info._calibrationBoardParameters[0].dotDiameterDistanceRatio;
                 }
                 return 0;
             }
             /// \brief returns x dot distance of the calibration board dot grid 
             inline const dReal& GetCalibrationBoardBigDotDiameterDistanceRatio() const {
-                if (_info._calibrationBoardParams.size() != 0) {
-                    return _info._calibrationBoardParams[0].bigDotDiameterDistanceRatio;
+                if (_info._calibrationBoardParameters.size() != 0) {
+                    return _info._calibrationBoardParameters[0].bigDotDiameterDistanceRatio;
                 }
                 return 0;
             }

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -204,7 +204,8 @@ public:
                    && _vCollisionScale == other._vCollisionScale
                    && _fTransparency == other._fTransparency
                    && _bVisible == other._bVisible
-                   && _bModifiable == other._bModifiable;
+                   && _bModifiable == other._bModifiable
+                   && _calibrationBoardParams == other._calibrationBoardParams;
         }
         bool operator!=(const GeometryInfo& other) const {
             return !operator==(other);
@@ -330,6 +331,31 @@ public:
         float _fTransparency = 0; ///< value from 0-1 for the transparency of the rendered object, 0 is opaque
         bool _bVisible = true; ///< if true, geometry is visible as part of the 3d model (default is true)
         bool _bModifiable = true; ///< if true, object geometry can be dynamically modified (default is true)
+
+        struct CalibrationBoardParams { ///< used by GT_CalibrationBoard
+            int numDotsX; ///< number of dots in x direction, minimum 3
+            int numDotsY; ///< number of dots in y direction, minimum 3
+            float dotsDistanceX; ///< distance between center of dots in x direction
+            float dotsDistanceY; ///< distance between center of dots in y direction
+            Vector dotColor;
+            std::string patternName;
+            float dotDiameterDistanceRatio; ///< dot diameter divided by minimum of dot distances x and y
+            float bigDotDiameterDistanceRatio; ///< big dot diameter divided by minimum of dot distances x and y
+            bool operator==(const CalibrationBoardParams& other) const {
+                return numDotsX == other.numDotsX
+                       && numDotsY == other.numDotsY
+                       && dotsDistanceX == other.dotsDistanceX
+                       && dotsDistanceY == other.dotsDistanceY
+                       && dotColor == other.dotColor
+                       && patternName == other.patternName
+                       && dotDiameterDistanceRatio == other.dotDiameterDistanceRatio
+                       && bigDotDiameterDistanceRatio == other.bigDotDiameterDistanceRatio;
+            }
+            bool operator!=(const CalibrationBoardParams& other) const {
+                return !operator==(other);
+            }
+        }
+        CalibrationBoardParams _calibrationBoardParams;
 
     };
     typedef boost::shared_ptr<GeometryInfo> GeometryInfoPtr;

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -627,7 +627,7 @@ public:
                 return _info._calibrationBoardParams.dotsDistanceY;
             }
             /// \brief returns pattern name of the calibration board dot grid 
-            inline const std::string& GetCalibrationBoardPattern() const {
+            inline const std::string& GetCalibrationBoardPatternName() const {
                 return _info._calibrationBoardParams.patternName;
             }
             /// \brief returns x dot distance of the calibration board dot grid 

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -333,37 +333,36 @@ public:
         bool _bModifiable = true; ///< if true, object geometry can be dynamically modified (default is true)
 
         struct CalibrationBoardParameters { ///< used by GT_CalibrationBoard
+            CalibrationBoardParameters() : numDotsX(3), numDotsY(3), dotsDistanceX(1), dotsDistanceY(1), patternName("threeBigDotsDotGrid"), dotDiameterDistanceRatio(0.25), bigDotDiameterDistanceRatio(0.5) {} ///< constructor
             int numDotsX; ///< number of dots in x direction, minimum 3
             int numDotsY; ///< number of dots in y direction, minimum 3
             dReal dotsDistanceX; ///< distance between center of dots in x direction
             dReal dotsDistanceY; ///< distance between center of dots in y direction
-            RaveVector<dReal> dotColor; ///< color of dot mesh, which can differ from the color of the board mesh
+            RaveVector<float> dotColor; ///< color of dot mesh, which can differ from the color of the board mesh
             std::string patternName; ///< string that determines pattern of big and normal dots
                                      /// currently, the only supported type is "threeBigDotsDotGrid"
                                      /// any unsupported pattern will generate a full grid of normal dots
             dReal dotDiameterDistanceRatio; ///< dot diameter divided by minimum of dot distances x and y
             dReal bigDotDiameterDistanceRatio; ///< big dot diameter divided by minimum of dot distances x and y
-            ///< trimesh representation of the collision data of calibration board dot grid in this local coordinate system
-            /// Shares the same caveats as _meshcollision.
-            TriMesh _dotmeshcollision;
+            int Compare(const CalibrationBoardParameters& other, dReal fEpsilon) const;
             bool operator==(const CalibrationBoardParameters& other) const {
                 return numDotsX == other.numDotsX
                        && numDotsY == other.numDotsY
-                       && dotsDistanceX - other.dotsDistanceX < dotsDistanceX*g_fEpsilon
-                       && dotsDistanceY - other.dotsDistanceY < dotsDistanceY*g_fEpsilon
+                       && dotsDistanceX == other.dotsDistanceX
+                       && dotsDistanceY == other.dotsDistanceY
                        && dotColor == other.dotColor
                        && patternName == other.patternName
-                       && dotDiameterDistanceRatio - other.dotDiameterDistanceRatio < dotDiameterDistanceRatio*g_fEpsilon
-                       && bigDotDiameterDistanceRatio - other.bigDotDiameterDistanceRatio < bigDotDiameterDistanceRatio*g_fEpsilon;
+                       && dotDiameterDistanceRatio == other.dotDiameterDistanceRatio
+                       && bigDotDiameterDistanceRatio == other.bigDotDiameterDistanceRatio;
             }
             bool operator!=(const CalibrationBoardParameters& other) const {
                 return !operator==(other);
             }
         };
-        CalibrationBoardParameters _calibrationBoardParams;
+        std::vector<CalibrationBoardParameters> _calibrationBoardParams;
 
         /// \brief Generates the calibration board's dot grid mesh based on calibration board settings
-        void GenerateCalibrationBoardDotMesh(float fTessellation=1);
+        void GenerateCalibrationBoardDotMesh(TriMesh& tri, float fTessellation=1);
 
     };
     typedef boost::shared_ptr<GeometryInfo> GeometryInfoPtr;
@@ -602,41 +601,65 @@ public:
             /// \brief sets the name of the geometry
             virtual void SetName(const std::string& name);
 
-            /// \brief returns the dot mesh of a calibration board
-            inline const TriMesh& GetCalibrationBoardDotMesh() const {
-                return _info._calibrationBoardParams._dotmeshcollision;
+            /// \brief generates the dot mesh of a calibration board
+            inline void GetCalibrationBoardDotMesh(TriMesh& tri) {
+                _info.GenerateCalibrationBoardDotMesh(tri);
             }
             /// \brief returns the color of the calibration board's dot mesh
-            inline const RaveVector<dReal>& GetCalibrationBoardDotColor() const {
-                return _info._calibrationBoardParams.dotColor;
+            inline const RaveVector<float>& GetCalibrationBoardDotColor() const {
+                if (_info._calibrationBoardParams.size() != 0) {
+                    return _info._calibrationBoardParams[0].dotColor;
+                }
+                return Vector(0, 0, 0);
             }
             /// \brief returns x dimension (in dots) of the calibration board dot grid 
             inline const int& GetCalibrationBoardNumDotsX() const {
-                return _info._calibrationBoardParams.numDotsX;
+                if (_info._calibrationBoardParams.size() != 0) {
+                    return _info._calibrationBoardParams[0].numDotsX;
+                }
+                return 0;
             }
             /// \brief returns y dimension (in dots) of the calibration board dot grid 
             inline const int& GetCalibrationBoardNumDotsY() const {
-                return _info._calibrationBoardParams.numDotsY;
+                if (_info._calibrationBoardParams.size() != 0) {
+                    return _info._calibrationBoardParams[0].numDotsY;
+                }
+                return 0;
             }
             /// \brief returns x dot distance of the calibration board dot grid 
             inline const dReal& GetCalibrationBoardDotsDistanceX() const {
-                return _info._calibrationBoardParams.dotsDistanceX;
+                if (_info._calibrationBoardParams.size() != 0) {
+                    return _info._calibrationBoardParams[0].dotsDistanceX;
+                }
+                return 0;
             }
             /// \brief returns y dot distance of the calibration board dot grid 
             inline const dReal& GetCalibrationBoardDotsDistanceY() const {
-                return _info._calibrationBoardParams.dotsDistanceY;
+                if (_info._calibrationBoardParams.size() != 0) {
+                    return _info._calibrationBoardParams[0].dotsDistanceY;
+                }
+                return 0;
             }
             /// \brief returns pattern name of the calibration board dot grid 
             inline const std::string& GetCalibrationBoardPatternName() const {
-                return _info._calibrationBoardParams.patternName;
+                if (_info._calibrationBoardParams.size() != 0) {
+                    return _info._calibrationBoardParams[0].patternName;
+                }
+                return "";
             }
             /// \brief returns x dot distance of the calibration board dot grid 
             inline const dReal& GetCalibrationBoardDotDiameterDistanceRatio() const {
-                return _info._calibrationBoardParams.dotDiameterDistanceRatio;
+                if (_info._calibrationBoardParams.size() != 0) {
+                    return _info._calibrationBoardParams[0].dotDiameterDistanceRatio;
+                }
+                return 0;
             }
             /// \brief returns x dot distance of the calibration board dot grid 
             inline const dReal& GetCalibrationBoardBigDotDiameterDistanceRatio() const {
-                return _info._calibrationBoardParams.bigDotDiameterDistanceRatio;
+                if (_info._calibrationBoardParams.size() != 0) {
+                    return _info._calibrationBoardParams[0].bigDotDiameterDistanceRatio;
+                }
+                return 0;
             }
 
 protected:

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -337,10 +337,13 @@ public:
             int numDotsY; ///< number of dots in y direction, minimum 3
             float dotsDistanceX; ///< distance between center of dots in x direction
             float dotsDistanceY; ///< distance between center of dots in y direction
-            Vector dotColor;
+            RaveVector<float> dotColor;
             std::string patternName;
             float dotDiameterDistanceRatio; ///< dot diameter divided by minimum of dot distances x and y
             float bigDotDiameterDistanceRatio; ///< big dot diameter divided by minimum of dot distances x and y
+            ///< trimesh representation of the collision data of calibration board dot grid in this local coordinate system
+            /// Shares the same caveats as _meshcollision.
+            TriMesh _dotmeshcollision;
             bool operator==(const CalibrationBoardParams& other) const {
                 return numDotsX == other.numDotsX
                        && numDotsY == other.numDotsY
@@ -354,8 +357,11 @@ public:
             bool operator!=(const CalibrationBoardParams& other) const {
                 return !operator==(other);
             }
-        }
+        };
         CalibrationBoardParams _calibrationBoardParams;
+
+        /// \brief Generates the calibration board's dot grid mesh based on calibration board settings
+        void GenerateCalibrationBoardDotMesh(float fTessellation=1);
 
     };
     typedef boost::shared_ptr<GeometryInfo> GeometryInfoPtr;
@@ -593,6 +599,13 @@ public:
 
             /// \brief sets the name of the geometry
             virtual void SetName(const std::string& name);
+
+            inline const TriMesh& GetCalibrationBoardDotMesh() const {
+                return _info._calibrationBoardParams._dotmeshcollision;
+            }
+            inline const RaveVector<float>& GetCalibrationBoardDotColor() const {
+                return _info._calibrationBoardParams.dotColor;
+            }
 
 protected:
             boost::weak_ptr<Link> _parent;

--- a/plugins/fclrave/fclspace.h
+++ b/plugins/fclrave/fclspace.h
@@ -585,6 +585,7 @@ private:
         case OpenRAVE::GT_None:
             return CollisionGeometryPtr();
 
+        case OpenRAVE::GT_CalibrationBoard:
         case OpenRAVE::GT_Box:
             return make_shared<fcl::Box>(info._vGeomData.x*2.0f,info._vGeomData.y*2.0f,info._vGeomData.z*2.0f);
 

--- a/plugins/qtosgrave/osgrenderitem.cpp
+++ b/plugins/qtosgrave/osgrenderitem.cpp
@@ -469,7 +469,7 @@ void KinBodyItem::Load()
                     pgeometrydata->addChild(geode);
                     break;
                 }
-                //  Board is a Box, dots are a separate Mesh
+                // Board is a Box, dots are a separate Mesh from the board's collision Mesh
                 case GT_CalibrationBoard: {
                     // Make board
                     Vector v;
@@ -501,6 +501,7 @@ void KinBodyItem::Load()
                     dotMat->setDiffuse( osg::Material::FRONT, osg::Vec4f(dotColor.x,dotColor.y,dotColor.z,1) );
                     dotMat->setDiffuse( osg::Material::FRONT_AND_BACK, osg::Vec4f(x,y,z,w) );
                     dotMat->setEmission(osg::Material::FRONT, osg::Vec4(0.0, 0.0, 0.0, 1.0));
+                    
                     // Place the two parts into the same pgeometrydata
                     osg::ref_ptr<osg::Geode> geode = new osg::Geode;
                     osg::ref_ptr<osg::ShapeDrawable> sd = new osg::ShapeDrawable(board.get());

--- a/plugins/qtosgrave/osgrenderitem.cpp
+++ b/plugins/qtosgrave/osgrenderitem.cpp
@@ -474,6 +474,7 @@ void KinBodyItem::Load()
                     // Make board
                     Vector v;
                     osg::ref_ptr<osg::Box> board = new osg::Box();
+                    board->setCenter(osg::Vec3f(0, 0, -orgeom->GetBoxExtents().z));
                     board->setHalfLengths(osg::Vec3f(orgeom->GetBoxExtents().x,orgeom->GetBoxExtents().y,orgeom->GetBoxExtents().z));
 
                     // Make dot mesh

--- a/plugins/qtosgrave/osgrenderitem.cpp
+++ b/plugins/qtosgrave/osgrenderitem.cpp
@@ -479,7 +479,8 @@ void KinBodyItem::Load()
                     // Make dot mesh
                     osg::ref_ptr<osg::Geometry> geom = new osg::Geometry;
 
-                    const TriMesh& mesh = orgeom->GetCalibrationBoardDotMesh();
+                    TriMesh mesh = TriMesh();
+                    orgeom->GetCalibrationBoardDotMesh(mesh);
                     osg::ref_ptr<osg::Vec3Array> vertices = new osg::Vec3Array();
                     vertices->reserveArray(mesh.vertices.size());
                     for(size_t i = 0; i < mesh.vertices.size(); ++i) {
@@ -496,7 +497,7 @@ void KinBodyItem::Load()
                     osgUtil::SmoothingVisitor::smooth(*geom);
 
                     // Set color of dot grid mesh
-                    RaveVector<dReal> dotColor = orgeom->GetCalibrationBoardDotColor();
+                    RaveVector<float> dotColor = orgeom->GetCalibrationBoardDotColor();
                     osg::ref_ptr<osg::Material> dotMat = new osg::Material;
                     dotMat->setDiffuse( osg::Material::FRONT, osg::Vec4(dotColor.x,dotColor.y,dotColor.z,1) );
                     dotMat->setAmbient( osg::Material::FRONT_AND_BACK, osg::Vec4f(x,y,z,1) );

--- a/plugins/qtosgrave/osgrenderitem.cpp
+++ b/plugins/qtosgrave/osgrenderitem.cpp
@@ -496,9 +496,9 @@ void KinBodyItem::Load()
                     osgUtil::SmoothingVisitor::smooth(*geom);
 
                     // Set color of dot grid mesh
-                    RaveVector<float> dotColor = orgeom->GetCalibrationBoardDotColor();
+                    RaveVector<dReal> dotColor = orgeom->GetCalibrationBoardDotColor();
                     osg::ref_ptr<osg::Material> dotMat = new osg::Material;
-                    dotMat->setDiffuse( osg::Material::FRONT, osg::Vec4f(dotColor.x,dotColor.y,dotColor.z,1) );
+                    dotMat->setDiffuse( osg::Material::FRONT, osg::Vec4(dotColor.x,dotColor.y,dotColor.z,1) );
                     dotMat->setAmbient( osg::Material::FRONT_AND_BACK, osg::Vec4f(x,y,z,1) );
                     dotMat->setEmission(osg::Material::FRONT, osg::Vec4(0.0, 0.0, 0.0, 1.0));
                     

--- a/plugins/qtosgrave/osgrenderitem.cpp
+++ b/plugins/qtosgrave/osgrenderitem.cpp
@@ -499,7 +499,7 @@ void KinBodyItem::Load()
                     RaveVector<float> dotColor = orgeom->GetCalibrationBoardDotColor();
                     osg::ref_ptr<osg::Material> dotMat = new osg::Material;
                     dotMat->setDiffuse( osg::Material::FRONT, osg::Vec4f(dotColor.x,dotColor.y,dotColor.z,1) );
-                    dotMat->setDiffuse( osg::Material::FRONT_AND_BACK, osg::Vec4f(x,y,z,w) );
+                    dotMat->setAmbient( osg::Material::FRONT_AND_BACK, osg::Vec4f(x,y,z,1) );
                     dotMat->setEmission(osg::Material::FRONT, osg::Vec4(0.0, 0.0, 0.0, 1.0));
                     
                     // Place the two parts into the same pgeometrydata
@@ -509,7 +509,6 @@ void KinBodyItem::Load()
                     osg::ref_ptr<osg::Geode> geode2 = new osg::Geode;
                     geode2->addDrawable(geom);
                     osg::ref_ptr<osg::StateSet> state = geode2->getOrCreateStateSet();
-                    state->setAttributeAndModes(mat, osg::StateAttribute::OFF | osg::StateAttribute::PROTECTED);
                     state->setAttributeAndModes(dotMat, osg::StateAttribute::ON | osg::StateAttribute::PROTECTED);
 
                     pgeometrydata->addChild(geode.get());

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -71,7 +71,7 @@ public:
     float _fTransparency = 0.0;
     bool _bVisible = true;
     bool _bModifiable = true;
-    object _calibrationBoardParams = py::make_tuple(0, 0, 0.0f, 0.0f, toPyVector3(Vector(0,0,0)), "", 0.0, 0.0);
+    py::dict _calibrationBoardParams;
 };
 
 typedef OPENRAVE_SHARED_PTR<PyGeometryInfo> PyGeometryInfoPtr;
@@ -265,11 +265,11 @@ public:
         float GetTransparency() const;
         object GetDiffuseColor() const;
         object GetAmbientColor() const;
-        object GetCalibrationBoardGridSize() const;
-        object GetCalibrationBoardDotsDistance() const;
+        object GetCalibrationBoardNumDots() const;
+        object GetCalibrationBoardDotsDistances() const;
         object GetCalibrationBoardDotColor() const;
-        object GetCalibrationBoardPattern() const;
-        object GetCalibrationBoardDotRatios() const;
+        object GetCalibrationBoardPatternName() const;
+        object GetCalibrationBoardDotDiameterDistanceRatios() const;
         object GetInfo();
         object ComputeInnerEmptyVolume() const;
         bool __eq__(OPENRAVE_SHARED_PTR<PyGeometry> p);

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -71,7 +71,7 @@ public:
     float _fTransparency = 0.0;
     bool _bVisible = true;
     bool _bModifiable = true;
-    py::dict _calibrationBoardParams;
+    py::dict _calibrationBoardParameters;
 };
 
 typedef OPENRAVE_SHARED_PTR<PyGeometryInfo> PyGeometryInfoPtr;

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -252,7 +252,7 @@ public:
         object GetTransform();
         object GetTransformPose();
         dReal GetSphereRadius() const;
-        dReal GetCylinderRadius() const ;
+        dReal GetCylinderRadius() const;
         dReal GetCylinderHeight() const;
         object GetBoxExtents() const;
         object GetContainerOuterExtents() const;
@@ -265,6 +265,11 @@ public:
         float GetTransparency() const;
         object GetDiffuseColor() const;
         object GetAmbientColor() const;
+        object GetCalibrationBoardGridSize() const;
+        object GetCalibrationBoardDotsDistance() const;
+        object GetCalibrationBoardDotColor() const;
+        object GetCalibrationBoardPattern() const;
+        object GetCalibrationBoardDotRatios() const;
         object GetInfo();
         object ComputeInnerEmptyVolume() const;
         bool __eq__(OPENRAVE_SHARED_PTR<PyGeometry> p);

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -71,6 +71,7 @@ public:
     float _fTransparency = 0.0;
     bool _bVisible = true;
     bool _bModifiable = true;
+    object _calibrationBoardParams = py::make_tuple(0, 0, 0.0f, 0.0f, toPyVector3(Vector(0,0,0)), "", 0.0, 0.0);
 };
 
 typedef OPENRAVE_SHARED_PTR<PyGeometryInfo> PyGeometryInfoPtr;

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -289,18 +289,18 @@ void PyGeometryInfo::Init(const KinBody::GeometryInfo& info) {
     _fTransparency = info._fTransparency;
     _bVisible = info._bVisible;
     _bModifiable = info._bModifiable;
-    py::dict calibrationBoardParams;
+    py::dict calibrationBoardParameters;
     if (info._type == GT_CalibrationBoard) {  
-        KinBody::GeometryInfo::CalibrationBoardParameters params = info._calibrationBoardParams.size() > 0 ? info._calibrationBoardParams[0] : KinBody::GeometryInfo::CalibrationBoardParameters();
-        calibrationBoardParams["numDotsX"] = params.numDotsX;
-        calibrationBoardParams["numDotsY"] = params.numDotsY;
-        calibrationBoardParams["dotsDistanceX"] = params.dotsDistanceX;
-        calibrationBoardParams["dotsDistanceY"] = params.dotsDistanceY;
-        calibrationBoardParams["dotColor"] = toPyVector3(params.dotColor);
-        calibrationBoardParams["patternName"] = ConvertStringToUnicode(params.patternName);
-        calibrationBoardParams["dotDiameterDistanceRatio"] = params.dotDiameterDistanceRatio;
-        calibrationBoardParams["bigDotDiameterDistanceRatio"] = params.bigDotDiameterDistanceRatio;
-        _calibrationBoardParams = calibrationBoardParams;
+        KinBody::GeometryInfo::CalibrationBoardParameters parameters = info._calibrationBoardParameters.size() > 0 ? info._calibrationBoardParameters[0] : KinBody::GeometryInfo::CalibrationBoardParameters();
+        calibrationBoardParameters["numDotsX"] = parameters.numDotsX;
+        calibrationBoardParameters["numDotsY"] = parameters.numDotsY;
+        calibrationBoardParameters["dotsDistanceX"] = parameters.dotsDistanceX;
+        calibrationBoardParameters["dotsDistanceY"] = parameters.dotsDistanceY;
+        calibrationBoardParameters["dotColor"] = toPyVector3(parameters.dotColor);
+        calibrationBoardParameters["patternName"] = ConvertStringToUnicode(parameters.patternName);
+        calibrationBoardParameters["dotDiameterDistanceRatio"] = parameters.dotDiameterDistanceRatio;
+        calibrationBoardParameters["bigDotDiameterDistanceRatio"] = parameters.bigDotDiameterDistanceRatio;
+        _calibrationBoardParameters = calibrationBoardParameters;
     }
 }
 
@@ -378,15 +378,15 @@ KinBody::GeometryInfoPtr PyGeometryInfo::GetGeometryInfo() {
     info._bVisible = _bVisible;
     info._bModifiable = _bModifiable;
     if (info._type == GT_CalibrationBoard) {
-        info._calibrationBoardParams.push_back(KinBody::GeometryInfo::CalibrationBoardParameters());
-        info._calibrationBoardParams[0].numDotsX = py::extract<int>(_calibrationBoardParams["numDotsX"]);
-        info._calibrationBoardParams[0].numDotsY = py::extract<int>(_calibrationBoardParams["numDotsY"]);
-        info._calibrationBoardParams[0].dotsDistanceX = py::extract<float>(_calibrationBoardParams["dotsDistanceX"]);
-        info._calibrationBoardParams[0].dotsDistanceY = py::extract<float>(_calibrationBoardParams["dotsDistanceY"]);
-        info._calibrationBoardParams[0].dotColor = ExtractVector34<dReal>(_calibrationBoardParams["dotColor"],0);
-        info._calibrationBoardParams[0].patternName = py::extract<std::string>(_calibrationBoardParams["patternName"]);
-        info._calibrationBoardParams[0].dotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams["dotDiameterDistanceRatio"]);
-        info._calibrationBoardParams[0].bigDotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams["bigDotDiameterDistanceRatio"]);
+        info._calibrationBoardParameters.push_back(KinBody::GeometryInfo::CalibrationBoardParameters());
+        info._calibrationBoardParameters[0].numDotsX = py::extract<int>(_calibrationBoardParameters["numDotsX"]);
+        info._calibrationBoardParameters[0].numDotsY = py::extract<int>(_calibrationBoardParameters["numDotsY"]);
+        info._calibrationBoardParameters[0].dotsDistanceX = py::extract<float>(_calibrationBoardParameters["dotsDistanceX"]);
+        info._calibrationBoardParameters[0].dotsDistanceY = py::extract<float>(_calibrationBoardParameters["dotsDistanceY"]);
+        info._calibrationBoardParameters[0].dotColor = ExtractVector34<dReal>(_calibrationBoardParameters["dotColor"],0);
+        info._calibrationBoardParameters[0].patternName = py::extract<std::string>(_calibrationBoardParameters["patternName"]);
+        info._calibrationBoardParameters[0].dotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParameters["dotDiameterDistanceRatio"]);
+        info._calibrationBoardParameters[0].bigDotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParameters["bigDotDiameterDistanceRatio"]);
     }
     return pinfo;
 }
@@ -4014,7 +4014,7 @@ public:
             r._fTransparency,
             r._bVisible,
             r._bModifiable,
-            r._calibrationBoardParams
+            r._calibrationBoardParameters
             );
     }
     static void setstate(PyGeometryInfo& r, py::tuple state) {
@@ -4059,7 +4059,7 @@ public:
             r._bModifiable = py::extract<bool>(state[11]);
         }
         if (r._type == GT_CalibrationBoard) {
-            r._calibrationBoardParams = (py::dict) state[12];
+            r._calibrationBoardParameters = (py::dict) state[12];
         }
     }
 };
@@ -4518,7 +4518,7 @@ void init_openravepy_kinbody()
                           .def_readwrite("_bVisible",&PyGeometryInfo::_bVisible)
                           .def_readwrite("_bModifiable",&PyGeometryInfo::_bModifiable)
                           .def_readwrite("_vSideWalls", &PyGeometryInfo::_vSideWalls)
-                          .def_readwrite("_calibrationBoardParameters", &PyGeometryInfo::_calibrationBoardParams)
+                          .def_readwrite("_calibrationBoardParameters", &PyGeometryInfo::_calibrationBoardParameters)
                           .def("ComputeInnerEmptyVolume",&PyGeometryInfo::ComputeInnerEmptyVolume, DOXY_FN(GeomeryInfo,ComputeInnerEmptyVolume))
                           .def("ComputeAABB",&PyGeometryInfo::ComputeAABB, PY_ARGS("transform") DOXY_FN(GeomeryInfo,ComputeAABB))
 #ifdef USE_PYBIND11_PYTHON_BINDINGS

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -289,7 +289,7 @@ void PyGeometryInfo::Init(const KinBody::GeometryInfo& info) {
     _fTransparency = info._fTransparency;
     _bVisible = info._bVisible;
     _bModifiable = info._bModifiable;
-    KinBody::GeometryInfo::CalibrationBoardParams params = info._calibrationBoardParams;
+    KinBody::GeometryInfo::CalibrationBoardParameters params = info._calibrationBoardParams;
     _calibrationBoardParams = py::make_tuple(params.numDotsX,
                                              params.numDotsY,
                                              params.dotsDistanceX, 

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -289,17 +289,19 @@ void PyGeometryInfo::Init(const KinBody::GeometryInfo& info) {
     _fTransparency = info._fTransparency;
     _bVisible = info._bVisible;
     _bModifiable = info._bModifiable;
-    KinBody::GeometryInfo::CalibrationBoardParameters params = info._calibrationBoardParams;
     py::dict calibrationBoardParams;
-    calibrationBoardParams["numDotsX"] = params.numDotsX;
-    calibrationBoardParams["numDotsY"] = params.numDotsY;
-    calibrationBoardParams["dotsDistanceX"] = params.dotsDistanceX;
-    calibrationBoardParams["dotsDistanceY"] = params.dotsDistanceY;
-    calibrationBoardParams["dotColor"] = toPyVector3(params.dotColor);
-    calibrationBoardParams["patternName"] = ConvertStringToUnicode(params.patternName);
-    calibrationBoardParams["dotDiameterDistanceRatio"] = params.dotDiameterDistanceRatio;
-    calibrationBoardParams["bigDotDiameterDistanceRatio"] = params.bigDotDiameterDistanceRatio;
-    _calibrationBoardParams = calibrationBoardParams;
+    if (info._type == GT_CalibrationBoard) {  
+        KinBody::GeometryInfo::CalibrationBoardParameters params = info._calibrationBoardParams.size() > 0 ? info._calibrationBoardParams[0] : KinBody::GeometryInfo::CalibrationBoardParameters();
+        calibrationBoardParams["numDotsX"] = params.numDotsX;
+        calibrationBoardParams["numDotsY"] = params.numDotsY;
+        calibrationBoardParams["dotsDistanceX"] = params.dotsDistanceX;
+        calibrationBoardParams["dotsDistanceY"] = params.dotsDistanceY;
+        calibrationBoardParams["dotColor"] = toPyVector3(params.dotColor);
+        calibrationBoardParams["patternName"] = ConvertStringToUnicode(params.patternName);
+        calibrationBoardParams["dotDiameterDistanceRatio"] = params.dotDiameterDistanceRatio;
+        calibrationBoardParams["bigDotDiameterDistanceRatio"] = params.bigDotDiameterDistanceRatio;
+        _calibrationBoardParams = calibrationBoardParams;
+    }
 }
 
 object PyGeometryInfo::ComputeInnerEmptyVolume()
@@ -375,14 +377,17 @@ KinBody::GeometryInfoPtr PyGeometryInfo::GetGeometryInfo() {
     info._fTransparency = _fTransparency;
     info._bVisible = _bVisible;
     info._bModifiable = _bModifiable;
-    info._calibrationBoardParams.numDotsX = py::extract<int>(_calibrationBoardParams["numDotsX"]);
-    info._calibrationBoardParams.numDotsY = py::extract<int>(_calibrationBoardParams["numDotsY"]);
-    info._calibrationBoardParams.dotsDistanceX = py::extract<float>(_calibrationBoardParams["dotsDistanceX"]);
-    info._calibrationBoardParams.dotsDistanceY = py::extract<float>(_calibrationBoardParams["dotsDistanceY"]);
-    info._calibrationBoardParams.dotColor = ExtractVector34<dReal>(_calibrationBoardParams["dotColor"],0);
-    info._calibrationBoardParams.patternName = py::extract<std::string>(_calibrationBoardParams["patternName"]);
-    info._calibrationBoardParams.dotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams["dotDiameterDistanceRatio"]);
-    info._calibrationBoardParams.bigDotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams["bigDotDiameterDistanceRatio"]);
+    if (info._type == GT_CalibrationBoard) {
+        info._calibrationBoardParams.push_back(KinBody::GeometryInfo::CalibrationBoardParameters());
+        info._calibrationBoardParams[0].numDotsX = py::extract<int>(_calibrationBoardParams["numDotsX"]);
+        info._calibrationBoardParams[0].numDotsY = py::extract<int>(_calibrationBoardParams["numDotsY"]);
+        info._calibrationBoardParams[0].dotsDistanceX = py::extract<float>(_calibrationBoardParams["dotsDistanceX"]);
+        info._calibrationBoardParams[0].dotsDistanceY = py::extract<float>(_calibrationBoardParams["dotsDistanceY"]);
+        info._calibrationBoardParams[0].dotColor = ExtractVector34<dReal>(_calibrationBoardParams["dotColor"],0);
+        info._calibrationBoardParams[0].patternName = py::extract<std::string>(_calibrationBoardParams["patternName"]);
+        info._calibrationBoardParams[0].dotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams["dotDiameterDistanceRatio"]);
+        info._calibrationBoardParams[0].bigDotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams["bigDotDiameterDistanceRatio"]);
+    }
     return pinfo;
 }
 
@@ -4513,7 +4518,7 @@ void init_openravepy_kinbody()
                           .def_readwrite("_bVisible",&PyGeometryInfo::_bVisible)
                           .def_readwrite("_bModifiable",&PyGeometryInfo::_bModifiable)
                           .def_readwrite("_vSideWalls", &PyGeometryInfo::_vSideWalls)
-                          .def_readwrite("_calibrationBoardParams", &PyGeometryInfo::_calibrationBoardParams)
+                          .def_readwrite("_calibrationBoardParameters", &PyGeometryInfo::_calibrationBoardParams)
                           .def("ComputeInnerEmptyVolume",&PyGeometryInfo::ComputeInnerEmptyVolume, DOXY_FN(GeomeryInfo,ComputeInnerEmptyVolume))
                           .def("ComputeAABB",&PyGeometryInfo::ComputeAABB, PY_ARGS("transform") DOXY_FN(GeomeryInfo,ComputeAABB))
 #ifdef USE_PYBIND11_PYTHON_BINDINGS

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -290,14 +290,16 @@ void PyGeometryInfo::Init(const KinBody::GeometryInfo& info) {
     _bVisible = info._bVisible;
     _bModifiable = info._bModifiable;
     KinBody::GeometryInfo::CalibrationBoardParameters params = info._calibrationBoardParams;
-    _calibrationBoardParams = py::make_tuple(params.numDotsX,
-                                             params.numDotsY,
-                                             params.dotsDistanceX, 
-                                             params.dotsDistanceY,
-                                             toPyVector3(params.dotColor),
-                                             ConvertStringToUnicode(params.patternName),
-                                             params.dotDiameterDistanceRatio,
-                                             params.bigDotDiameterDistanceRatio);
+    py::dict calibrationBoardParams;
+    calibrationBoardParams["numDotsX"] = params.numDotsX;
+    calibrationBoardParams["numDotsY"] = params.numDotsY;
+    calibrationBoardParams["dotsDistanceX"] = params.dotsDistanceX;
+    calibrationBoardParams["dotsDistanceY"] = params.dotsDistanceY;
+    calibrationBoardParams["dotColor"] = toPyVector3(params.dotColor);
+    calibrationBoardParams["patternName"] = ConvertStringToUnicode(params.patternName);
+    calibrationBoardParams["dotDiameterDistanceRatio"] = params.dotDiameterDistanceRatio;
+    calibrationBoardParams["bigDotDiameterDistanceRatio"] = params.bigDotDiameterDistanceRatio;
+    _calibrationBoardParams = calibrationBoardParams;
 }
 
 object PyGeometryInfo::ComputeInnerEmptyVolume()
@@ -373,14 +375,14 @@ KinBody::GeometryInfoPtr PyGeometryInfo::GetGeometryInfo() {
     info._fTransparency = _fTransparency;
     info._bVisible = _bVisible;
     info._bModifiable = _bModifiable;
-    info._calibrationBoardParams.numDotsX = py::extract<int>(_calibrationBoardParams[0]);
-    info._calibrationBoardParams.numDotsY = py::extract<int>(_calibrationBoardParams[1]);
-    info._calibrationBoardParams.dotsDistanceX = py::extract<float>(_calibrationBoardParams[2]);
-    info._calibrationBoardParams.dotsDistanceY = py::extract<float>(_calibrationBoardParams[3]);
-    info._calibrationBoardParams.dotColor = ExtractVector34<dReal>(_calibrationBoardParams[4],0);
-    info._calibrationBoardParams.patternName = py::extract<std::string>(_calibrationBoardParams[5]);
-    info._calibrationBoardParams.dotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams[6]);
-    info._calibrationBoardParams.bigDotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams[7]);
+    info._calibrationBoardParams.numDotsX = py::extract<int>(_calibrationBoardParams["numDotsX"]);
+    info._calibrationBoardParams.numDotsY = py::extract<int>(_calibrationBoardParams["numDotsY"]);
+    info._calibrationBoardParams.dotsDistanceX = py::extract<float>(_calibrationBoardParams["dotsDistanceX"]);
+    info._calibrationBoardParams.dotsDistanceY = py::extract<float>(_calibrationBoardParams["dotsDistanceY"]);
+    info._calibrationBoardParams.dotColor = ExtractVector34<dReal>(_calibrationBoardParams["dotColor"],0);
+    info._calibrationBoardParams.patternName = py::extract<std::string>(_calibrationBoardParams["patternName"]);
+    info._calibrationBoardParams.dotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams["dotDiameterDistanceRatio"]);
+    info._calibrationBoardParams.bigDotDiameterDistanceRatio = py::extract<float>(_calibrationBoardParams["bigDotDiameterDistanceRatio"]);
     return pinfo;
 }
 
@@ -1272,19 +1274,19 @@ object PyLink::PyGeometry::GetAmbientColor() const {
 object PyLink::PyGeometry::GetInfo() {
     return py::to_object(PyGeometryInfoPtr(new PyGeometryInfo(_pgeometry->GetInfo())));
 }
-object PyLink::PyGeometry::GetCalibrationBoardGridSize() const {
+object PyLink::PyGeometry::GetCalibrationBoardNumDots() const {
     return py::make_tuple(_pgeometry->GetCalibrationBoardNumDotsX(), _pgeometry->GetCalibrationBoardNumDotsY());
 }
-object PyLink::PyGeometry::GetCalibrationBoardDotsDistance() const {
+object PyLink::PyGeometry::GetCalibrationBoardDotsDistances() const {
     return py::make_tuple(_pgeometry->GetCalibrationBoardDotsDistanceX(), _pgeometry->GetCalibrationBoardDotsDistanceY());
 }
 object PyLink::PyGeometry::GetCalibrationBoardDotColor() const {
     return toPyVector3(_pgeometry->GetCalibrationBoardDotColor());
 }
-object PyLink::PyGeometry::GetCalibrationBoardPattern() const {
-    return ConvertStringToUnicode(_pgeometry->GetCalibrationBoardPattern());
+object PyLink::PyGeometry::GetCalibrationBoardPatternName() const {
+    return ConvertStringToUnicode(_pgeometry->GetCalibrationBoardPatternName());
 }
-object PyLink::PyGeometry::GetCalibrationBoardDotRatios() const {
+object PyLink::PyGeometry::GetCalibrationBoardDotDiameterDistanceRatios() const {
     return py::make_tuple(_pgeometry->GetCalibrationBoardDotDiameterDistanceRatio(), _pgeometry->GetCalibrationBoardBigDotDiameterDistanceRatio());
 }
 object PyLink::PyGeometry::ComputeInnerEmptyVolume() const
@@ -4052,7 +4054,7 @@ public:
             r._bModifiable = py::extract<bool>(state[11]);
         }
         if (r._type == GT_CalibrationBoard) {
-            r._calibrationBoardParams = state[12];
+            r._calibrationBoardParams = (py::dict) state[12];
         }
     }
 };
@@ -5478,11 +5480,11 @@ void init_openravepy_kinbody()
                                   .def("GetTransparency",&PyLink::PyGeometry::GetTransparency,DOXY_FN(KinBody::Link::Geometry,GetTransparency))
                                   .def("GetDiffuseColor",&PyLink::PyGeometry::GetDiffuseColor,DOXY_FN(KinBody::Link::Geometry,GetDiffuseColor))
                                   .def("GetAmbientColor",&PyLink::PyGeometry::GetAmbientColor,DOXY_FN(KinBody::Link::Geometry,GetAmbientColor))
-                                  .def("GetCalibrationBoardGridSize",&PyLink::PyGeometry::GetCalibrationBoardGridSize, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardGridSize))
-                                  .def("GetCalibrationBoardDotsDistance",&PyLink::PyGeometry::GetCalibrationBoardDotsDistance, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardDotsDistance))
+                                  .def("GetCalibrationBoardNumDots",&PyLink::PyGeometry::GetCalibrationBoardNumDots, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardNumDots))
+                                  .def("GetCalibrationBoardDotsDistances",&PyLink::PyGeometry::GetCalibrationBoardDotsDistances, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardDotsDistances))
                                   .def("GetCalibrationBoardDotColor",&PyLink::PyGeometry::GetCalibrationBoardDotColor, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardDotColor))
-                                  .def("GetCalibrationBoardPattern",&PyLink::PyGeometry::GetCalibrationBoardPattern, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardPattern))
-                                  .def("GetCalibrationBoardDotRatios",&PyLink::PyGeometry::GetCalibrationBoardDotRatios, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardDotRatios))
+                                  .def("GetCalibrationBoardPatternName",&PyLink::PyGeometry::GetCalibrationBoardPatternName, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardPatternName))
+                                  .def("GetCalibrationBoardDotDiameterDistanceRatios",&PyLink::PyGeometry::GetCalibrationBoardDotDiameterDistanceRatios, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardDotDiameterDistanceRatios))
                                   .def("ComputeInnerEmptyVolume",&PyLink::PyGeometry::ComputeInnerEmptyVolume,DOXY_FN(KinBody::Link::Geometry,ComputeInnerEmptyVolume))
                                   .def("GetInfo",&PyLink::PyGeometry::GetInfo,DOXY_FN(KinBody::Link::Geometry,GetInfo))
                                   .def("__eq__",&PyLink::PyGeometry::__eq__)

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -1272,6 +1272,21 @@ object PyLink::PyGeometry::GetAmbientColor() const {
 object PyLink::PyGeometry::GetInfo() {
     return py::to_object(PyGeometryInfoPtr(new PyGeometryInfo(_pgeometry->GetInfo())));
 }
+object PyLink::PyGeometry::GetCalibrationBoardGridSize() const {
+    return py::make_tuple(_pgeometry->GetCalibrationBoardNumDotsX(), _pgeometry->GetCalibrationBoardNumDotsY());
+}
+object PyLink::PyGeometry::GetCalibrationBoardDotsDistance() const {
+    return py::make_tuple(_pgeometry->GetCalibrationBoardDotsDistanceX(), _pgeometry->GetCalibrationBoardDotsDistanceY());
+}
+object PyLink::PyGeometry::GetCalibrationBoardDotColor() const {
+    return toPyVector3(_pgeometry->GetCalibrationBoardDotColor());
+}
+object PyLink::PyGeometry::GetCalibrationBoardPattern() const {
+    return ConvertStringToUnicode(_pgeometry->GetCalibrationBoardPattern());
+}
+object PyLink::PyGeometry::GetCalibrationBoardDotRatios() const {
+    return py::make_tuple(_pgeometry->GetCalibrationBoardDotDiameterDistanceRatio(), _pgeometry->GetCalibrationBoardBigDotDiameterDistanceRatio());
+}
 object PyLink::PyGeometry::ComputeInnerEmptyVolume() const
 {
     Transform tInnerEmptyVolume;
@@ -5463,6 +5478,11 @@ void init_openravepy_kinbody()
                                   .def("GetTransparency",&PyLink::PyGeometry::GetTransparency,DOXY_FN(KinBody::Link::Geometry,GetTransparency))
                                   .def("GetDiffuseColor",&PyLink::PyGeometry::GetDiffuseColor,DOXY_FN(KinBody::Link::Geometry,GetDiffuseColor))
                                   .def("GetAmbientColor",&PyLink::PyGeometry::GetAmbientColor,DOXY_FN(KinBody::Link::Geometry,GetAmbientColor))
+                                  .def("GetCalibrationBoardGridSize",&PyLink::PyGeometry::GetCalibrationBoardGridSize, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardGridSize))
+                                  .def("GetCalibrationBoardDotsDistance",&PyLink::PyGeometry::GetCalibrationBoardDotsDistance, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardDotsDistance))
+                                  .def("GetCalibrationBoardDotColor",&PyLink::PyGeometry::GetCalibrationBoardDotColor, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardDotColor))
+                                  .def("GetCalibrationBoardPattern",&PyLink::PyGeometry::GetCalibrationBoardPattern, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardPattern))
+                                  .def("GetCalibrationBoardDotRatios",&PyLink::PyGeometry::GetCalibrationBoardDotRatios, DOXY_FN(KinBody::Link::Geometry,GetCalibrationBoardDotRatios))
                                   .def("ComputeInnerEmptyVolume",&PyLink::PyGeometry::ComputeInnerEmptyVolume,DOXY_FN(KinBody::Link::Geometry,ComputeInnerEmptyVolume))
                                   .def("GetInfo",&PyLink::PyGeometry::GetInfo,DOXY_FN(KinBody::Link::Geometry,GetInfo))
                                   .def("__eq__",&PyLink::PyGeometry::__eq__)

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -2436,8 +2436,8 @@ public:
                 break;
             case GT_CalibrationBoard:
                 itgeominfo->_vGeomData *= vscale;
-                itgeominfo->_calibrationBoardParams[0].dotsDistanceX *= vscale.x;
-                itgeominfo->_calibrationBoardParams[0].dotsDistanceY *= vscale.y;
+                itgeominfo->_calibrationBoardParameters[0].dotsDistanceX *= vscale.x;
+                itgeominfo->_calibrationBoardParameters[0].dotsDistanceY *= vscale.y;
                 break;
             default:
                 RAVELOG_WARN(str(boost::format("unknown geometry type: 0x%x")%itgeominfo->_type));
@@ -3119,7 +3119,7 @@ public:
                             }
                         }
                         else if( name == "calibration_board" ) {
-                            geominfo._calibrationBoardParams.clear();
+                            geominfo._calibrationBoardParameters.clear();
                             // get locations of required attributes
                             daeElementRef pparams = children[i]->getChild("parameters");
                             if (!!pparams) {
@@ -3186,15 +3186,15 @@ public:
                                         // put all attributes into geometry info
                                         geominfo._type = GT_CalibrationBoard;
                                         geominfo._vGeomData = vextents;
-                                        geominfo._calibrationBoardParams.push_back(KinBody::GeometryInfo::CalibrationBoardParameters());
-                                        geominfo._calibrationBoardParams[0].numDotsX = numDotsX;
-                                        geominfo._calibrationBoardParams[0].numDotsY = numDotsY;
-                                        geominfo._calibrationBoardParams[0].dotsDistanceX = dotsDistanceX;
-                                        geominfo._calibrationBoardParams[0].dotsDistanceY = dotsDistanceY;
-                                        geominfo._calibrationBoardParams[0].dotColor = dotColor;
-                                        geominfo._calibrationBoardParams[0].patternName = pattern;
-                                        geominfo._calibrationBoardParams[0].dotDiameterDistanceRatio = dotDiameterDistanceRatio;
-                                        geominfo._calibrationBoardParams[0].bigDotDiameterDistanceRatio = bigDotDiameterDistanceRatio;
+                                        geominfo._calibrationBoardParameters.push_back(KinBody::GeometryInfo::CalibrationBoardParameters());
+                                        geominfo._calibrationBoardParameters[0].numDotsX = numDotsX;
+                                        geominfo._calibrationBoardParameters[0].numDotsY = numDotsY;
+                                        geominfo._calibrationBoardParameters[0].dotsDistanceX = dotsDistanceX;
+                                        geominfo._calibrationBoardParameters[0].dotsDistanceY = dotsDistanceY;
+                                        geominfo._calibrationBoardParameters[0].dotColor = dotColor;
+                                        geominfo._calibrationBoardParameters[0].patternName = pattern;
+                                        geominfo._calibrationBoardParameters[0].dotDiameterDistanceRatio = dotDiameterDistanceRatio;
+                                        geominfo._calibrationBoardParameters[0].bigDotDiameterDistanceRatio = bigDotDiameterDistanceRatio;
                                         geominfo._t = tlocalgeom;
                                         bfoundgeom = true;
                                     }

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -3122,58 +3122,65 @@ public:
                             // get locations of required attributes
                             daeElementRef pparams = children[i]->getChild("parameters");
                             if (!!pparams) {
-                                // grid_size contains two integer values:
-                                // number of columns along x axis, and number of rows along y axis
-                                daeElementRef pgrid_size = pparams->getChild("grid_size");
-                                // dot_distance contains two float values:
-                                // x distance between centers of adjacent dots, and y distance between centers of adjacent dots
-                                daeElementRef pdot_distance = pparams->getChild("dot_distance");
-                                // dot_color has four float values denoting RGB dot color, distinct from board color
+                                daeElementRef pnum_dots_x = pparams->getChild("num_dots_x");
+                                daeElementRef pnum_dots_y = pparams->getChild("num_dots_y");
+                                daeElementRef pdots_distance_x = pparams->getChild("dots_distance_x");
+                                daeElementRef pdots_distance_y = pparams->getChild("dots_distance_y");
                                 daeElementRef pdot_color = pparams->getChild("dot_color");
-                                // pattern is a string indicating what pattern of dot types to use
-                                daeElementRef ppattern = pparams->getChild("pattern");
-                                // dot_ratios contains two float values:
-                                // normal dot diameter to x distance ratio, and big dot diameter to x distance ratio
-                                daeElementRef pdot_ratios = pparams->getChild("dot_ratios");
+                                daeElementRef ppattern_name = pparams->getChild("pattern_name");
+                                daeElementRef pdot_diameter_distance_ratio = pparams->getChild("dot_diameter_distance_ratio");
+                                daeElementRef pbig_dot_diameter_distance_ratio = pparams->getChild("big_dot_diameter_distance_ratio");
                                 daeElementRef phalf_extents = children[i]->getChild("half_extents");
 
-                                if (!!pgrid_size
-                                    && !!pdot_distance
+                                if (!!pnum_dots_x
+                                    && !!pnum_dots_y
+                                    && !!pdots_distance_x
+                                    && !!pdots_distance_y
                                     && !!pdot_color
-                                    && !!ppattern
-                                    && !!pdot_ratios
+                                    && !!ppattern_name
+                                    && !!pdot_diameter_distance_ratio
+                                    && !!pbig_dot_diameter_distance_ratio
                                     && !!phalf_extents) {
                                     // set up each stringstream to get each calibration board attribute
-                                    stringstream ss(pgrid_size->getCharData());
+                                    stringstream ss(pnum_dots_x->getCharData());
+                                    stringstream ss2(pnums_dots_y->getCharData());
                                     int numDotsX, numDotsY;
-                                    ss >> numDotsX >> numDotsY;
+                                    ss >> numDotsX;
+                                    ss2 >> numDotsY;
 
-                                    stringstream ss2(pdot_distance->getCharData());
-                                    float dotsDistanceX, dotsDistanceY;
-                                    ss2 >> dotsDistanceX >> dotsDistanceY;
+                                    stringstream ss3(pdots_distance_x->getCharData());
+                                    stringstream ss4(pdots_distance_y->getCharData());
+                                    dReal dotsDistanceX, dotsDistanceY;
+                                    ss3 >> dotsDistanceX;
+                                    ss4 >> dotsDistanceY;
 
-                                    stringstream ss3(pdot_color->getCharData());
+                                    stringstream ss5(pdot_color->getCharData());
                                     Vector dotColor;
-                                    ss3 >> dotColor.x >> dotColor.y >> dotColor.z >> dotColor.w;
+                                    ss5 >> dotColor.x >> dotColor.y >> dotColor.z >> dotColor.w;
 
-                                    stringstream ss4(ppattern->getCharData());
+                                    stringstream ss6(ppattern_name->getCharData());
                                     std::string pattern;
-                                    ss4 >> pattern;
+                                    ss6 >> pattern;
 
-                                    stringstream ss5(pdot_ratios->getCharData());
-                                    float dotDiameterDistanceRatio, bigDotDiameterDistanceRatio;
-                                    ss5 >> dotDiameterDistanceRatio >> bigDotDiameterDistanceRatio;
+                                    stringstream ss7(pdot_diameter_distance_ratio->getCharData());
+                                    stringstream ss8(pbig_dot_diameter_distance_ratio->getCharData());
+                                    dReal dotDiameterDistanceRatio, bigDotDiameterDistanceRatio;
+                                    ss7 >> dotDiameterDistanceRatio;
+                                    ss8 >> bigDotDiameterDistanceRatio;
 
-                                    stringstream ss6(phalf_extents->getCharData());
+                                    stringstream ss9(phalf_extents->getCharData());
                                     Vector vextents;
-                                    ss6 >> vextents.x >> vextents.y >> vextents.z;
+                                    ss9 >> vextents.x >> vextents.y >> vextents.z;
 
                                     if ((ss.eof() || !!ss)
                                         && (ss2.eof() || !!ss2)
                                         && (ss3.eof() || !!ss3)
                                         && (ss4.eof() || !!ss4)
                                         && (ss5.eof() || !!ss5)
-                                        && (ss6.eof() || !!ss6)) {
+                                        && (ss6.eof() || !!ss6)
+                                        && (ss7.eof() || !!ss7)
+                                        && (ss8.eof() || !!ss8)
+                                        && (ss9.eof() || !!ss9)) {
                                         // if every attribute required for calibration board is found,
                                         // put all attributes into geometry info
                                         geominfo._type = GT_CalibrationBoard;

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -3143,7 +3143,7 @@ public:
                                     && !!phalf_extents) {
                                     // set up each stringstream to get each calibration board attribute
                                     stringstream ss(pnum_dots_x->getCharData());
-                                    stringstream ss2(pnums_dots_y->getCharData());
+                                    stringstream ss2(pnum_dots_y->getCharData());
                                     int numDotsX, numDotsY;
                                     ss >> numDotsX;
                                     ss2 >> numDotsY;

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -2436,8 +2436,8 @@ public:
                 break;
             case GT_CalibrationBoard:
                 itgeominfo->_vGeomData *= vscale;
-                itgeominfo->_calibrationBoardParams.dotsDistanceX *= vscale.x;
-                itgeominfo->_calibrationBoardParams.dotsDistanceY *= vscale.y;
+                itgeominfo->_calibrationBoardParams[0].dotsDistanceX *= vscale.x;
+                itgeominfo->_calibrationBoardParams[0].dotsDistanceY *= vscale.y;
                 break;
             default:
                 RAVELOG_WARN(str(boost::format("unknown geometry type: 0x%x")%itgeominfo->_type));
@@ -3119,6 +3119,7 @@ public:
                             }
                         }
                         else if( name == "calibration_board" ) {
+                            geominfo._calibrationBoardParams.clear();
                             // get locations of required attributes
                             daeElementRef pparams = children[i]->getChild("parameters");
                             if (!!pparams) {
@@ -3185,18 +3186,17 @@ public:
                                         // put all attributes into geometry info
                                         geominfo._type = GT_CalibrationBoard;
                                         geominfo._vGeomData = vextents;
-                                        geominfo._calibrationBoardParams.numDotsX = numDotsX;
-                                        geominfo._calibrationBoardParams.numDotsY = numDotsY;
-                                        geominfo._calibrationBoardParams.dotsDistanceX = dotsDistanceX;
-                                        geominfo._calibrationBoardParams.dotsDistanceY = dotsDistanceY;
-                                        geominfo._calibrationBoardParams.dotColor = dotColor;
-                                        geominfo._calibrationBoardParams.patternName = pattern;
-                                        geominfo._calibrationBoardParams.dotDiameterDistanceRatio = dotDiameterDistanceRatio;
-                                        geominfo._calibrationBoardParams.bigDotDiameterDistanceRatio = bigDotDiameterDistanceRatio;
+                                        geominfo._calibrationBoardParams.push_back(KinBody::GeometryInfo::CalibrationBoardParameters());
+                                        geominfo._calibrationBoardParams[0].numDotsX = numDotsX;
+                                        geominfo._calibrationBoardParams[0].numDotsY = numDotsY;
+                                        geominfo._calibrationBoardParams[0].dotsDistanceX = dotsDistanceX;
+                                        geominfo._calibrationBoardParams[0].dotsDistanceY = dotsDistanceY;
+                                        geominfo._calibrationBoardParams[0].dotColor = dotColor;
+                                        geominfo._calibrationBoardParams[0].patternName = pattern;
+                                        geominfo._calibrationBoardParams[0].dotDiameterDistanceRatio = dotDiameterDistanceRatio;
+                                        geominfo._calibrationBoardParams[0].bigDotDiameterDistanceRatio = bigDotDiameterDistanceRatio;
                                         geominfo._t = tlocalgeom;
                                         bfoundgeom = true;
-                                        geominfo.GenerateCalibrationBoardDotMesh();
-
                                     }
                                 }
                             }

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -3119,43 +3119,63 @@ public:
                             }
                         }
                         else if( name == "calibration_board" ) {
-                            daeElementRef phalf_extents = children[i]->getChild("half_extents");
+                            // get locations of required attributes
                             daeElementRef pparams = children[i]->getChild("parameters");
-                            if (!!phalf_extents && !!pparams) {
+                            if (!!pparams) {
+                                // grid_size contains two integer values:
+                                // number of columns along x axis, and number of rows along y axis
                                 daeElementRef pgrid_size = pparams->getChild("grid_size");
+                                // dot_distance contains two float values:
+                                // x distance between centers of adjacent dots, and y distance between centers of adjacent dots
                                 daeElementRef pdot_distance = pparams->getChild("dot_distance");
+                                // dot_color has four float values denoting RGB dot color, distinct from board color
                                 daeElementRef pdot_color = pparams->getChild("dot_color");
+                                // pattern is a string indicating what pattern of dot types to use
                                 daeElementRef ppattern = pparams->getChild("pattern");
+                                // dot_ratios contains two float values:
+                                // normal dot diameter to x distance ratio, and big dot diameter to x distance ratio
                                 daeElementRef pdot_ratios = pparams->getChild("dot_ratios");
+                                daeElementRef phalf_extents = children[i]->getChild("half_extents");
+
                                 if (!!pgrid_size
                                     && !!pdot_distance
                                     && !!pdot_color
                                     && !!ppattern
-                                    && !!pdot_ratios) {
+                                    && !!pdot_ratios
+                                    && !!phalf_extents) {
+                                    // set up each stringstream to get each calibration board attribute
                                     stringstream ss(pgrid_size->getCharData());
                                     int numDotsX, numDotsY;
                                     ss >> numDotsX >> numDotsY;
+
                                     stringstream ss2(pdot_distance->getCharData());
                                     float dotsDistanceX, dotsDistanceY;
                                     ss2 >> dotsDistanceX >> dotsDistanceY;
+
                                     stringstream ss3(pdot_color->getCharData());
                                     Vector dotColor;
                                     ss3 >> dotColor.x >> dotColor.y >> dotColor.z >> dotColor.w;
+
                                     stringstream ss4(ppattern->getCharData());
                                     std::string pattern;
                                     ss4 >> pattern;
+
                                     stringstream ss5(pdot_ratios->getCharData());
                                     float dotDiameterDistanceRatio, bigDotDiameterDistanceRatio;
                                     ss5 >> dotDiameterDistanceRatio >> bigDotDiameterDistanceRatio;
+
                                     stringstream ss6(phalf_extents->getCharData());
                                     Vector vextents;
                                     ss6 >> vextents.x >> vextents.y >> vextents.z;
+
                                     if ((ss.eof() || !!ss)
                                         && (ss2.eof() || !!ss2)
                                         && (ss3.eof() || !!ss3)
                                         && (ss4.eof() || !!ss4)
                                         && (ss5.eof() || !!ss5)
                                         && (ss6.eof() || !!ss6)) {
+                                        // if every attribute required for calibration board is found,
+                                        // put all attributes into geometry info
                                         geominfo._type = GT_CalibrationBoard;
                                         geominfo._vGeomData = vextents;
                                         geominfo._calibrationBoardParams.numDotsX = numDotsX;
@@ -3169,6 +3189,7 @@ public:
                                         geominfo._t = tlocalgeom;
                                         bfoundgeom = true;
                                         geominfo.GenerateCalibrationBoardDotMesh();
+
                                     }
                                 }
                             }

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -1995,6 +1995,35 @@ private:
                 }
                 break;
             }
+            case GT_CalibrationBoard: {
+                daeElementRef pcalibrationboard = ptec->add("calibration_board");
+                ss << geom->GetBoxExtents().x << " " << geom->GetBoxExtents().y << " " << geom->GetBoxExtents().z;
+                pcalibrationboard->add("half_extents")->setCharData(ss.str());
+
+                daeElementRef pparams = pcalibrationboard->add("parameters");
+                const KinBody::GeometryInfo::CalibrationBoardParams& paramsInfo = geom->GetInfo()._calibrationBoardParams;
+
+                ss.str(""); ss.clear();
+                ss << paramsInfo.numDotsX << " " << paramsInfo.numDotsY;
+                pparams->add("grid_size")->setCharData(ss.str());
+
+                ss.str(""); ss.clear();
+                ss << paramsInfo.dotsDistanceX << " " << paramsInfo.dotsDistanceY;
+                pparams->add("dot_distance")->setCharData(ss.str());
+
+                ss.str(""); ss.clear();
+                ss << paramsInfo.dotColor.x << " " << paramsInfo.dotColor.y << " " << paramsInfo.dotColor.z << " " << paramsInfo.dotColor.w;
+                pparams->add("dot_color")->setCharData(ss.str());
+
+                ss.str(""); ss.clear();
+                ss << paramsInfo.patternName;
+                pparams->add("pattern")->setCharData(ss.str());
+
+                ss.str(""); ss.clear();
+                ss << paramsInfo.dotDiameterDistanceRatio << " " << paramsInfo.bigDotDiameterDistanceRatio;
+                pparams->add("dot_ratios")->setCharData(ss.str());
+                break;
+            }
             case GT_Sphere:
                 ptec->add("sphere")->add("radius")->setCharData(ss.str());
                 break;

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -2004,12 +2004,20 @@ private:
                 const KinBody::GeometryInfo::CalibrationBoardParameters& paramsInfo = geom->GetInfo()._calibrationBoardParams;
 
                 ss.str(""); ss.clear();
-                ss << paramsInfo.numDotsX << " " << paramsInfo.numDotsY;
-                pparams->add("grid_size")->setCharData(ss.str());
+                ss << paramsInfo.numDotsX;
+                pparams->add("num_dots_x")->setCharData(ss.str());
 
                 ss.str(""); ss.clear();
-                ss << paramsInfo.dotsDistanceX << " " << paramsInfo.dotsDistanceY;
-                pparams->add("dot_distance")->setCharData(ss.str());
+                ss << paramsInfo.numDotsX;
+                pparams->add("num_dots_y")->setCharData(ss.str());
+
+                ss.str(""); ss.clear();
+                ss << paramsInfo.dotsDistanceX;
+                pparams->add("dots_distance_x")->setCharData(ss.str());
+
+                ss.str(""); ss.clear();
+                ss << paramsInfo.dotsDistanceY;
+                pparams->add("dots_distance_y")->setCharData(ss.str());
 
                 ss.str(""); ss.clear();
                 ss << paramsInfo.dotColor.x << " " << paramsInfo.dotColor.y << " " << paramsInfo.dotColor.z << " " << paramsInfo.dotColor.w;
@@ -2017,11 +2025,15 @@ private:
 
                 ss.str(""); ss.clear();
                 ss << paramsInfo.patternName;
-                pparams->add("pattern")->setCharData(ss.str());
+                pparams->add("pattern_name")->setCharData(ss.str());
 
                 ss.str(""); ss.clear();
-                ss << paramsInfo.dotDiameterDistanceRatio << " " << paramsInfo.bigDotDiameterDistanceRatio;
-                pparams->add("dot_ratios")->setCharData(ss.str());
+                ss << paramsInfo.dotDiameterDistanceRatio;
+                pparams->add("dot_diameter_distance_ratio")->setCharData(ss.str());
+
+                ss.str(""); ss.clear();
+                ss << paramsInfo.bigDotDiameterDistanceRatio;
+                pparams->add("big_dot_diameter_distance_ratio")->setCharData(ss.str());
                 break;
             }
             case GT_Sphere:

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -2001,7 +2001,11 @@ private:
                 pcalibrationboard->add("half_extents")->setCharData(ss.str());
 
                 daeElementRef pparams = pcalibrationboard->add("parameters");
-                const KinBody::GeometryInfo::CalibrationBoardParameters& paramsInfo = geom->GetInfo()._calibrationBoardParams;
+                std::vector<KinBody::GeometryInfo::CalibrationBoardParameters> vParamsInfo = geom->GetInfo()._calibrationBoardParams;
+                if (vParamsInfo.size() == 0) {
+                    vParamsInfo.push_back(KinBody::GeometryInfo::CalibrationBoardParameters());
+                }
+                const KinBody::GeometryInfo::CalibrationBoardParameters& paramsInfo = vParamsInfo[0];
 
                 ss.str(""); ss.clear();
                 ss << paramsInfo.numDotsX;

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -2001,7 +2001,7 @@ private:
                 pcalibrationboard->add("half_extents")->setCharData(ss.str());
 
                 daeElementRef pparams = pcalibrationboard->add("parameters");
-                const KinBody::GeometryInfo::CalibrationBoardParams& paramsInfo = geom->GetInfo()._calibrationBoardParams;
+                const KinBody::GeometryInfo::CalibrationBoardParameters& paramsInfo = geom->GetInfo()._calibrationBoardParams;
 
                 ss.str(""); ss.clear();
                 ss << paramsInfo.numDotsX << " " << paramsInfo.numDotsY;

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -2001,7 +2001,7 @@ private:
                 pcalibrationboard->add("half_extents")->setCharData(ss.str());
 
                 daeElementRef pparams = pcalibrationboard->add("parameters");
-                std::vector<KinBody::GeometryInfo::CalibrationBoardParameters> vParamsInfo = geom->GetInfo()._calibrationBoardParams;
+                std::vector<KinBody::GeometryInfo::CalibrationBoardParameters> vParamsInfo = geom->GetInfo()._calibrationBoardParameters;
                 if (vParamsInfo.size() == 0) {
                     vParamsInfo.push_back(KinBody::GeometryInfo::CalibrationBoardParameters());
                 }

--- a/src/libopenrave-core/xmlreaders-core.cpp
+++ b/src/libopenrave-core/xmlreaders-core.cpp
@@ -1151,6 +1151,7 @@ public:
                     case GT_Sphere:
                         mass = MASS::GetSphericalMassD((*itgeom)->GetSphereRadius(), Vector(),_fMassDensity);
                         break;
+                    case GT_CalibrationBoard:
                     case GT_Box:
                         mass = MASS::GetBoxMassD((*itgeom)->GetBoxExtents(), Vector(), _fMassDensity);
                         break;
@@ -1179,6 +1180,7 @@ public:
                     case GT_Sphere:
                         mass = MASS::GetSphericalMassD((*itgeom)->GetSphereRadius(), Vector(),1000);
                         break;
+                    case GT_CalibrationBoard:
                     case GT_Box:
                         mass = MASS::GetBoxMassD((*itgeom)->GetBoxExtents(), Vector(), 1000);
                         break;

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -197,6 +197,8 @@ void KinBody::GeometryInfo::GenerateCalibrationBoardDotMesh(float fTessellation)
     params._dotmeshcollision.indices.clear();
     params._dotmeshcollision.vertices.clear();
     // create mesh for dot grid
+    float nDotsX = params.numDotsX;
+    float nDotsY = params.numDotsY;
     float dotDx = params.dotsDistanceX;
     float dotDy = params.dotsDistanceY;
     float dotRadius = params.dotDiameterDistanceRatio * std::min(dotDx, dotDy) / 2;
@@ -207,8 +209,8 @@ void KinBody::GeometryInfo::GenerateCalibrationBoardDotMesh(float fTessellation)
     int numverts = (int)(fTessellation*48.0f) + 3;
 
     if (params.numDotsX >= 3 && params.numDotsY >= 3) {
-        for (float rowPos = -(params.numDotsX-1)/2; rowPos <= (params.numDotsX-1)/2; rowPos++ ) {
-            for (float colPos = -(params.numDotsY-1)/2; colPos <= (params.numDotsY-1)/2; colPos++ ) {
+        for (float rowPos = -(nDotsX-1)/2; rowPos <= (nDotsX-1)/2; rowPos++ ) {
+            for (float colPos = -(nDotsY-1)/2; colPos <= (nDotsY-1)/2; colPos++ ) {
                 Vector dotPos = Vector(rowPos * dotDx, colPos * dotDy, dotZOffset);
                 // calibration board pattern types
                 if (params.patternName == "threeBigDotsDotGrid") {

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -411,6 +411,14 @@ bool KinBody::GeometryInfo::InitCollisionMesh(float fTessellation)
         }
         break;
     }
+    case GT_CalibrationBoard: {
+        AppendBoxTriangulation(Vector(0, 0, 0), GetBoxExtents(), _meshcollision);
+        CalibrationBoardParams params = _calibrationBoardParams;
+        if (params.numDotsX >= 3 && params.numDotsY >= 3) {
+            
+        }
+        break;
+    }
     default:
         throw OPENRAVE_EXCEPTION_FORMAT(_("unrecognized geom type %d!"), _type, ORE_InvalidArguments);
     }

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -863,9 +863,6 @@ void KinBody::GeometryInfo::SerializeJSON(rapidjson::Value& rGeometryInfo, rapid
         orjson::SetJsonValueByKey(rGeometryInfo, "halfExtents", _vGeomData*fUnitScale, allocator);
         rapidjson::Value rCalibrationBoardParams;
         rCalibrationBoardParams.SetObject();
-        RAVELOG_WARN("==== CALIBRATION BOARD PARAMS ====\n");
-        RAVELOG_WARN_FORMAT("numDots: %d %d", _calibrationBoardParams.numDotsX % _calibrationBoardParams.numDotsY);
-        RAVELOG_WARN_FORMAT("dotsDistance: %f %f", _calibrationBoardParams.dotsDistanceX % _calibrationBoardParams.dotsDistanceY);
         orjson::SetJsonValueByKey(rCalibrationBoardParams, "numDotsX", _calibrationBoardParams.numDotsX, allocator);
         orjson::SetJsonValueByKey(rCalibrationBoardParams, "numDotsY", _calibrationBoardParams.numDotsY, allocator);
         orjson::SetJsonValueByKey(rCalibrationBoardParams, "dotsDistanceX", _calibrationBoardParams.dotsDistanceX*fUnitScale, allocator);

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -165,6 +165,27 @@ void AppendBoxTriangulation(const Vector& pos, const Vector& ex, TriMesh& tri)
     tri.indices.insert(tri.indices.end(), &indices[0], &indices[nindices]);
 }
 
+void AppendCylinderTriangulation(const dReal& rad, const dReal& len, const int& numverts, TriMesh& tri) {
+    // once again, cylinder is on z axis
+    dReal dtheta = 2 * PI / (dReal)numverts;
+    tri.vertices.push_back(Vector(0,0,len));
+    tri.vertices.push_back(Vector(0,0,-len));
+    tri.vertices.push_back(Vector(rad,0,len));
+    tri.vertices.push_back(Vector(rad,0,-len));
+    for(int i = 0; i < numverts+1; ++i) {
+        dReal s = rad * RaveSin(dtheta * (dReal)i);
+        dReal c = rad * RaveCos(dtheta * (dReal)i);
+        int off = (int)tri.vertices.size();
+        tri.vertices.push_back(Vector(c, s, len));
+        tri.vertices.push_back(Vector(c, s, -len));
+
+        tri.indices.push_back(0);       tri.indices.push_back(off-2);       tri.indices.push_back(off);
+        tri.indices.push_back(1);       tri.indices.push_back(off+1);       tri.indices.push_back(off-1);
+        tri.indices.push_back(off-2);   tri.indices.push_back(off-1);       tri.indices.push_back(off);
+        tri.indices.push_back(off);     tri.indices.push_back(off-1);       tri.indices.push_back(off+1);
+    }
+}
+
 int KinBody::GeometryInfo::SideWall::Compare(const SideWall& rhs, dReal fUnitScale, dReal fEpsilon) const
 {
     if(!IsZeroWithEpsilon3(transf.trans - rhs.transf.trans*fUnitScale, fEpsilon)) {
@@ -332,23 +353,7 @@ bool KinBody::GeometryInfo::InitCollisionMesh(float fTessellation)
         // cylinder is on z axis
         dReal rad = GetCylinderRadius(), len = GetCylinderHeight()*0.5f;
         int numverts = (int)(fTessellation*48.0f) + 3;
-        dReal dtheta = 2 * PI / (dReal)numverts;
-        _meshcollision.vertices.push_back(Vector(0,0,len));
-        _meshcollision.vertices.push_back(Vector(0,0,-len));
-        _meshcollision.vertices.push_back(Vector(rad,0,len));
-        _meshcollision.vertices.push_back(Vector(rad,0,-len));
-        for(int i = 0; i < numverts+1; ++i) {
-            dReal s = rad * RaveSin(dtheta * (dReal)i);
-            dReal c = rad * RaveCos(dtheta * (dReal)i);
-            int off = (int)_meshcollision.vertices.size();
-            _meshcollision.vertices.push_back(Vector(c, s, len));
-            _meshcollision.vertices.push_back(Vector(c, s, -len));
-
-            _meshcollision.indices.push_back(0);       _meshcollision.indices.push_back(off-2);       _meshcollision.indices.push_back(off);
-            _meshcollision.indices.push_back(1);       _meshcollision.indices.push_back(off+1);       _meshcollision.indices.push_back(off-1);
-            _meshcollision.indices.push_back(off-2);   _meshcollision.indices.push_back(off-1);         _meshcollision.indices.push_back(off);
-            _meshcollision.indices.push_back(off);   _meshcollision.indices.push_back(off-1);         _meshcollision.indices.push_back(off+1);
-        }
+        AppendCylinderTriangulation(rad, len, numverts, _meshcollision);
         break;
     }
     case GT_Cage: {

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -863,6 +863,9 @@ void KinBody::GeometryInfo::SerializeJSON(rapidjson::Value& rGeometryInfo, rapid
         orjson::SetJsonValueByKey(rGeometryInfo, "halfExtents", _vGeomData*fUnitScale, allocator);
         rapidjson::Value rCalibrationBoardParams;
         rCalibrationBoardParams.SetObject();
+        RAVELOG_WARN("==== CALIBRATION BOARD PARAMS ====\n");
+        RAVELOG_WARN_FORMAT("numDots: %d %d", _calibrationBoardParams.numDotsX % _calibrationBoardParams.numDotsY);
+        RAVELOG_WARN_FORMAT("dotsDistance: %f %f", _calibrationBoardParams.dotsDistanceX % _calibrationBoardParams.dotsDistanceY);
         orjson::SetJsonValueByKey(rCalibrationBoardParams, "numDotsX", _calibrationBoardParams.numDotsX, allocator);
         orjson::SetJsonValueByKey(rCalibrationBoardParams, "numDotsY", _calibrationBoardParams.numDotsY, allocator);
         orjson::SetJsonValueByKey(rCalibrationBoardParams, "dotsDistanceX", _calibrationBoardParams.dotsDistanceX*fUnitScale, allocator);

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -209,7 +209,7 @@ void KinBody::GeometryInfo::GenerateCalibrationBoardDotMesh(TriMesh& tri, float 
     dReal bigDotRadius = parameters.bigDotDiameterDistanceRatio * std::min(dotDx, dotDy) / 2;
     dReal selectedRadius = dotRadius;
     dReal dotLength = 0.01f * boardEx[2];
-    dReal dotZOffset = boardEx[2] + (dotLength)/2;
+    dReal dotZOffset = dotLength/2;
     int numverts = (int)(fTessellation*48.0f) + 3;
 
     if (nDotsX >= 3 && nDotsY >= 3) {
@@ -506,7 +506,7 @@ bool KinBody::GeometryInfo::InitCollisionMesh(float fTessellation)
     case GT_CalibrationBoard: {
         // create board mesh
         Vector boardEx = GetBoxExtents();
-        AppendBoxTriangulation(Vector(0, 0, 0), boardEx, _meshcollision);
+        AppendBoxTriangulation(Vector(0, 0, -boardEx[2]), boardEx, _meshcollision);
         break;
     }
     default:

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -228,6 +228,8 @@ void KinBody::GeometryInfo::GenerateCalibrationBoardDotMesh(float fTessellation)
                 AppendCylinderTriangulation(dotPos, selectedRadius, dotLength, numverts, _calibrationBoardParams._dotmeshcollision);
             }
         }
+    } else {
+        RAVELOG_WARN_FORMAT("Cannot generate calibration board dot grid of size %sx%s - minimum size is 3 x 3.", params.numDotsX%params.numDotsY);
     }
 }
 
@@ -677,9 +679,7 @@ inline void LoadJsonValue(const rapidjson::Value& rValue, KinBody::GeometryInfo:
     };
     for (int idx = 0; idx < 8; idx++) {
         if (!rValue.HasMember(calibrationBoardParamNames[idx])) {
-            char paramError[1024];
-            sprintf(paramError, "Missing calibration board parameter \"%s\".", calibrationBoardParamNames[idx]);
-            throw OPENRAVE_EXCEPTION_FORMAT0(paramError, OpenRAVE::ORE_InvalidArguments);
+            RAVELOG_ERROR_FORMAT("Missing calibration board parameter \"%s\".", calibrationBoardParamNames[idx]);
         }
     }
     orjson::LoadJsonValue(rValue["numDotsX"], p.numDotsX);
@@ -1104,6 +1104,7 @@ AABB KinBody::GeometryInfo::ComputeAABB(const Transform& tGeometryWorld) const
         ab.extents.y = 0;
         ab.extents.z = 0;
         break;
+    case GT_CalibrationBoard: // the tangible part of the board is basically the box
     case GT_Box: // origin of box is at the center
         ab.extents.x = RaveFabs(tglobal.m[0])*_vGeomData.x + RaveFabs(tglobal.m[1])*_vGeomData.y + RaveFabs(tglobal.m[2])*_vGeomData.z;
         ab.extents.y = RaveFabs(tglobal.m[4])*_vGeomData.x + RaveFabs(tglobal.m[5])*_vGeomData.y + RaveFabs(tglobal.m[6])*_vGeomData.z;
@@ -1272,12 +1273,6 @@ AABB KinBody::GeometryInfo::ComputeAABB(const Transform& tGeometryWorld) const
         }
         break;
     }
-    case GT_CalibrationBoard: // the tangible part of the board is basically the box
-        ab.extents.x = RaveFabs(tglobal.m[0])*_vGeomData.x + RaveFabs(tglobal.m[1])*_vGeomData.y + RaveFabs(tglobal.m[2])*_vGeomData.z;
-        ab.extents.y = RaveFabs(tglobal.m[4])*_vGeomData.x + RaveFabs(tglobal.m[5])*_vGeomData.y + RaveFabs(tglobal.m[6])*_vGeomData.z;
-        ab.extents.z = RaveFabs(tglobal.m[8])*_vGeomData.x + RaveFabs(tglobal.m[9])*_vGeomData.y + RaveFabs(tglobal.m[10])*_vGeomData.z;
-        ab.pos = tglobal.trans;
-        break;
     default:
         throw OPENRAVE_EXCEPTION_FORMAT(_("unknown geometry type %d"), _type, ORE_InvalidArguments);
     }

--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -192,30 +192,30 @@ void KinBody::GeometryInfo::GenerateCalibrationBoardDotMesh(float fTessellation)
         return;
     }
     Vector boardEx = _vGeomData;
-    CalibrationBoardParams params = _calibrationBoardParams;
+    CalibrationBoardParameters params = _calibrationBoardParams;
     // reset dots mesh
     params._dotmeshcollision.indices.clear();
     params._dotmeshcollision.vertices.clear();
     // create mesh for dot grid
-    float nDotsX = params.numDotsX;
-    float nDotsY = params.numDotsY;
-    float dotDx = params.dotsDistanceX;
-    float dotDy = params.dotsDistanceY;
-    float dotRadius = params.dotDiameterDistanceRatio * std::min(dotDx, dotDy) / 2;
-    float bigDotRadius = params.bigDotDiameterDistanceRatio * std::min(dotDx, dotDy) / 2;
-    float selectedRadius = dotRadius;
-    float dotLength = 0.01f * boardEx[2];
-    float dotZOffset = boardEx[2] + (dotLength)/2;
+    dReal nDotsX = params.numDotsX;
+    dReal nDotsY = params.numDotsY;
+    dReal dotDx = params.dotsDistanceX;
+    dReal dotDy = params.dotsDistanceY;
+    dReal dotRadius = params.dotDiameterDistanceRatio * std::min(dotDx, dotDy) / 2;
+    dReal bigDotRadius = params.bigDotDiameterDistanceRatio * std::min(dotDx, dotDy) / 2;
+    dReal selectedRadius = dotRadius;
+    dReal dotLength = 0.01f * boardEx[2];
+    dReal dotZOffset = boardEx[2] + (dotLength)/2;
     int numverts = (int)(fTessellation*48.0f) + 3;
 
     if (params.numDotsX >= 3 && params.numDotsY >= 3) {
-        for (float rowPos = -(nDotsX-1)/2; rowPos <= (nDotsX-1)/2; rowPos++ ) {
-            for (float colPos = -(nDotsY-1)/2; colPos <= (nDotsY-1)/2; colPos++ ) {
+        for (dReal rowPos = -(nDotsX-1)/2; rowPos <= (nDotsX-1)/2; rowPos++ ) {
+            for (dReal colPos = -(nDotsY-1)/2; colPos <= (nDotsY-1)/2; colPos++ ) {
                 Vector dotPos = Vector(rowPos * dotDx, colPos * dotDy, dotZOffset);
                 // calibration board pattern types
                 if (params.patternName == "threeBigDotsDotGrid") {
-                    float cRowPos = std::ceil(rowPos);
-                    float cColPos = std::ceil(colPos);
+                    dReal cRowPos = std::ceil(rowPos);
+                    dReal cColPos = std::ceil(colPos);
                     // use big dot radius if dot pos coords is at (0, 0), (0, 1), or (1, 0) when ceiling'd
                     // otherwise, use normal dot radius
                     if ((cRowPos == 0 && (cColPos == 0 || cColPos == 1))
@@ -666,7 +666,7 @@ inline void LoadJsonValue(const rapidjson::Value& rValue, KinBody::GeometryInfo:
     }
 }
 
-inline void LoadJsonValue(const rapidjson::Value& rValue, KinBody::GeometryInfo::CalibrationBoardParams& p) {
+inline void LoadJsonValue(const rapidjson::Value& rValue, KinBody::GeometryInfo::CalibrationBoardParameters& p) {
     if (!rValue.IsObject()) {
         throw OPENRAVE_EXCEPTION_FORMAT0("Cannot load value of non-object.", OpenRAVE::ORE_InvalidArguments);
     }
@@ -765,7 +765,7 @@ void KinBody::GeometryInfo::Reset()
     _fTransparency = 0;
     _bVisible = true;
     _bModifiable = true;
-    _calibrationBoardParams = CalibrationBoardParams();
+    _calibrationBoardParams = CalibrationBoardParameters();
 }
 
 inline std::string _GetGeometryTypeString(const GeometryType& geometryType)
@@ -861,17 +861,17 @@ void KinBody::GeometryInfo::SerializeJSON(rapidjson::Value& rGeometryInfo, rapid
     }
     case GT_CalibrationBoard: {
         orjson::SetJsonValueByKey(rGeometryInfo, "halfExtents", _vGeomData*fUnitScale, allocator);
-        rapidjson::Value rCalibrationBoardParams;
-        rCalibrationBoardParams.SetObject();
-        orjson::SetJsonValueByKey(rCalibrationBoardParams, "numDotsX", _calibrationBoardParams.numDotsX, allocator);
-        orjson::SetJsonValueByKey(rCalibrationBoardParams, "numDotsY", _calibrationBoardParams.numDotsY, allocator);
-        orjson::SetJsonValueByKey(rCalibrationBoardParams, "dotsDistanceX", _calibrationBoardParams.dotsDistanceX*fUnitScale, allocator);
-        orjson::SetJsonValueByKey(rCalibrationBoardParams, "dotsDistanceY", _calibrationBoardParams.dotsDistanceY*fUnitScale, allocator);
-        orjson::SetJsonValueByKey(rCalibrationBoardParams, "dotColor", _calibrationBoardParams.dotColor, allocator);
-        orjson::SetJsonValueByKey(rCalibrationBoardParams, "patternName", _calibrationBoardParams.patternName, allocator);
-        orjson::SetJsonValueByKey(rCalibrationBoardParams, "dotDiameterDistanceRatio", _calibrationBoardParams.dotDiameterDistanceRatio, allocator);
-        orjson::SetJsonValueByKey(rCalibrationBoardParams, "bigDotDiameterDistanceRatio", _calibrationBoardParams.bigDotDiameterDistanceRatio, allocator);
-        rGeometryInfo.AddMember(rapidjson::Document::StringRefType("calibrationBoardParameters"), rCalibrationBoardParams, allocator);
+        rapidjson::Value rCalibrationBoardParameters;
+        rCalibrationBoardParameters.SetObject();
+        orjson::SetJsonValueByKey(rCalibrationBoardParameters, "numDotsX", _calibrationBoardParams.numDotsX, allocator);
+        orjson::SetJsonValueByKey(rCalibrationBoardParameters, "numDotsY", _calibrationBoardParams.numDotsY, allocator);
+        orjson::SetJsonValueByKey(rCalibrationBoardParameters, "dotsDistanceX", _calibrationBoardParams.dotsDistanceX*fUnitScale, allocator);
+        orjson::SetJsonValueByKey(rCalibrationBoardParameters, "dotsDistanceY", _calibrationBoardParams.dotsDistanceY*fUnitScale, allocator);
+        orjson::SetJsonValueByKey(rCalibrationBoardParameters, "dotColor", _calibrationBoardParams.dotColor, allocator);
+        orjson::SetJsonValueByKey(rCalibrationBoardParameters, "patternName", _calibrationBoardParams.patternName, allocator);
+        orjson::SetJsonValueByKey(rCalibrationBoardParameters, "dotDiameterDistanceRatio", _calibrationBoardParams.dotDiameterDistanceRatio, allocator);
+        orjson::SetJsonValueByKey(rCalibrationBoardParameters, "bigDotDiameterDistanceRatio", _calibrationBoardParams.bigDotDiameterDistanceRatio, allocator);
+        rGeometryInfo.AddMember(rapidjson::Document::StringRefType("calibrationBoardParameters"), rCalibrationBoardParameters, allocator);
         break;
     }
     default:
@@ -931,7 +931,7 @@ void KinBody::GeometryInfo::DeserializeJSON(const rapidjson::Value &value, const
         }
     }
     Vector vGeomDataTemp;
-    CalibrationBoardParams calibrationBoardParamsTemp;
+    CalibrationBoardParameters calibrationBoardParamsTemp;
     switch (_type) {
     case GT_Box:
         if (value.HasMember("halfExtents")) {

--- a/test/testdata/calibration_board.dae
+++ b/test/testdata/calibration_board.dae
@@ -58,7 +58,7 @@
 						<parameters>
 							<grid_size>5 6</grid_size>
 							<dot_distance>0.04 0.03</dot_distance>
-							<dot_color>0 0 0 1</dot_color>
+							<dot_color>1 1 1 1</dot_color>
 							<pattern>threeBigDotsDotGrid</pattern>
 							<dot_ratios>0.4 0.8</dot_ratios>
 						</parameters>

--- a/test/testdata/calibration_board.dae
+++ b/test/testdata/calibration_board.dae
@@ -56,11 +56,14 @@
 					<calibration_board>
 						<half_extents>0.1 0.1 0.01</half_extents>
 						<parameters>
-							<grid_size>5 6</grid_size>
-							<dot_distance>0.04 0.03</dot_distance>
-							<dot_color>1 1 1 1</dot_color>
-							<pattern>threeBigDotsDotGrid</pattern>
-							<dot_ratios>0.4 0.8</dot_ratios>
+							<num_dots_x>5</num_dots_x>
+							<num_dots_y>6</num_dots_y>
+							<dots_distance_x>0.04</dots_distance_x>
+							<dots_distance_y>0.03</dots_distance_y>
+							<dot_color>0 0 0.5 1</dot_color>
+							<pattern_name>threeBigDotsDotGrid</pattern_name>
+							<dot_diameter_distance_ratio>0.4</dot_diameter_distance_ratio>
+							<big_dot_diameter_distance_ratio>0.8</big_dot_diameter_distance_ratio>
 						</parameters>
 					</calibration_board>
 					<visible>

--- a/test/testdata/calibration_board.dae
+++ b/test/testdata/calibration_board.dae
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<COLLADA xmlns="http://www.collada.org/2008/03/COLLADASchema" version="1.5.0">
+	<asset>
+		<contributor>
+			<authoring_tool>OpenRAVE Collada Writer</authoring_tool>
+		</contributor>
+		<created>2012-08-17T18:04:39.000000</created>
+		<modified>2012-08-17T18:04:39.000000</modified>
+		<unit/>
+		<up_axis>Z_UP</up_axis>
+	</asset>
+	<library_visual_scenes id="vscenes">
+		<visual_scene id="vscene" name="OpenRAVE Visual Scene">
+			<node id="visual1" name="calibration_board0" sid="visual1">
+				<translate>0 0 0</translate>
+				<rotate>1 0 0 0</rotate>
+				<node id="v1.node0" name="base" sid="node0">
+					<translate>0 0 0</translate>
+					<rotate>1 0 0 0</rotate>
+					<instance_geometry url="#g1_link0_geom0">
+						<bind_material>
+							<technique_common>
+								<instance_material symbol="mat0" target="#g1_link0_geom0_mat"/>
+							</technique_common>
+						</bind_material>
+					</instance_geometry>
+				</node>
+			</node>
+		</visual_scene>
+	</library_visual_scenes>
+	<library_geometries id="geometries">
+		<geometry id="g1_link0_geom0">
+			<mesh>
+				<source id="g1_link0_geom0_positions">
+					<float_array id="g1_link0_geom0_positions-array" count="24" digits="2490384">0.1 0.1 0.02 0.1 0.1 0 0.1 -0.1 0.02 0.1 -0.1 0 -0.1 0.1 0.02 -0.1 0.1 0 -0.1 -0.1 0.02 -0.1 -0.1 0</float_array>
+					<technique_common>
+						<accessor count="8" source="#g1_link0_geom0_positions-array" stride="3">
+							<param name="X" type="float"/>
+							<param name="Y" type="float"/>
+							<param name="Z" type="float"/>
+						</accessor>
+					</technique_common>
+				</source>
+				<vertices id="g1_link0_geom0_vertices">
+					<input semantic="POSITION" source="#g1_link0_geom0_positions"/>
+				</vertices>
+				<triangles count="12" material="mat0">
+					<input offset="0" semantic="VERTEX" source="#g1_link0_geom0_vertices" set="0"/>
+					<p>0 2 1 1 2 3 4 5 6 5 7 6 0 1 4 1 5 4 2 6 3 3 6 7 0 4 2 2 4 6 1 3 5 3 7 5</p>
+				</triangles>
+			</mesh>
+			<extra type="geometry_info">
+				<technique profile="OpenRAVE">
+					<translate>0 0 0.1</translate>
+					<rotate>1 0 0 0</rotate>
+					<calibration_board>
+						<half_extents>0.1 0.1 0.01</half_extents>
+						<parameters>
+							<grid_size>5 6</grid_size>
+							<dot_distance>0.04 0.03</dot_distance>
+							<dot_color>0 0 0 1</dot_color>
+							<pattern>threeBigDotsDotGrid</pattern>
+							<dot_ratios>0.4 0.8</dot_ratios>
+						</parameters>
+					</calibration_board>
+					<visible>
+						<bool>true</bool>
+					</visible>
+				</technique>
+			</extra>
+		</geometry>
+	</library_geometries>
+	<library_effects id="effects">
+		<effect id="g1_link0_geom0_eff">
+			<profile_COMMON>
+				<technique sid="">
+					<phong>
+						<ambient>
+							<color>0 0 0 0</color>
+						</ambient>
+						<diffuse>
+							<color>0.6 0.6 0.6 0</color>
+						</diffuse>
+					</phong>
+				</technique>
+			</profile_COMMON>
+		</effect>
+	</library_effects>
+	<library_materials id="materials">
+		<material id="g1_link0_geom0_mat">
+			<instance_effect url="#g1_link0_geom0_eff"/>
+		</material>
+	</library_materials>
+	<library_kinematics_models id="kmodels">
+		<kinematics_model id="kmodel1" name="calibration_board0">
+			<asset>
+				<subject>Not documented yet.</subject>
+			</asset>
+			<technique_common>
+				<link sid="link0" name="base">
+					<translate>0 0 0</translate>
+					<rotate>1 0 0 0</rotate>
+				</link>
+			</technique_common>
+			<extra type="interface_type">
+				<technique profile="OpenRAVE">
+					<interface type="kinbody"/>
+				</technique>
+			</extra>
+			<extra type="collision">
+				<technique profile="OpenRAVE"/>
+			</extra>
+		</kinematics_model>
+	</library_kinematics_models>
+	<library_articulated_systems id="asystems">
+		<articulated_system id="body1_kinematics">
+			<kinematics>
+				<instance_kinematics_model url="#kmodel1" sid="kmodel1_inst">
+					<newparam sid="body1_kinematics_kmodel1_inst">
+						<SIDREF>body1_kinematics/kmodel1_inst</SIDREF>
+					</newparam>
+				</instance_kinematics_model>
+				<technique_common/>
+			</kinematics>
+			<extra type="interface_type">
+				<technique profile="OpenRAVE">
+					<interface type="kinbody"/>
+				</technique>
+			</extra>
+		</articulated_system>
+	</library_articulated_systems>
+	<library_kinematics_scenes id="kscenes">
+		<kinematics_scene id="kscene" name="OpenRAVE Kinematics Scene">
+			<instance_articulated_system sid="body1_kinematics_inst" url="#body1_kinematics" name="calibration_board0">
+				<newparam sid="kscene_kmodel1_inst">
+					<SIDREF>body1_kinematics/body1_kinematics_kmodel1_inst</SIDREF>
+				</newparam>
+			</instance_articulated_system>
+		</kinematics_scene>
+	</library_kinematics_scenes>
+	<library_physics_scenes id="pscenes">
+		<physics_scene id="pscene" name="OpenRAVE Physics Scene">
+			<instance_physics_model url="#pmodel1" sid="pmodel1_inst" parent="#visual1">
+				<instance_rigid_body body="rigid0" sid="rigid0" target="#v1.node0"/>
+			</instance_physics_model>
+			<technique_common>
+				<gravity>0 0 -9.797930195020351</gravity>
+			</technique_common>
+		</physics_scene>
+	</library_physics_scenes>
+	<library_physics_models id="pmodels">
+		<physics_model id="pmodel1" name="calibration_board0">
+			<rigid_body sid="rigid0" name="base">
+				<technique_common>
+					<dynamic>true</dynamic>
+					<mass>1</mass>
+					<mass_frame>
+						<translate>0 0 0</translate>
+						<rotate>1 0 0 0</rotate>
+					</mass_frame>
+					<inertia>0.4 0.4 0.4</inertia>
+					<shape>
+						<instance_geometry url="#g1_link0_geom0"/>
+						<translate>0 0 0.1</translate>
+						<rotate>1 0 0 0</rotate>
+					</shape>
+				</technique_common>
+			</rigid_body>
+		</physics_model>
+	</library_physics_models>
+	<scene>
+		<instance_physics_scene url="#pscene" sid="pscene_inst"/>
+		<instance_visual_scene url="#vscene" sid="vscene_inst"/>
+		<instance_kinematics_scene url="#kscene" sid="kscene_inst">
+			<bind_kinematics_model node="visual1/node0">
+				<param>kscene_kmodel1_inst</param>
+			</bind_kinematics_model>
+		</instance_kinematics_scene>
+	</scene>
+	<extra id="sensors" type="library_sensors">
+		<technique profile="OpenRAVE"/>
+	</extra>
+	<extra id="actuators" type="library_actuators">
+		<technique profile="OpenRAVE"/>
+	</extra>
+</COLLADA>


### PR DESCRIPTION
Support for calibration board geometry.

Generate dot mesh for board automatically according to parameters. Serialized collada file will not contain the dots on the other hand.

Sample collada file can be found at `test/testdata/calibration_board.dae`

![image](https://user-images.githubusercontent.com/3591338/94113738-4ed4e480-fe82-11ea-9974-4753b7c13e5a.png)
