### PR TITLE
Fixed parabolicsmoothers

### DIFF
--- a/plugins/rplanners/parabolicsmoother.cpp
+++ b/plugins/rplanners/parabolicsmoother.cpp
@@ -2307,7 +2307,7 @@ protected:
                                 RAVELOG_VERBOSE_FORMAT("env=%d, the final SolveMinTime generated feasible segment, inserting it to outramps", GetEnv()->GetId());
                                 outramps.pop_back();
                                 outramps.insert(outramps.end(), outramps2.begin(), outramps2.end());
-                                break;
+                                // continue to inserting outramps to accumoutramps.
                             }
                             else if (retcheck.retcode == CFO_CheckTimeBasedConstraints) {
                                 nNumTimeBasedConstraintsFailed++;

--- a/plugins/rplanners/parabolicsmoother2.cpp
+++ b/plugins/rplanners/parabolicsmoother2.cpp
@@ -1697,6 +1697,7 @@ protected:
         std::vector<RampOptimizer::RampND>& shortcutRampNDVect = _cacheRampNDVect; // for storing interpolated trajectory
         std::vector<RampOptimizer::RampND>& shortcutRampNDVectOut = _cacheRampNDVectOut, &shortcutRampNDVectOut1 = _cacheRampNDVectOut1; // for storing checked trajectory
         std::vector<dReal>& x0Vect = _cacheX0Vect, &x1Vect = _cacheX1Vect, &v0Vect = _cacheV0Vect, &v1Vect = _cacheV1Vect;
+        std::vector<dReal>& tempX0Vect = _cacheTempX0Vect, &tempV0Vect = _cacheTempV0Vect;
         const dReal tOriginal = parabolicpath.GetDuration(); // the original trajectory duration before being shortcut
         dReal tTotal = tOriginal; // keeps track of the latest trajectory duration
 
@@ -1951,13 +1952,13 @@ protected:
                             // Modification inside Check2 results in the shortcut trajectory not ending at the desired velocity v1.
                             dReal allowedStretchTime = (t1 - t0) - (segmentTime + minTimeStep); // the time that this segment is allowed to stretch out such that it is still a useful shortcut
 
-                            shortcutRampNDVectOut.back().GetX0Vect(x0Vect);
-                            shortcutRampNDVectOut.back().GetV0Vect(v0Vect);
+                            shortcutRampNDVectOut.back().GetX0Vect(tempX0Vect);
+                            shortcutRampNDVectOut.back().GetV0Vect(tempV0Vect);
 #ifdef SMOOTHER2_TIMING_DEBUG
                             _nCallsInterpolator += 1;
                             _tStartInterpolator = utils::GetMicroTime();
 #endif
-                            bool res2 = _interpolator.ComputeArbitraryVelNDTrajectory(x0Vect, x1Vect, v0Vect, v1Vect, _parameters->_vConfigLowerLimit, _parameters->_vConfigUpperLimit, vellimits, accellimits, shortcutRampNDVect, true);
+                            bool res2 = _interpolator.ComputeArbitraryVelNDTrajectory(tempX0Vect, x1Vect, tempV0Vect, v1Vect, _parameters->_vConfigLowerLimit, _parameters->_vConfigUpperLimit, vellimits, accellimits, shortcutRampNDVect, true);
 #ifdef SMOOTHER2_TIMING_DEBUG
                             _tEndInterpolator = utils::GetMicroTime();
                             _totalTimeInterpolator += 0.000001f*(float)(_tEndInterpolator - _tStartInterpolator);
@@ -2448,6 +2449,7 @@ protected:
         std::vector<RampOptimizer::RampND>& shortcutRampNDVect = _cacheRampNDVect; // for storing interpolated trajectory
         std::vector<RampOptimizer::RampND>& shortcutRampNDVectOut = _cacheRampNDVectOut, &shortcutRampNDVectOut1 = _cacheRampNDVectOut1; // for storing checked trajectory
         std::vector<dReal>& x0Vect = _cacheX0Vect, &x1Vect = _cacheX1Vect, &v0Vect = _cacheV0Vect, &v1Vect = _cacheV1Vect;
+        std::vector<dReal>& tempX0Vect = _cacheTempX0Vect, &tempV0Vect = _cacheTempV0Vect;
         const dReal tOriginal = parabolicpath.GetDuration(); // the original trajectory duration before being shortcut
         dReal tTotal = tOriginal; // keeps track of the latest trajectory duration
 
@@ -2815,13 +2817,13 @@ protected:
                             // Modification inside Check2 results in the shortcut trajectory not ending at the desired velocity v1.
                             dReal allowedStretchTime = (t1 - t0) - (segmentTime + minTimeStep); // the time that this segment is allowed to stretch out such that it is still a useful shortcut
 
-                            shortcutRampNDVectOut.back().GetX0Vect(x0Vect);
-                            shortcutRampNDVectOut.back().GetV0Vect(v0Vect);
+                            shortcutRampNDVectOut.back().GetX0Vect(tempX0Vect);
+                            shortcutRampNDVectOut.back().GetV0Vect(tempV0Vect);
 #ifdef SMOOTHER2_TIMING_DEBUG
                             _nCallsInterpolator += 1;
                             _tStartInterpolator = utils::GetMicroTime();
 #endif
-                            bool res2 = _interpolator.ComputeArbitraryVelNDTrajectory(x0Vect, x1Vect, v0Vect, v1Vect, _parameters->_vConfigLowerLimit, _parameters->_vConfigUpperLimit, vellimits, accellimits, shortcutRampNDVect, true);
+                            bool res2 = _interpolator.ComputeArbitraryVelNDTrajectory(tempX0Vect, x1Vect, tempV0Vect, v1Vect, _parameters->_vConfigLowerLimit, _parameters->_vConfigUpperLimit, vellimits, accellimits, shortcutRampNDVect, true);
 #ifdef SMOOTHER2_TIMING_DEBUG
                             _tEndInterpolator = utils::GetMicroTime();
                             _totalTimeInterpolator += 0.000001f*(float)(_tEndInterpolator - _tStartInterpolator);
@@ -3436,6 +3438,7 @@ protected:
     std::vector<dReal> _cacheWaypoints; ///< stores concatenated waypoints obtained from the input trajectory
     std::vector<std::vector<dReal> > _cacheWaypointVect; ///< each element is a vector storing a waypoint
     std::vector<dReal> _cacheX0Vect, _cacheX1Vect, _cacheV0Vect, _cacheV1Vect, _cacheTVect; ///< used in PlanPath and _Shortcut
+    std::vector<dReal> _cacheTempX0Vect, _cacheTempV0Vect; ///< used in _Shortcut
     RampOptimizer::RampND _cacheRampND, _cacheRemRampND;
     std::vector<RampOptimizer::RampND> _cacheRampNDVect; ///< use cases: 1. being passed to _ComputeRampWithZeroVelEndpoints when retrieving cubic waypoints from input traj
                                                          ///             2. in _SetMileStones: being passed to _ComputeRampWithZeroVelEndpoints


### PR DESCRIPTION
`parabolicsmoother`: fixed a bug that skips adding checked ramps into the resulting shortcut segment
`parabolicsmoother2`: fixed a bug that causes discrepancies in the initial joint values and velocities of shortcut segments