### PR TITLE
python binding: added extracting gripperInfos from connected body

### DIFF
--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -614,6 +614,7 @@ OPENRAVEPY_API std::vector<KinBody::GrabbedInfoPtr> ExtractGrabbedInfoArray(py::
 OPENRAVEPY_API std::vector< std::pair< std::pair<std::string, int>, dReal>> ExtractDOFValuesArray(py::object pyDOFValuesList);
 OPENRAVEPY_API std::map<std::string, ReadablePtr> ExtractReadableInterfaces(py::object pyReadableInterfaces);
 OPENRAVEPY_API std::vector<RobotBase::AttachedSensorInfoPtr> ExtractAttachedSensorInfoArray(py::object pyAttachedSensorInfoList);
+OPENRAVEPY_API std::vector<RobotBase::GripperInfoPtr> ExtractGripperInfoArray(py::object pyGripperInfoList);
 OPENRAVEPY_API std::vector<RobotBase::ManipulatorInfoPtr> ExtractManipulatorInfoArray(py::object pyManipList);
 OPENRAVEPY_API std::vector<RobotBase::ConnectedBodyInfoPtr> ExtractConnectedBodyInfoArray(py::object pyConnectedBodyInfoList);
 OPENRAVEPY_API py::object ReturnDOFValues(const std::vector<std::pair<std::pair<std::string, int>, dReal>>& vDOFValues);

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -330,7 +330,13 @@ RobotBase::ConnectedBodyInfoPtr PyConnectedBodyInfo::GetConnectedBodyInfo() cons
     FOREACHC(it, vAttachedSensorInfos) {
         pinfo->_vAttachedSensorInfos.push_back(*it);
     }
-    // TODO: gripperinfos
+    // gripperinfos
+    std::vector<RobotBase::GripperInfoPtr> vGripperInfos = ExtractGripperInfoArray(_gripperInfos);
+    pinfo->_vGripperInfos.clear();
+    pinfo->_vGripperInfos.reserve(vGripperInfos.size());
+    FOREACHC(it, vGripperInfos) {
+        pinfo->_vGripperInfos.push_back(*it);
+    }
     return pinfo;
 }
 


### PR DESCRIPTION
it seems just missing implementation

previously, didn't return `gripperInfos`
```
In : robot.GetConnectedBodies()[0].GetInfo().SerializeJSON().keys()
Out: ['name', 'links', 'joints', 'uri', 'transform', 'linkName', 'tools', 'id', 'isActive']
```

with this PR,
```
In : robot.GetConnectedBodies()[0].GetInfo().SerializeJSON().keys()
Out: ['name', 'links', 'joints', 'uri', 'transform', 'gripperInfos', 'linkName', 'tools', 'id', 'isActive']
```

