### PR TITLE
call UpdateViewport only when widget is visible

### DIFF
--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -2106,7 +2106,9 @@ void QtOSGViewer::_UpdateEnvironment()
 
         // have to update model after messages since it can lock the environment
         UpdateFromModel();
-        _UpdateViewport();
+        if (_posgWidget->isVisible()) {
+            _UpdateViewport();
+        }
     }
 }
 


### PR DESCRIPTION
1. `qtosgrave::QtOSGViewer` has timer thread which calls `SetViewport` and `addEvent` constantly, and `GUIEventAdapter` event is queued in `osgFA::EventQueue`

2. queued events are consumed in `osgGA::EventQueue::takeEvents` which is called in rendering loop `qtosgrave::QOSGViewerWidget::paintGL`, and which fires only when **viewer is visible**.

These lead to memory leak (or huge memory consumption) when viewer is not visible.
Memory consumption speed is
240 (sizeof(GUIEventAdapter)) * 60 (Hz, timer frequency) * 3600 (to hour) = 49 MB / hour
The number above is very close to memory profiling result.

This PR fixes the issue by not calling SetViewport when an viewer (widget) is not visible.