### PR TITLE
Fix hash computation

### DIFF
--- a/src/libopenrave/libopenrave.h
+++ b/src/libopenrave/libopenrave.h
@@ -204,7 +204,7 @@ template <class T>
 inline void SerializeRound4(std::ostream& o, const RaveVector<T>& v)
 {
     // This function is used only for serializing quaternions. Need to
-    // take into account the face that v and -v represent the same
+    // take into account the fact that v and -v represent the same
     // rotation. Convert v to a rotation matrix instead to get a
     // unique representation. Then since the thrid column can be uniquely
     // determined given the first two, serializing only the first two

--- a/src/libopenrave/libopenrave.h
+++ b/src/libopenrave/libopenrave.h
@@ -230,9 +230,11 @@ inline void SerializeRound(std::ostream& o, const RaveTransform<T>& t)
 template <class T>
 inline void SerializeRound(std::ostream& o, const RaveTransformMatrix<T>& t)
 {
+    // Since the thrid column of the rotation matrix can be uniquely
+    // determined given the first two, serializing only the first two
+    // columns is sufficient for the purpose of hash computation.
     o << SerializationValue(t.m[0]) << " " << SerializationValue(t.m[4]) << " " << SerializationValue(t.m[8]) << " "
-      << SerializationValue(t.m[1]) << " " << SerializationValue(t.m[5]) << " " << SerializationValue(t.m[9]) << " "
-      << SerializationValue(t.m[2]) << " " << SerializationValue(t.m[6]) << " " << SerializationValue(t.m[10]) << " ";
+      << SerializationValue(t.m[1]) << " " << SerializationValue(t.m[5]) << " " << SerializationValue(t.m[9]) << " ";
     SerializeRound(o,t.trans);
 }
 

--- a/src/libopenrave/libopenrave.h
+++ b/src/libopenrave/libopenrave.h
@@ -203,7 +203,15 @@ inline void SerializeRound(std::ostream& o, double f)
 template <class T>
 inline void SerializeRound(std::ostream& o, const RaveVector<T>& v)
 {
-    o << SerializationValue(v.x) << " " << SerializationValue(v.y) << " " << SerializationValue(v.z) << " " << SerializationValue(v.w) << " ";
+    // This function is used only for serializing quaternions. Need to
+    // take into account the face that v and -v represent the same
+    // rotation. Convert v to a rotation matrix instead to get a
+    // unique representation. Then since the thrid column can be uniquely
+    // determined given the first two, serializing only the first two
+    // columns is sufficient for the purpose of hash computation.
+    RaveTransformMatrix<T> t = matrixFromQuat(v);
+    o << SerializationValue(t.m[0]) << " " << SerializationValue(t.m[4]) << " " << SerializationValue(t.m[8]) << " "
+      << SerializationValue(t.m[1]) << " " << SerializationValue(t.m[5]) << " " << SerializationValue(t.m[9]) << " ";
 }
 
 template <class T>

--- a/src/libopenrave/libopenrave.h
+++ b/src/libopenrave/libopenrave.h
@@ -218,7 +218,7 @@ inline void SerializeRound(std::ostream& o, const RaveTransform<T>& t)
     // because we're serializing a quaternion, have to fix what side of the hypershpere it is on
     Vector v = t.rot;
     for(int i = 0; i < 4; ++i) {
-        if( v[i] < g_fEpsilon ) {
+        if( v[i] < -g_fEpsilon ) {
             v = -v;
             break;
         }
@@ -227,7 +227,7 @@ inline void SerializeRound(std::ostream& o, const RaveTransform<T>& t)
         }
     }
     SerializeRound(o,v);
-    SerializeRound(o,t.trans);
+    SerializeRound3(o,t.trans);
 }
 
 template <class T>

--- a/src/libopenrave/libopenrave.h
+++ b/src/libopenrave/libopenrave.h
@@ -201,7 +201,7 @@ inline void SerializeRound(std::ostream& o, double f)
 }
 
 template <class T>
-inline void SerializeRound(std::ostream& o, const RaveVector<T>& v)
+inline void SerializeRound4(std::ostream& o, const RaveVector<T>& v)
 {
     // This function is used only for serializing quaternions. Need to
     // take into account the face that v and -v represent the same
@@ -223,18 +223,7 @@ inline void SerializeRound3(std::ostream& o, const RaveVector<T>& v)
 template <class T>
 inline void SerializeRound(std::ostream& o, const RaveTransform<T>& t)
 {
-    // because we're serializing a quaternion, have to fix what side of the hypershpere it is on
-    Vector v = t.rot;
-    for(int i = 0; i < 4; ++i) {
-        if( v[i] < -g_fEpsilon ) {
-            v = -v;
-            break;
-        }
-        else if( v[i] > g_fEpsilon ) {
-            break;
-        }
-    }
-    SerializeRound(o,v);
+    SerializeRound4(o,t.rot);
     SerializeRound3(o,t.trans);
 }
 

--- a/src/libopenrave/libopenrave.h
+++ b/src/libopenrave/libopenrave.h
@@ -201,7 +201,7 @@ inline void SerializeRound(std::ostream& o, double f)
 }
 
 template <class T>
-inline void SerializeRound4(std::ostream& o, const RaveVector<T>& v)
+inline void SerializeRoundQuaternion(std::ostream& o, const RaveVector<T>& v)
 {
     // This function is used only for serializing quaternions. Need to
     // take into account the fact that v and -v represent the same
@@ -223,7 +223,7 @@ inline void SerializeRound3(std::ostream& o, const RaveVector<T>& v)
 template <class T>
 inline void SerializeRound(std::ostream& o, const RaveTransform<T>& t)
 {
-    SerializeRound4(o,t.rot);
+    SerializeRoundQuaternion(o,t.rot);
     SerializeRound3(o,t.trans);
 }
 

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -2319,6 +2319,9 @@ void RobotBase::_PostprocessChangedParameters(uint32_t parameters)
             (*itmanip)->__hashkinematicsstructure.resize(0);
         }
     }
+    if( parameters & (Prop_LinkGeometry|Prop_RobotManipulatorTool|Prop_Sensors|Prop_SensorPlacement) ) {
+        __hashrobotstructure.resize(0);
+    }
     KinBody::_PostprocessChangedParameters(parameters);
 }
 


### PR DESCRIPTION
- Now serializing the rotational part of a pose by converting it to the rotation matrix representation first. Previously quaternion representation was used, leading to a problem as a quaternion `v` is equivalent to `-v`.
- In addition, when serializing a rotation matrix, only consider two columns as the third one can always be uniquely determined from the other two, to help save time.
- When serializing the translational part of a pose, consider only the first three values of the vector, instead of 4 (by using `SerializeRound3` instead of `SerializeRound`).
- Renamed `SerializeRound(std::ostream& o, const RaveVector<T>& v)` to `SerializeRoundQuaternion(std::ostream& o, const RaveVector<T>& v)` for clarity.
- Now clearing `__hashrobotstructure` when related properties change.

Thanks @kanbouchou  for the discussion.