### PR TITLE
Fix error due to automatically adding first partial variable

### DIFF
--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2010,8 +2010,7 @@ void KinBody::Joint::SetMimicEquations(int iaxis, const std::string& poseq, cons
     }
 
     for(int itype = 1; itype < 3; ++itype) {
-        if(itype == 2 && pmimic->_equations[itype].empty()) {
-            // ignore empty mimic_accel
+        if(itype != 0 && pmimic->_equations[itype].empty()) {
             continue;
         }
 


### PR DESCRIPTION
Fix error where the first partial equation is automatically added when the pos equation have a variable. When the pos equation evaluates to 0, loading the saved dae will assert since the variable in the first partial doesn't exit in the pos equation anymore and will fail to set mimic equations on all following joints.