### PR TITLE
Do not visualize frustum when fx and fy are 0

### DIFF
--- a/plugins/basesensors/basecamera.h
+++ b/plugins/basesensors/basecamera.h
@@ -481,7 +481,7 @@ protected:
         if( !_bRenderGeometry ) {
             return;
         }
-        if( !_graphgeometry ) {
+        if( !_graphgeometry && _pgeom->KK.fx > 0 && _pgeom->KK.fy > 0 ) {
             // render a simple frustum outlining camera's dimension
             // the frustum is colored with vColor, the x and y axes are colored separetely
             Vector points[7];


### PR DESCRIPTION
```h
dReal ik0 = 1/_pgeom->KK.fx, ik1 = 1/_pgeom->KK.fy;
points[0] = Vector(0,0,0);
points[1] = Vector(((dReal)_pgeom->width-_pgeom->KK.cx)*ik0, ((dReal)_pgeom->height-_pgeom->KK.cy)*ik1, 1);
```

skip rendering frustum when `fx` or `fy` is zero, since renderer cannot handle infinite far away points