### PR TITLE
Priority-based GUI thread message queueing system (Issue #893 cont'd)

### DIFF
--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1187,10 +1187,12 @@ void QtOSGViewer::_ProcessApplicationQuit()
 {
     RAVELOG_VERBOSE("processing viewer application quit\n");
     // remove all messages in order to release the locks
-    boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
-
     FOREACH(itpriority, _mapGUIFunctionLists) {
-        list<GUIThreadFunctionPtr> listGUIFunctions = itpriority->second;
+        list<GUIThreadFunctionPtr> listGUIFunctions;
+        {
+            boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
+            listGUIFunctions.swap(itpriority->second);
+        }
         if( listGUIFunctions.size() > 0 ) {
             bool bnotify = false;
             FOREACH(it,listGUIFunctions) {
@@ -2164,10 +2166,13 @@ void QtOSGViewer::SetEnvironmentSync(bool bUpdate)
 
     if( !bUpdate ) {
         // remove all messages in order to release the locks
-        boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
         // Clear GUI function lists for all priorities
         FOREACH(itpriority, _mapGUIFunctionLists) {
-            list<GUIThreadFunctionPtr> listGUIFunctions = itpriority->second;
+            list<GUIThreadFunctionPtr> listGUIFunctions;
+            {
+                boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
+                listGUIFunctions.swap(itpriority->second);
+            }
             if( listGUIFunctions.size() > 0 ) {
                 bool bnotify = false;
                 FOREACH(it,listGUIFunctions) {

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1353,10 +1353,10 @@ void QtOSGViewer::quitmainloop()
 void QtOSGViewer::Show(int showtype)
 {
     if( showtype ) {
-        _PostToGUIThread(boost::bind(&QtOSGViewer::show, this), GUIThreadQueuePriority::HIGH);
+        _PostToGUIThread(boost::bind(&QtOSGViewer::show, this), GUIThreadQueuePriority::VERY_HIGH);
     }
     else {
-        _PostToGUIThread(boost::bind(&QtOSGViewer::hide, this), GUIThreadQueuePriority::HIGH);
+        _PostToGUIThread(boost::bind(&QtOSGViewer::hide, this), GUIThreadQueuePriority::VERY_HIGH);
     }
 //    // have to put this in the message queue
 //    if (showtype ) {
@@ -2130,7 +2130,7 @@ void QtOSGViewer::_UpdateEnvironment()
 size_t QtOSGViewer::_GetQueueSizeForPriority(GUIThreadQueuePriority priority) {
     size_t queueSize = 0;
     for (uint8_t i = static_cast<uint8_t>(priority); i < 4; i++) {
-        queueSize += _mapGUIFunctionListLimits[static_cast<GUIThreadQueuePriority>(i)].size();
+        queueSize += _mapGUIFunctionLists[static_cast<GUIThreadQueuePriority>(i)].size();
     }
     return queueSize;
 }
@@ -2154,7 +2154,7 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, GUIThreadQ
         RAVELOG_WARN("GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[priority]);
         return;
     }
-    _mapGUIFunctionLists[priority].push_back(pfn)
+    _mapGUIFunctionLists[priority].push_back(pfn);
     if( block ) {
         while(!pfn->IsFinished()) {
             _notifyGUIFunctionComplete.wait(_mutexGUIFunctions);

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -2143,10 +2143,6 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, ViewerComm
     }
     // GUI thread function queue size limit
     if (_mapGUIFunctionLists[priority].size() >= _mapGUIFunctionListLimits[priority]) {
-        if (!_DropOldViewerCommandFromQueue(priority)) {
-            RAVELOG_WARN("New GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[priority]);
-            return;
-        }
         if(_mapGUIFunctionLists[priority].size() > 0) {
             _mapGUIFunctionLists[priority].pop_front();
             RAVELOG_WARN("Old GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[static_cast<ViewerCommandPriority>(i)]);

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -473,7 +473,7 @@ void QtOSGViewer::_UpdateViewerCallback()
         if (!_excessGUIFunctions.empty()) {
             boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
             int excessSize = _excessGUIFunctions.size();
-            for (int idx = 0; idx < excessSize && idx < 1000; idx++) {
+            for (int idx = 0; idx < excessSize && _listGUIFunctions.size() < 1000; idx++) {
                 _listGUIFunctions.push_back(_excessGUIFunctions.front());
                 _excessGUIFunctions.pop_front();
             }

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -472,9 +472,9 @@ void QtOSGViewer::_UpdateViewerCallback()
         }
         if (!_listGUIFunctionsBuffer.empty()) {
             boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
-            auto insertPos = _listGUIFunctions.end();
-            auto bufferStartPos = _listGUIFunctionsBuffer.begin();
-            auto bufferEndPos = _listGUIFunctionsBuffer.begin();
+            std::list<GUIThreadFunctionPtr>::iterator insertPos = _listGUIFunctions.end();
+            std::list<GUIThreadFunctionPtr>::iterator bufferStartPos = _listGUIFunctionsBuffer.begin();
+            std::list<GUIThreadFunctionPtr>::iterator bufferEndPos = _listGUIFunctionsBuffer.begin();
             int itemsToAdd = 1000 < _listGUIFunctions.size() ? 0 : 1000 - _listGUIFunctions.size();
             std::advance(bufferEndPos, std::min(itemsToAdd, (int) _listGUIFunctionsBuffer.size()));
             _listGUIFunctions.splice(insertPos, _listGUIFunctionsBuffer, bufferStartPos, bufferEndPos);

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -2130,12 +2130,8 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, bool block
 
     boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
     GUIThreadFunctionPtr pfn(new GUIThreadFunction(fn, block));
-    if( _listGUIFunctions.size() > 1000 || !_listGUIFunctionsBuffer.empty() ) {
-        // can happen if system is especially slow
-        _listGUIFunctionsBuffer.push_back(pfn);
-    } else {
-        _listGUIFunctions.push_back(pfn);
-    }
+    // pushing to buffer directly is thread-safe
+    _listGUIFunctionsBuffer.push_back(pfn);
     if( block ) {
         while(!pfn->IsFinished()) {
             _notifyGUIFunctionComplete.wait(_mutexGUIFunctions);

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -472,10 +472,9 @@ void QtOSGViewer::_UpdateViewerCallback()
         }
         if (!_listGUIFunctionsBuffer.empty()) {
             boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
-            auto insertPos = _listGUIFunctions.begin();
+            auto insertPos = _listGUIFunctions.end();
             auto bufferStartPos = _listGUIFunctionsBuffer.begin();
             auto bufferEndPos = _listGUIFunctionsBuffer.begin();
-            std::advance(insertPos, _listGUIFunctions.size());
             int itemsToAdd = 1000 < _listGUIFunctions.size() ? 0 : 1000 - _listGUIFunctions.size();
             std::advance(bufferEndPos, std::min(itemsToAdd, (int) _listGUIFunctionsBuffer.size()));
             _listGUIFunctions.splice(insertPos, _listGUIFunctionsBuffer, bufferStartPos, bufferEndPos);

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -2100,10 +2100,6 @@ void QtOSGViewer::_UpdateEnvironment()
             listGUIFunctions.swap(_listGUIFunctions);
         }
 
-        if (listGUIFunctions.size() > 100) {
-            RAVELOG_WARN("gui insertion indices: %d %d %d", _mapGUIInsertionIndices[GUIThreadQueuePriority::HIGH], _mapGUIInsertionIndices[GUIThreadQueuePriority::MEDIUM], _mapGUIInsertionIndices[GUIThreadQueuePriority::LOW]);
-        }
-
         FOREACH(itmsg, listGUIFunctions) {
             try {
                 (*itmsg)->Call();
@@ -2147,8 +2143,8 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, GUIThreadQ
         return;
     }
     // GUI thread function queue size limit for essential functions
-    if (_mapGUIInsertionIndices[GUIThreadQueuePriority::HIGH] >= 10000) {
-        RAVELOG_WARN("GUI thread function of priority %d dropped due to function queue exceeding size of 10000", priority);
+    if (_mapGUIInsertionIndices[GUIThreadQueuePriority::HIGH] >= 100000) {
+        RAVELOG_WARN("GUI thread function of priority %d dropped due to function queue exceeding size of 100000", priority);
         return;
     }
     std::advance(it, _mapGUIInsertionIndices[priority]);

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -2145,7 +2145,7 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, ViewerComm
     if (_mapGUIFunctionLists[priority].size() >= _mapGUIFunctionListLimits[priority]) {
         if(_mapGUIFunctionLists[priority].size() > 0) {
             _mapGUIFunctionLists[priority].pop_front();
-            RAVELOG_WARN("Old GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[static_cast<ViewerCommandPriority>(i)]);
+            RAVELOG_WARN("Old GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[priority]);
         } else {
             RAVELOG_WARN("New GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[priority]);
             return;

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1516,7 +1516,7 @@ GraphHandlePtr QtOSGViewer::plot3(const float* ppoints, int numPoints, int strid
     }
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::POINTS, new osg::Point(fPointSize),color.w<1), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::POINTS, new osg::Point(fPointSize),color.w<1), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1537,7 +1537,7 @@ GraphHandlePtr QtOSGViewer::plot3(const float* ppoints, int numPoints, int strid
         }
     }
 
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::POINTS, osg::ref_ptr<osg::Point>(new osg::Point(fPointSize)), bhasalpha), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::POINTS, osg::ref_ptr<osg::Point>(new osg::Point(fPointSize)), bhasalpha), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1552,7 +1552,7 @@ GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, i
     }
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, int stride, float fwidth, const float* colors)
@@ -1567,7 +1567,7 @@ GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, i
         (*vcolors)[i] = osg::Vec4f(colors[i * 3 + 0], colors[i * 3 + 1], colors[i * 3 + 2], 1.0f);
     }
 
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1581,7 +1581,7 @@ GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, in
     }
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, int stride, float fwidth, const float* colors)
@@ -1596,7 +1596,7 @@ GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, in
         (*vcolors)[i] = osg::Vec4f(colors[i * 3 + 0], colors[i * 3 + 1], colors[i * 3 + 2], 1.0f);
     }
 
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1630,7 +1630,7 @@ void QtOSGViewer::_DrawBox(OSGSwitchPtr handle, const RaveVector<float>& vpos, c
 GraphHandlePtr QtOSGViewer::drawbox(const RaveVector<float>& vpos, const RaveVector<float>& vextents)
 {
     OSGSwitchPtr handle = _CreateGraphHandle();
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawBox, this, handle, vpos, vextents, false), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawBox, this, handle, vpos, vextents, false), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr();
 }
 
@@ -1712,7 +1712,7 @@ void QtOSGViewer::_DrawPlane(OSGSwitchPtr handle, const RaveTransform<float>& tp
 GraphHandlePtr QtOSGViewer::drawplane(const RaveTransform<float>& tplane, const RaveVector<float>& vextents, const boost::multi_array<float,3>& vtexture)
 {
     OSGSwitchPtr handle = _CreateGraphHandle();
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawPlane, this, handle, tplane, vextents, vtexture), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawPlane, this, handle, tplane, vextents, vtexture), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1777,7 +1777,7 @@ GraphHandlePtr QtOSGViewer::drawtrimesh(const float* ppoints, int stride, const 
     osg::ref_ptr<osg::Vec4Array> osgcolors = new osg::Vec4Array(1);
     (*osgcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
 
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, handle, osgvertices, osgcolors, osgindices, color.w<1), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, handle, osgvertices, osgcolors, osgindices, color.w<1), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1812,7 +1812,7 @@ GraphHandlePtr QtOSGViewer::drawtrimesh(const float* ppoints, int stride, const 
     }
 
     OSGSwitchPtr handle = _CreateGraphHandle();
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, handle, osgvertices, osgcolors, osgindices, bhasalpha), ViewerCommandPriority::HIGH); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, handle, osgvertices, osgcolors, osgindices, bhasalpha), ViewerCommandPriority::MEDIUM); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -2143,13 +2143,9 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, ViewerComm
     }
     // GUI thread function queue size limit
     if (_mapGUIFunctionLists[priority].size() >= _mapGUIFunctionListLimits[priority]) {
-        if(_mapGUIFunctionLists[priority].size() > 0) {
-            _mapGUIFunctionLists[priority].pop_front();
-            RAVELOG_WARN("Old GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[priority]);
-        } else {
-            RAVELOG_WARN("New GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[priority]);
-            return;
-        }
+        // Possibly undefined behavior if _mapGUIFunctionListLimits[priority] is ever set to be 0, but that currently never happens
+        _mapGUIFunctionLists[priority].pop_front();
+        RAVELOG_WARN("Old GUI thread function of priority %d dropped due to function queue for given priority exceeding size of %d", priority, _mapGUIFunctionListLimits[priority]);
     }
     _mapGUIFunctionLists[priority].push_back(pfn);
     if( block ) {

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -471,6 +471,7 @@ void QtOSGViewer::_UpdateViewerCallback()
             }
         }
         if (!_excessGUIFunctions.empty()) {
+            boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
             int excessSize = _excessGUIFunctions.size();
             for (int idx = 0; idx < excessSize && idx < 1000; idx++) {
                 _listGUIFunctions.push_back(_excessGUIFunctions.front());

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1514,7 +1514,7 @@ GraphHandlePtr QtOSGViewer::plot3(const float* ppoints, int numPoints, int strid
     }
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, OSGSwitchPtr(handle), vvertices, vcolors, osg::PrimitiveSet::POINTS, new osg::Point(fPointSize),color.w<1)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::POINTS, new osg::Point(fPointSize),color.w<1)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1535,7 +1535,7 @@ GraphHandlePtr QtOSGViewer::plot3(const float* ppoints, int numPoints, int strid
         }
     }
 
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, OSGSwitchPtr(handle), vvertices, vcolors, osg::PrimitiveSet::POINTS, osg::ref_ptr<osg::Point>(new osg::Point(fPointSize)), bhasalpha)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::POINTS, osg::ref_ptr<osg::Point>(new osg::Point(fPointSize)), bhasalpha)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1550,7 +1550,7 @@ GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, i
     }
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, OSGSwitchPtr(handle), vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, int stride, float fwidth, const float* colors)
@@ -1565,7 +1565,7 @@ GraphHandlePtr QtOSGViewer::drawlinestrip(const float* ppoints, int numPoints, i
         (*vcolors)[i] = osg::Vec4f(colors[i * 3 + 0], colors[i * 3 + 1], colors[i * 3 + 2], 1.0f);
     }
 
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, OSGSwitchPtr(handle), vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINE_STRIP, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1579,7 +1579,7 @@ GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, in
     }
     osg::ref_ptr<osg::Vec4Array> vcolors = new osg::Vec4Array(1);
     (*vcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, OSGSwitchPtr(handle), vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), color.w<1)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, int stride, float fwidth, const float* colors)
@@ -1594,7 +1594,7 @@ GraphHandlePtr QtOSGViewer::drawlinelist(const float* ppoints, int numPoints, in
         (*vcolors)[i] = osg::Vec4f(colors[i * 3 + 0], colors[i * 3 + 1], colors[i * 3 + 2], 1.0f);
     }
 
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, OSGSwitchPtr(handle), vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_Draw, this, handle, vvertices, vcolors, osg::PrimitiveSet::LINES, osg::ref_ptr<osg::LineWidth>(new osg::LineWidth(fwidth)), false)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1628,7 +1628,7 @@ void QtOSGViewer::_DrawBox(OSGSwitchPtr handle, const RaveVector<float>& vpos, c
 GraphHandlePtr QtOSGViewer::drawbox(const RaveVector<float>& vpos, const RaveVector<float>& vextents)
 {
     OSGSwitchPtr handle = _CreateGraphHandle();
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawBox, this, OSGSwitchPtr(handle), vpos, vextents, false)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawBox, this, handle, vpos, vextents, false)); // copies ref counts
     return GraphHandlePtr();
 }
 
@@ -1710,7 +1710,7 @@ void QtOSGViewer::_DrawPlane(OSGSwitchPtr handle, const RaveTransform<float>& tp
 GraphHandlePtr QtOSGViewer::drawplane(const RaveTransform<float>& tplane, const RaveVector<float>& vextents, const boost::multi_array<float,3>& vtexture)
 {
     OSGSwitchPtr handle = _CreateGraphHandle();
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawPlane, this, OSGSwitchPtr(handle), tplane, vextents, vtexture)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawPlane, this, handle, tplane, vextents, vtexture)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1775,7 +1775,7 @@ GraphHandlePtr QtOSGViewer::drawtrimesh(const float* ppoints, int stride, const 
     osg::ref_ptr<osg::Vec4Array> osgcolors = new osg::Vec4Array(1);
     (*osgcolors)[0] = osg::Vec4f(color.x, color.y, color.z, color.w);
 
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, OSGSwitchPtr(handle), osgvertices, osgcolors, osgindices, color.w<1)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, handle, osgvertices, osgcolors, osgindices, color.w<1)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -1810,7 +1810,7 @@ GraphHandlePtr QtOSGViewer::drawtrimesh(const float* ppoints, int stride, const 
     }
 
     OSGSwitchPtr handle = _CreateGraphHandle();
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, OSGSwitchPtr(handle), osgvertices, osgcolors, osgindices, bhasalpha)); // copies ref counts
+    _PostToGUIThread(boost::bind(&QtOSGViewer::_DrawTriMesh, this, handle, osgvertices, osgcolors, osgindices, bhasalpha)); // copies ref counts
     return GraphHandlePtr(new PrivateGraphHandle(shared_viewer(), handle));
 }
 
@@ -2131,7 +2131,7 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, bool block
 
     boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
     GUIThreadFunctionPtr pfn(new GUIThreadFunction(fn, block));
-    if( _listGUIFunctions.size() > 1000 ) {
+    if( _listGUIFunctions.size() > 1000 || !_listGUIFunctionsBuffer.empty() ) {
         // can happen if system is especially slow
         _listGUIFunctionsBuffer.push_back(pfn);
     } else {

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -472,13 +472,12 @@ void QtOSGViewer::_UpdateViewerCallback()
         }
         if (!_listGUIFunctionsBuffer.empty()) {
             boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
-            int excessSize = _listGUIFunctionsBuffer.size();
             auto insertPos = _listGUIFunctions.begin();
             auto bufferStartPos = _listGUIFunctionsBuffer.begin();
             auto bufferEndPos = _listGUIFunctionsBuffer.begin();
             std::advance(insertPos, _listGUIFunctions.size());
-            std::advance(bufferStartPos, 1);
-            std::advance(bufferEndPos, std::min(1000 - _listGUIFunctions.size(), _listGUIFunctionsBuffer.size())+1);
+            int itemsToAdd = 1000 < _listGUIFunctions.size() ? 0 : 1000 - _listGUIFunctions.size();
+            std::advance(bufferEndPos, std::min(itemsToAdd, (int) _listGUIFunctionsBuffer.size()));
             _listGUIFunctions.splice(insertPos, _listGUIFunctionsBuffer, bufferStartPos, bufferEndPos);
         }
     }

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -350,12 +350,6 @@ public:
         LOW = 0 ///< denotes a GUI task that presents negligibly adversely effects on the program should it fail to complete execution
     };
 
-    /// \brief gets "queue number", or sum of lengths of all queues of equal or higher priority than the input priority
-    size_t _GetViewerCommandNumber(ViewerCommandPriority priority);
-
-    /// \brief finds then drops the oldest and lowest priority function if it is <= input priority, returning true if a match was found
-    bool _DropOldViewerCommandFromQueue(ViewerCommandPriority priority);
-
     /// \brief posts a function to be executed in the GUI thread
     ///
     /// \param fn the function to execute

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -344,9 +344,10 @@ public:
 
     /// \brief priority values used to determine how important it is to process certain GUI thread functions over others
     enum GUIThreadQueuePriority : uint8_t {
-        HIGH = 0, ///< denotes an important GUI task that must be processed regardless of viewer state or queue size
+        VERY_HIGH = 3 //< denotes an critical GUI task that must be processed ASAP regardless of viewer state or queue size
+        HIGH = 2, ///< denotes an important GUI task that must be processed regardless of viewer state or queue size
         MEDIUM = 1, ///< denotes a GUI task that takes precedence over low-priority tasks but yields to important tasks
-        LOW = 2 ///< denotes a GUI task that presents negligibly adversely effects on the program should it fail to complete execution
+        LOW = 0 ///< denotes a GUI task that presents negligibly adversely effects on the program should it fail to complete execution
     };
 
     /// \brief posts a function to be executed in the GUI thread
@@ -402,8 +403,8 @@ public:
     bool _PanCameraYDirectionCommand(ostream& sout, istream& sinput);
 
     //@{ Message Queue
-    std::map<GUIThreadQueuePriority, uint> _mapGUIInsertionIndices; ///< map between priority and index of next insertion for given priority level
-    list<GUIThreadFunctionPtr> _listGUIFunctions; ///< list of GUI functions that should be called in the viewer update thread. protected by _mutexGUIFunctions
+    std::map<GUIThreadQueuePriority, list<GUIThreadFunctionPtr>> _mapGUIFunctionLists; ///< map between priority and sublist for given priority level. protected by _mutexGUIFunctions
+    std::map<GUIThreadQueuePriority, size_t> _mapGUIFunctionListLimits; ///< map between priority and sublist size limit for given priority level
     mutable list<Item*> _listRemoveItems; ///< raw points of items to be deleted in the viewer update thread, triggered from _DeleteItemCallback. proteced by _mutexItems
     boost::mutex _mutexItems; ///< protects _listRemoveItems
     mutable boost::mutex _mutexGUIFunctions;

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -283,7 +283,7 @@ public:
         {
             boost::shared_ptr<QtOSGViewer> viewer = _wviewer.lock();
             if(!!viewer) {
-                viewer->_PostToGUIThread(boost::bind(&QtOSGViewer::_SetGraphShow, viewer, _handle, bShow), ViewerCommandPriority::HIGH); // _handle is copied, so it will maintain the reference
+                viewer->_PostToGUIThread(boost::bind(&QtOSGViewer::_SetGraphShow, viewer, _handle, bShow), ViewerCommandPriority::VERY_HIGH); // _handle is copied, so it will maintain the reference
             }
         }
 

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -396,6 +396,7 @@ public:
 
     //@{ Message Queue
     list<GUIThreadFunctionPtr> _listGUIFunctions; ///< list of GUI functions that should be called in the viewer update thread. protected by _mutexGUIFunctions
+    list<GUIThreadFunctionPtr> _excessGUIFunctions; ///< list of GUI functions that exceed the queue limit and are thus stashed.
     mutable list<Item*> _listRemoveItems; ///< raw points of items to be deleted in the viewer update thread, triggered from _DeleteItemCallback. proteced by _mutexItems
     boost::mutex _mutexItems; ///< protects _listRemoveItems
     mutable boost::mutex _mutexGUIFunctions;

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -396,7 +396,7 @@ public:
 
     //@{ Message Queue
     list<GUIThreadFunctionPtr> _listGUIFunctions; ///< list of GUI functions that should be called in the viewer update thread. protected by _mutexGUIFunctions
-    list<GUIThreadFunctionPtr> _excessGUIFunctions; ///< list of GUI functions that exceed the queue limit and are thus stashed.
+    list<GUIThreadFunctionPtr> _listGUIFunctionsBuffer; ///< list of GUI functions that exceed the queue limit and are thus stashed.
     mutable list<Item*> _listRemoveItems; ///< raw points of items to be deleted in the viewer update thread, triggered from _DeleteItemCallback. proteced by _mutexItems
     boost::mutex _mutexItems; ///< protects _listRemoveItems
     mutable boost::mutex _mutexGUIFunctions;

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -344,11 +344,14 @@ public:
 
     /// \brief priority values used to determine how important it is to process certain GUI thread functions over others
     enum GUIThreadQueuePriority : uint8_t {
-        VERY_HIGH = 3 //< denotes an critical GUI task that must be processed ASAP regardless of viewer state or queue size
+        VERY_HIGH = 3, //< denotes an critical GUI task that must be processed ASAP regardless of viewer state or queue size
         HIGH = 2, ///< denotes an important GUI task that must be processed regardless of viewer state or queue size
         MEDIUM = 1, ///< denotes a GUI task that takes precedence over low-priority tasks but yields to important tasks
         LOW = 0 ///< denotes a GUI task that presents negligibly adversely effects on the program should it fail to complete execution
     };
+
+    /// \brief gets "queue position", or sum of lengths of all queues of equal or higher priority than the input priority
+    size_t _GetQueueSizeForPriority(GUIThreadQueuePriority priority);
 
     /// \brief posts a function to be executed in the GUI thread
     ///


### PR DESCRIPTION
This pull request addresses issue #893 by categorizing all GUI thread message functions into three priority categories, with lesser-priority message being queued later in the queue and more likely to be dropped when the queue exceeds a certain size limit. High-priority messages are deemed essential and are able to enter the queue even when the viewer is unable to process messages (other messages are instead dropped on the spot in this case) as well as join the queue beyond the regular size limit, although a hard limit for high-priority messages still exists and can be set in the event that an extremely high amount of messages flood the queue. Such a solution allows important messages like handle closures to be handled to the best of the viewer's ability while devoting less resources to less essential messages if needed.

Feel free to suggest or edit in changes in the priority values given to each of the GUI thread message functions.