### PR TITLE
15x speedup log level access

### DIFF
--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -595,43 +595,18 @@ public:
         _nDebugLevel = level;
     }
 
-    int GetDebugLevel()
-    {
-        int level = _nDebugLevel;
-        if (_logger != NULL) {
-            if (_logger->isEnabledFor(log4cxx::Level::getTrace())) {
-                level = Level_Verbose;
-            }
-            else if (_logger->isEnabledFor(log4cxx::Level::getDebug())) {
-                level = Level_Debug;
-            }
-            else if (_logger->isEnabledFor(log4cxx::Level::getInfo())) {
-                level = Level_Info;
-            }
-            else if (_logger->isEnabledFor(log4cxx::Level::getWarn())) {
-                level = Level_Warn;
-            }
-            else if (_logger->isEnabledFor(log4cxx::Level::getError())) {
-                level = Level_Error;
-            }
-            else {
-                level = Level_Fatal;
-            }
-        }
-        return level | (_nDebugLevel & ~Level_OutputMask);
-    }
-
 #else
     void SetDebugLevel(int level)
     {
         _nDebugLevel = level;
     }
 
+#endif
+
     int GetDebugLevel()
     {
         return _nDebugLevel;
     }
-#endif
 
     class XMLReaderFunctionData : public UserData
     {


### PR DESCRIPTION
Problem
===========
Checking log level was taking long time and non-printed log messages was costing non-negligible time.

Fix
=======
``isEnabledFor`` and ``log4cxx::Level::get`` was taking non-negligible time. since ``_nDebugLevel`` should be storing the correct log level, just return it without accessing log4cxx.


Improvement
=============

One call to ``RAVELOG_VERBOSE("")`` when debug level is INFO took about 150ns in production branch. In this feature branch, it takes about 10ns or less.

With internal benchmark script ``******_benchmark.py -p 1`` 100 times, there is about 2% speed up.
```
production:  0.018038 ± 0.000156
feature:  0.017646 ± 0.000130
```
Time is in sec.