### PR TITLE
Add Python binding for KinBody::Joint::IsActive()

### DIFF
--- a/python/bindings/docstrings.cpp
+++ b/python/bindings/docstrings.cpp
@@ -203,6 +203,7 @@ m["en function KinBody::Joint GetJointIndex"] = "\n\nint  **GetJointIndex**\\()\
 m["en function KinBody::Joint GetParent"] = "\n\nKinBodyPtr  **GetParent**\\()\n    \n            ";
 m["en function KinBody::Joint GetFirstAttached"] = "\n\nLinkPtr  **GetFirstAttached**\\()\n    \n            ";
 m["en function KinBody::Joint GetSecondAttached"] = "\n\nLinkPtr  **GetSecondAttached**\\()\n    \n            ";
+m["en function KinBody::Joint IsActive"] = "\n\nbool  **IsActive**\\()\n    \n    Return true if joint is active\n    \n            ";
 m["en function KinBody::Joint IsStatic"] = "\n\nbool  **IsStatic**\\()\n    \n    Return true if joint can be treated as a static binding (ie all limits are 0)\n    \n            ";
 m["en function KinBody::Joint IsCircular"] = "\n\nbool  **IsCircular**\\(int iaxis)\n    \n    Return true if joint axis has an identification at some of its lower and upper limits.\n    \n    An identification of the lower and upper limits means that once the joint reaches its upper limits, it is also at its lower limit. The most common identification on revolute joints at -pi and pi. 'circularity' means the joint does not stop at limits. Although currently not developed, it could be possible to support identification for joints that are not revolute.         ";
 m["en function KinBody::Joint IsRevolute"] = "\n\nbool  **IsRevolute**\\(int iaxis)\n    \n    returns true if the axis describes a rotation around an axis.\n    \n    *Parameters*\n     ``iaxis`` - \n      the axis of the joint to return the results for \n            ";

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -408,6 +408,7 @@ public:
     bool IsCircular(int iaxis) const;
     bool IsRevolute(int iaxis) const;
     bool IsPrismatic(int iaxis) const;
+    bool IsActive() const;
     bool IsStatic() const;
 
     int GetDOF() const;

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -1756,6 +1756,9 @@ bool PyJoint::IsRevolute(int iaxis) const {
 bool PyJoint::IsPrismatic(int iaxis) const {
     return _pjoint->IsPrismatic(iaxis);
 }
+bool PyJoint::IsActive() const {
+    return _pjoint->IsActive();
+}
 bool PyJoint::IsStatic() const {
     return _pjoint->IsStatic();
 }
@@ -5640,6 +5643,7 @@ void init_openravepy_kinbody()
                            .def("GetParent", &PyJoint::GetParent, DOXY_FN(KinBody::Joint,GetParent))
                            .def("GetFirstAttached", &PyJoint::GetFirstAttached, DOXY_FN(KinBody::Joint,GetFirstAttached))
                            .def("GetSecondAttached", &PyJoint::GetSecondAttached, DOXY_FN(KinBody::Joint,GetSecondAttached))
+                           .def("IsActive",&PyJoint::IsActive, DOXY_FN(KinBody::Joint,IsActive))
                            .def("IsStatic",&PyJoint::IsStatic, DOXY_FN(KinBody::Joint,IsStatic))
                            .def("IsCircular",&PyJoint::IsCircular, DOXY_FN(KinBody::Joint,IsCircular))
                            .def("IsRevolute",&PyJoint::IsRevolute, DOXY_FN(KinBody::Joint,IsRevolute))


### PR DESCRIPTION
This patch adds a missing Python binding for `KinBody::Joint::IsActive()`.