### PR TITLE
boost::bind users should include boost/bind.hpp

### DIFF
--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -40,6 +40,7 @@
 #include <boost/format.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/version.hpp>
+#include <boost/bind.hpp>
 
 #define PY_ARRAY_UNIQUE_SYMBOL PyArrayHandle
 #ifndef USE_PYBIND11_PYTHON_BINDINGS


### PR DESCRIPTION
otherwise we get this using boost latest 1.74:

```
/home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_int.cpp: In member function ‘pybind11::object openravepy::PyEnvironmentBase::RegisterBodyCallback(pybind11::object)’:
/home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_int.cpp:1850:125: error: ‘_1’ was not declared in this scope
 1850 |     UserDataPtr p = _penv->RegisterBodyCallback(boost::bind(&PyEnvironmentBase::_BodyCallback,shared_from_this(),fncallback,_1,_2));
      |                                                                                                                             ^~
```

similar PR https://github.com/mujin/controllerclientcpp/pull/73

also please take a brief look at ikfastcpp/fixBoostBind and robotbridges/fixBoostBind