### PR TITLE
[quick] Fix typo

### DIFF
--- a/plugins/fclrave/fclcollision.h
+++ b/plugins/fclrave/fclcollision.h
@@ -1165,7 +1165,7 @@ private:
             //RAVELOG_VERBOSE_FORMAT("env=%d, link %s:%s with %s:%s", GetEnv()->GetId()%plink1->GetParent()->GetName()%plink1->GetName()%plink2->GetParent()->GetName()%plink2->GetName());
             FOREACH(itgeompair1, pLINK1->vgeoms) {
                 FOREACH(itgeompair2, pLINK2->vgeoms) {
--                   CheckNarrowPhaseGeomDistance(itgeompair1->second.get(), itgeompair2->second.get(), pcb, dist);
+                    CheckNarrowPhaseGeomDistance(itgeompair1->second.get(), itgeompair2->second.get(), pcb, dist);
                 }
             }
         }


### PR DESCRIPTION
I guess following code is legal
```
bool func() { return true; }

int main()
{
    -func();
    return 0;
}
```