### PR TITLE
Fix: Populate KinBody::LinkInfo::_vForcedAdjacentLinks with "adjacent" elements in XML parser

### DIFF
--- a/src/libopenrave-core/xmlreaders-core.cpp
+++ b/src/libopenrave-core/xmlreaders-core.cpp
@@ -2284,6 +2284,18 @@ public:
                 pair<string, string> entry;
                 _ss >> entry.first >> entry.second;
                 _pchain->_vForcedAdjacentLinks.push_back(entry);
+                KinBody::LinkPtr plink0 = _pchain->GetLink(entry.first);
+                if( !plink0 ) {
+                    RAVELOG_WARN(str(boost::format("failed to resolve link0 %s\n")%entry.first));
+                }
+                else {
+                    if( !_pchain->GetLink(entry.second) ) {
+                        RAVELOG_WARN(str(boost::format("failed to resolve link1 %s\n")%entry.second));
+                    }
+                    else {
+                        plink0->_info._vForcedAdjacentLinks.push_back(entry.second);
+                    }
+                }
             }
             else if( xmlname == "modelsdir" ) {
                 _strModelsDir = _ss.str();


### PR DESCRIPTION
While reading a robot XML file, `KinBody::LinkInfo::_vForcedAdjacentLinks` also needs to be populated with link pairs specified as `adjacent`. This makes the JSON serialiser export adjacent links imported from a robot XML file properly.

Related: #964 

Sidenote: `KinBody::LinkInfo::_vForcedAdjacentLinks` is the primary information source about adjacent links while `KinBody::_vForcedAdjacentLinks` are updated with `KinBody::LinkInfo::_vForcedAdjacentLinks` in `KinBody::_InitAndAddLink()`.
