### PR TITLE
Fixes for fclmanager

### DIFF
--- a/plugins/fclrave/fclmanagercache.h
+++ b/plugins/fclrave/fclmanagercache.h
@@ -487,7 +487,7 @@ public:
             KinBodyConstPtr pbody = cache.pwbody.lock();
             if( !pbody || pbody->GetEnvironmentBodyIndex() == 0 ) {
                 // should happen when parts are removed
-                RAVELOG_VERBOSE_FORMAT("env=%d, %u manager contains invalid body %s, removing for now", _fclspace.GetEnvironmentId()%_lastSyncTimeStamp%(!pbody ? std::string() : pbody->GetName()));
+                // RAVELOG_VERBOSE_FORMAT("env=%d, %u manager contains invalid body %s, removing for now", _fclspace.GetEnvironmentId()%_lastSyncTimeStamp%(!pbody ? std::string() : pbody->GetName()));
                 FOREACH(itcolobj, cache.vcolobjs) {
                     if( !!itcolobj->get() ) {
                         pmanager->unregisterObject(itcolobj->get());

--- a/plugins/fclrave/fclmanagercache.h
+++ b/plugins/fclrave/fclmanagercache.h
@@ -763,7 +763,9 @@ public:
                 // could be the case that the same pointer was re-added to the environment so have to check the environment id
                 // make sure we don't need to make this asusmption of body id change when bodies are removed and re-added
                 if( !pbody || attachedBodies.count(pbody) == 0 || pbody->GetEnvironmentBodyIndex() != bodyIndex ) {
-                    RAVELOG_VERBOSE_FORMAT("env=%d, %x, %u removing old cache %d", pbody->GetEnv()->GetId()%this%_lastSyncTimeStamp%bodyIndex);
+                    if( !!pbody && IS_DEBUGLEVEL(OpenRAVE::Level_Verbose) ) {
+                        RAVELOG_VERBOSE_FORMAT("env=%d, %x, %u removing old cache %d", pbody->GetEnv()->GetId()%this%_lastSyncTimeStamp%bodyIndex);
+                    }
                     // not in attached bodies so should remove
                     FOREACH(itcol, cache.vcolobjs) {
                         if( !!itcol->get() ) {


### PR DESCRIPTION
### Changes
- Commented out flooding (verbose) log message.
- Added checking `!!pbody` before using calling `pbody->GetEnv()->GetId()`.

cc @kanbouchou 