### PR TITLE
Optimize log4cxx log level access 20210408

### DIFF
--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -570,7 +570,8 @@ public:
             if( bRead ) {
                 if( !!ifstream(fullfilename.c_str()) ) {
                     return fullfilename;
-                }            }
+                }
+            }
             else {
                 return fullfilename;
             }

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -570,8 +570,7 @@ public:
             if( bRead ) {
                 if( !!ifstream(fullfilename.c_str()) ) {
                     return fullfilename;
-                }
-            }
+                }            }
             else {
                 return fullfilename;
             }
@@ -602,18 +601,35 @@ public:
         _nDebugLevel = level;
     }
 
+    int GetDebugLevel()
+    {
+        int level = _nDebugLevel;
+        if (_logger != NULL && _logger->getEffectiveLevel() != NULL) {
+            level = _logger->getEffectiveLevel()->toInt();
+            switch (level) {
+            case log4cxx::Level::FATAL_INT: level = Level_Fatal; break;
+            case log4cxx::Level::ERROR_INT: level = Level_Error; break;
+            case log4cxx::Level::WARN_INT:  level = Level_Warn; break;
+            case log4cxx::Level::INFO_INT:  level = Level_Info; break;
+            case log4cxx::Level::DEBUG_INT: level = Level_Debug; break;
+            case log4cxx::Level::TRACE_INT: level = Level_Verbose; break;
+            default: level = Level_Info;
+            }
+        }
+        return level | (_nDebugLevel & ~Level_OutputMask);
+    }
+
 #else
     void SetDebugLevel(int level)
     {
         _nDebugLevel = level;
     }
 
-#endif
-
     int GetDebugLevel()
     {
         return _nDebugLevel;
     }
+#endif
 
     class XMLReaderFunctionData : public UserData
     {


### PR DESCRIPTION
Revives getting log level access from log4cxx by speeding up previous performance when using log4cxx.

Performance test script:
```c++
#include <iostream>

#include <mujincontrollercommon/logging.h>
#include <openrave/openrave.h>

MUJIN_LOGGER("mujin.robotbridges.server.core");


int main() {
    const size_t numIterations = 100000000;
    struct timespec start, end;

    /*** Benchmark openrave get log level ***/
    // warm up
    OpenRAVE::RaveInitialize(true);
    for (size_t itr = 0; itr < numIterations; itr++)
    {
        OpenRAVE::RaveGetDebugLevel();
    }
    // benchmark
    clock_gettime(CLOCK_MONOTONIC_RAW, &start);
    for (size_t itr = 0; itr < numIterations; itr++)
    {
        OpenRAVE::RaveGetDebugLevel();
    }
    clock_gettime(CLOCK_MONOTONIC_RAW, &end);
    time_t elapsed = (end.tv_sec - start.tv_sec) * 1000000000 + (end.tv_nsec - start.tv_nsec);

    // logging
    std::cout << "iterations " << numIterations << std::endl;
    std::cout << "total " << elapsed << " nsec" << std::endl;
    std::cout << "average " << elapsed / numIterations << " nsec" << std::endl;
    return 0;
}
```

current get log access without log4cxx
```c++
iterations 100000000
total 514619209 nsec
average 5 nsec
```
with previous get log access from log4cxx: https://github.com/rdiankov/openrave/pull/941/files
```c++
iterations 100000000
total 5940225472 nsec
average 59 nsec
```

with this MR changes to get log access from log4cxx by checking effective level
```c++
iterations 100000000
total 783700733 nsec
average 7 nsec
```