### PR TITLE
[quick] warning on empty geometry name

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -654,8 +654,13 @@ bool KinBody::InitFromGeometries(const std::vector<KinBody::GeometryInfoConstPtr
     plink->_index = 0;
     plink->_info._name = "base";
     plink->_info._bStatic = true;
-    FOREACHC(itinfo,geometries) {
-        Link::GeometryPtr geom(new Link::Geometry(plink,**itinfo));
+    for (size_t index = 0; index < geometries.size(); ++index) {
+        const KinBody::GeometryInfo& geomInfo = *geometries[index];
+        if (geomInfo.GetName().empty()) {
+            RAVELOG_WARN_FORMAT("env=%s, geometry of index %d of link \"%s:%s\" has empty name", GetEnv()->GetNameId()%index%GetName()%plink->GetName());
+        }
+            
+        Link::GeometryPtr geom(new Link::Geometry(plink, geomInfo));
         geom->_info.InitCollisionMesh();
         plink->_vGeometries.push_back(geom);
         plink->_collision.Append(geom->GetCollisionMesh(),geom->GetTransform());


### PR DESCRIPTION
to make debugging easy.