### PR TITLE
Add GeometryConstPtr to CollisionReport

### DIFF
--- a/include/openrave/collisionchecker.h
+++ b/include/openrave/collisionchecker.h
@@ -83,6 +83,8 @@ public:
 
     std::vector<std::pair<KinBody::LinkConstPtr, KinBody::LinkConstPtr> > vLinkColliding; ///< all link collision pairs. Set when CO_AllCollisions is enabled.
 
+    KinBody::GeometryConstPtr pgeom1, pgeom2; ///< the specified geometries hit for the given links
+
     std::vector<CONTACT> contacts; ///< the convention is that the normal will be "out" of plink1's surface. Filled if CO_UseContacts option is set.
 
     int options; ///< the options that the CollisionReport was called with. It is overwritten by the options set on the collision checker writing the report
@@ -92,7 +94,6 @@ public:
 
     uint8_t nKeepPrevious; ///< if 1, will keep all previous data when resetting the collision checker. otherwise will reset
 
-    //KinBody::Link::GeomConstPtr pgeom1, pgeom2; ///< the specified geometries hit for the given links
 };
 
 typedef CollisionReport COLLISIONREPORT RAVE_DEPRECATED;

--- a/python/bindings/include/openravepy/openravepy_collisionreport.h
+++ b/python/bindings/include/openravepy/openravepy_collisionreport.h
@@ -50,6 +50,8 @@ public:
     int options;
     object plink1 = py::none_();
     object plink2 = py::none_();
+    object pgeom1 = py::none_();
+    object pgeom2 = py::none_();
     py::list vLinkColliding;
     dReal minDistance;
     int numWithinTol;

--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -768,6 +768,7 @@ OPENRAVEPY_API PyInterfaceBasePtr toPyKinBody(KinBodyPtr, PyEnvironmentBasePtr);
 OPENRAVEPY_API py::object toPyKinBody(KinBodyPtr, py::object opyenv);
 OPENRAVEPY_API py::object toPyKinBodyLink(KinBody::LinkPtr plink, PyEnvironmentBasePtr);
 OPENRAVEPY_API py::object toPyKinBodyLink(KinBody::LinkPtr plink, py::object opyenv);
+OPENRAVEPY_API py::object toPyKinBodyGeometry(KinBody::GeometryPtr pgeom);
 OPENRAVEPY_API KinBody::LinkPtr GetKinBodyLink(py::object);
 OPENRAVEPY_API KinBody::LinkConstPtr GetKinBodyLinkConst(py::object);
 OPENRAVEPY_API py::object toPyKinBodyJoint(KinBody::JointPtr pjoint, PyEnvironmentBasePtr);

--- a/python/bindings/openravepy_collisionchecker.cpp
+++ b/python/bindings/openravepy_collisionchecker.cpp
@@ -93,6 +93,18 @@ void PyCollisionReport::init(PyEnvironmentBasePtr pyenv)
     else {
         plink2 = py::none_();
     }
+    if( !!report->pgeom1 ) {
+        pgeom1 = openravepy::toPyKinBodyGeometry(OPENRAVE_CONST_POINTER_CAST<KinBody::Geometry>(report->pgeom1));
+    }
+    else {
+        pgeom1 = py::none_();
+    }
+    if( !!report->pgeom2 ) {
+        pgeom2 = openravepy::toPyKinBodyGeometry(OPENRAVE_CONST_POINTER_CAST<KinBody::Geometry>(report->pgeom2));
+    }
+    else {
+        pgeom2 = py::none_();
+    }
     py::list newcontacts;
     FOREACH(itc, report->contacts) {
         newcontacts.append(PYCONTACT(*itc));
@@ -764,6 +776,8 @@ void init_openravepy_collisionchecker()
     .def_readonly("options",&PyCollisionReport::options)
     .def_readonly("plink1",&PyCollisionReport::plink1)
     .def_readonly("plink2",&PyCollisionReport::plink2)
+    .def_readonly("pgeom1",&PyCollisionReport::pgeom1)
+    .def_readonly("pgeom2",&PyCollisionReport::pgeom2)
     .def_readonly("minDistance",&PyCollisionReport::minDistance)
     .def_readonly("numWithinTol",&PyCollisionReport::numWithinTol)
     .def_readonly("contacts",&PyCollisionReport::contacts)

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -4000,6 +4000,14 @@ object toPyKinBodyLink(KinBody::LinkPtr plink, object opyenv)
     return py::none_();
 }
 
+object toPyKinBodyGeometry(KinBody::GeometryPtr pgeom)
+{
+    if( !pgeom ) {
+        return py::none_();
+    }
+    return py::to_object(OPENRAVE_SHARED_PTR<PyLink::PyGeometry>(new PyLink::PyGeometry(pgeom)));
+}
+
 object toPyKinBodyJoint(KinBody::JointPtr pjoint, PyEnvironmentBasePtr pyenv)
 {
     if( !pjoint ) {

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -2012,6 +2012,8 @@ void CollisionReport::Reset(int coloptions)
         vLinkColliding.resize(0);
         plink1.reset();
         plink2.reset();
+        pgeom1.reset();
+        pgeom2.reset();
     }
 }
 
@@ -2059,6 +2061,9 @@ std::string CollisionReport::__str__() const
                 RAVELOG_WARN_FORMAT("could not get parent for link name %s when printing collision report", plink1->GetName());
                 s << "[deleted]:" << plink1->GetName();
             }
+            if( !!pgeom1 ) {
+                s << ":" << (pgeom1->GetName() == "" ? "[unnamed]" : pgeom1->GetName());
+            }
         }
         s << ")x(";
         if( !!plink2 ) {
@@ -2069,6 +2074,9 @@ std::string CollisionReport::__str__() const
             else {
                 RAVELOG_WARN_FORMAT("could not get parent for link name %s when printing collision report", plink2->GetName());
                 s << "[deleted]:" << plink2->GetName();
+            }
+            if( !!pgeom2 ) {
+                s << ":" << (pgeom2->GetName() == "" ? "[unnamed]" : pgeom2->GetName());
             }
         }
         s << ")";

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -2062,7 +2062,7 @@ std::string CollisionReport::__str__() const
                 s << "[deleted]:" << plink1->GetName();
             }
             if( !!pgeom1 ) {
-                s << ":" << (pgeom1->GetName() == "" ? "[unnamed]" : pgeom1->GetName());
+                s << ":" << pgeom1->GetName();
             }
         }
         s << ")x(";
@@ -2076,7 +2076,7 @@ std::string CollisionReport::__str__() const
                 s << "[deleted]:" << plink2->GetName();
             }
             if( !!pgeom2 ) {
-                s << ":" << (pgeom2->GetName() == "" ? "[unnamed]" : pgeom2->GetName());
+                s << ":" << pgeom2->GetName();
             }
         }
         s << ")";


### PR DESCRIPTION
In order to get which geometry is colliding from collisionreport, I added pyGeometry in CollisionReport.
Also changed FCLSpace to store GeomtryPtr in pinfo->linkinfo->vgeominfos[]->_pgeom.
I also modified function ```std::string CollisionReport::__str__() const``` for debugging purpose to know which geometry is colliding.