### PR TITLE
wip: Speedup parameter planner parameters assignment

### DIFF
--- a/include/openrave/planner.h
+++ b/include/openrave/planner.h
@@ -445,7 +445,9 @@ protected:
     ///
     /// This is called from assignment operator(=), each derived class is responsible for overriding this.
     /// overriding _Copy should copy member variables introduced in derived class, and also call Base class' _Copy to make sure member variables in base class is also copied
-    virtual void _Copy(const PlannerParameters& other);
+    /// \param other planner parameter from which to copy
+    /// \return whether copying succeeds. if downcasting to same class as this fails, should return false
+    virtual bool _Copy(const PlannerParameters& other);
 
     // router to a default implementation of _checkpathconstraintsfn that calls on _checkpathvelocityconstraintsfn
     bool _CheckPathConstraintsOld(const std::vector<dReal>&q0, const std::vector<dReal>&q1, IntervalType interval, ConfigurationListPtr pvCheckedConfigurations) {

--- a/include/openrave/planner.h
+++ b/include/openrave/planner.h
@@ -437,6 +437,8 @@ private:
     /// For example, when _samplefn is set and a SpaceSampler is used as the underlying number generator, then it should be added to this list.
     std::list<SpaceSamplerBasePtr> _listInternalSamplers;
 
+    virtual bool ParseExtraParameters();
+
 protected:
     /// \brief copies other into this
     ///
@@ -608,7 +610,7 @@ public:
         \param robot main robot to be used for planning
         \param params The parameters of the planner, any class derived from PlannerParameters can be passed. The planner should copy these parameters for future instead of storing the pointer.
      */
-    virtual bool InitPlan(RobotBasePtr robot, PlannerParametersConstPtr params) = 0;
+    virtual bool InitPlan(RobotBasePtr robot, PlannerParametersConstPtr params, bool loadExtraParameters) = 0;
 
     /** \brief Setup scene, robot, and properties of the plan, and reset all structures with pparams.
 

--- a/include/openrave/planner.h
+++ b/include/openrave/planner.h
@@ -166,7 +166,7 @@ private:
 
     /** \brief Attemps to copy data from one set of parameters to another.
 
-        pointers to functions are copied directly
+        pointers to functions and member variables are copied directly
 
         classes deriving from PlannerParameters have to override _Copy function for coping of variables introduced in derived class.
      */
@@ -437,7 +437,8 @@ private:
     /// For example, when _samplefn is set and a SpaceSampler is used as the underlying number generator, then it should be added to this list.
     std::list<SpaceSamplerBasePtr> _listInternalSamplers;
 
-    virtual bool ParseExtraParameters();
+    /// loads extra parameters xml string into this, used when setting parameters from _sPostProcessingParameters
+    virtual void LoadExtraParameters(const std::string& extraParameters);
 
 protected:
     /// \brief copies other into this
@@ -610,7 +611,7 @@ public:
         \param robot main robot to be used for planning
         \param params The parameters of the planner, any class derived from PlannerParameters can be passed. The planner should copy these parameters for future instead of storing the pointer.
      */
-    virtual bool InitPlan(RobotBasePtr robot, PlannerParametersConstPtr params, bool loadExtraParameters) = 0;
+    virtual bool InitPlan(RobotBasePtr robot, PlannerParametersConstPtr params, const std::string& extraParameters) = 0;
 
     /** \brief Setup scene, robot, and properties of the plan, and reset all structures with pparams.
 

--- a/include/openrave/planner.h
+++ b/include/openrave/planner.h
@@ -164,10 +164,11 @@ private:
 
     typedef boost::shared_ptr<StateSaver> StateSaverPtr;
 
-    /** \brief Attemps to copy data from one set of parameters to another in the safest manner.
+    /** \brief Attemps to copy data from one set of parameters to another.
 
-        First serializes the data of the right hand into a string, then initializes the current parameters via >>
         pointers to functions are copied directly
+
+        classes deriving from PlannerParameters have to override _Copy function for coping of variables introduced in derived class.
      */
     virtual PlannerParameters& operator=(const PlannerParameters& r);
     virtual void copy(boost::shared_ptr<PlannerParameters const> r);
@@ -437,6 +438,12 @@ private:
     std::list<SpaceSamplerBasePtr> _listInternalSamplers;
 
 protected:
+    /// \brief copies other into this
+    ///
+    /// This is called from assignment operator(=), each derived class is responsible for overriding this.
+    /// overriding _Copy should copy member variables introduced in derived class, and also call Base class' _Copy to make sure member variables in base class is also copied
+    virtual void _Copy(const PlannerParameters& other);
+
     // router to a default implementation of _checkpathconstraintsfn that calls on _checkpathvelocityconstraintsfn
     bool _CheckPathConstraintsOld(const std::vector<dReal>&q0, const std::vector<dReal>&q1, IntervalType interval, ConfigurationListPtr pvCheckedConfigurations) {
         RAVELOG_VERBOSE("using deprecated PlannerParameters::_checkpathconstraintsfn, consider switching to PlannerParameters::_checkpathvelocityconstraintsfn\n");

--- a/include/openrave/plannerparameters.h
+++ b/include/openrave/plannerparameters.h
@@ -596,6 +596,7 @@ protected:
 
     ProcessElement startElement(const std::string& name, const AttributesList& atts)
     {
+        RAVELOG_WARN_FORMAT("%d:%s", _bProcessing%name);
         if( _bProcessing ) {
             return PE_Ignore;
         }
@@ -606,11 +607,13 @@ protected:
         }
 
         _bProcessing = name=="interpolation" || name=="hastimestamps" || name=="hasvelocities" || name=="pointtolerance" || name=="outputaccelchanges" || name=="multidofinterp"||name=="verifyinitialpath";
+        RAVELOG_WARN_FORMAT("%d:%s", _bProcessing%name);
         return _bProcessing ? PE_Support : PE_Pass;
     }
 
     virtual bool endElement(const std::string& name)
     {
+        RAVELOG_WARN_FORMAT("%d:%s", _bProcessing%name);
         if( _bProcessing ) {
             if( name == "interpolation") {
                 _ss >> _interpolation;

--- a/include/openrave/plannerparameters.h
+++ b/include/openrave/plannerparameters.h
@@ -32,6 +32,18 @@ public:
         _vXMLParameters.push_back("expectedsize");
     }
 
+    virtual void _Copy(const PlannerParameters& r) override
+    {
+        PlannerParameters::_Copy(r);
+        const ExplorationParameters* pother = dynamic_cast<const ExplorationParameters*>(&r);
+        if (!pother) {
+            return;
+        }
+        const ExplorationParameters& other = *pother;
+        _fExploreProb = other._fExploreProb;
+        _nExpectedDataSize = other._nExpectedDataSize;
+    }
+
     dReal _fExploreProb; ///< explore close to the neighbors already added
     int _nExpectedDataSize; ///< the expected number of nodes of the RRT tree to expand to before returning a solution. This allows the RRT tree to build up
 
@@ -101,6 +113,21 @@ public:
         _vXMLParameters.push_back("goalcoeff");
         _vXMLParameters.push_back("maxchildren");
         _vXMLParameters.push_back("maxsampletries");
+    }
+
+    virtual void _Copy(const PlannerParameters& r) override
+    {
+        PlannerParameters::_Copy(r);
+        const RAStarParameters* pother = dynamic_cast<const RAStarParameters*>(&r);
+        if (!pother) {
+            return;
+        }
+        const RAStarParameters& other = *pother;
+        fRadius = other.fRadius;
+        fDistThresh = other.fDistThresh;
+        fGoalCoeff = other.fGoalCoeff;
+        nMaxChildren = other.nMaxChildren;
+        nMaxSampleTries = other.nMaxSampleTries;
     }
 
     dReal fRadius;          ///< _pDistMetric thresh is the radius that children must be within parents
@@ -178,6 +205,28 @@ public:
         _vXMLParameters.push_back("numgradsamples");
         _vXMLParameters.push_back("visgraspthresh");
         _vXMLParameters.push_back("graspdistthresh");
+    }
+
+    virtual void _Copy(const PlannerParameters& r) override
+    {
+        PlannerParameters::_Copy(r);
+        const GraspSetParameters* pother = dynamic_cast<const GraspSetParameters*>(&r);
+        if (!pother) {
+            return;
+        }
+        const GraspSetParameters& other = *pother;
+
+        _vgrasps = other._vgrasps;
+        if (!!other._ptarget) {
+            // is this correct to assume that env body index is same for this and other env?
+            _ptarget = _penv->GetBodyFromEnvironmentBodyIndex(other._ptarget->GetEnvironmentBodyIndex());
+        }
+        else {
+            _ptarget.reset();
+        }
+        _nGradientSamples = other._nGradientSamples;
+        _fVisibiltyGraspThresh = other._fVisibiltyGraspThresh;
+        _fGraspDistThresh = other._fGraspDistThresh;
     }
 
     std::vector<Transform> _vgrasps;     ///< grasps with respect to the target object
@@ -286,6 +335,41 @@ public:
         _bProcessingGrasp = false;
     }
 
+    virtual void _Copy(const PlannerParameters& r) override
+    {
+        PlannerParameters::_Copy(r);
+
+        const GraspParameters* pother = dynamic_cast<const GraspParameters*>(&r);
+        if (!pother) {
+            return;
+        }
+        const GraspParameters& other = *pother;
+
+        fstandoff = other.fstandoff;
+        if (!!other.targetbody) {
+            targetbody = _penv->GetBodyFromEnvironmentBodyIndex(other.targetbody->GetEnvironmentBodyIndex());
+        }
+        else {
+            targetbody.reset();
+        }
+        ftargetroll = other.ftargetroll;
+        vtargetdirection = other.vtargetdirection;
+        vtargetposition = other.vtargetposition;
+        vmanipulatordirection = other.vmanipulatordirection;
+        btransformrobot = other.btransformrobot;
+        breturntrajectory = other.breturntrajectory;
+        bonlycontacttarget = other.bonlycontacttarget;
+        btightgrasp = other.btightgrasp;
+        bavoidcontact = other.bavoidcontact;
+        vavoidlinkgeometry = other.vavoidlinkgeometry;
+        fcoarsestep = other.fcoarsestep;
+        ffinestep = other.ffinestep;
+        ftranslationstepmult = other.ftranslationstepmult;
+        fgraspingnoise = other.fgraspingnoise;
+        vintersectplane = other.vintersectplane;
+        vordereddofindices = other.vordereddofindices;
+    }
+    
     dReal fstandoff;     ///< start closing fingers when at this distance
     KinBodyPtr targetbody;     ///< the target that will be grasped, all parameters will be in this coordinate system. if not present, then below transformations are in absolute coordinate system.
     dReal ftargetroll;     ///< rotate the hand about the palm normal (if one exists) by this many radians
@@ -463,6 +547,25 @@ public:
         _vXMLParameters.push_back("verifyinitialpath");
     }
 
+    virtual void _Copy(const PlannerParameters& r) override
+    {
+        PlannerParameters::_Copy(r);
+
+        const TrajectoryTimingParameters* pother = dynamic_cast<const TrajectoryTimingParameters*>(&r);
+        if (!pother) {
+            return;
+        }
+        const TrajectoryTimingParameters& other = *pother;
+
+        _interpolation = other._interpolation;
+        _hastimestamps = other._hastimestamps;
+        _hasvelocities = other._hasvelocities;
+        _pointtolerance = other._pointtolerance;
+        _outputaccelchanges = other._outputaccelchanges;
+        _multidofinterp = other._multidofinterp;
+        verifyinitialpath = other.verifyinitialpath;
+    }
+
     std::string _interpolation;
     dReal _pointtolerance; ///< multiple of dof resolutions to set on discretization tolerance
     bool _hastimestamps, _hasvelocities;
@@ -564,6 +667,34 @@ public:
         _vXMLParameters.push_back("nshortcutcycles");
         _vXMLParameters.push_back("searchvelaccelmult");
         _vXMLParameters.push_back("durationimprovementcutoffratio");
+    }
+
+    virtual void _Copy(const PlannerParameters& r) override
+    {
+        TrajectoryTimingParameters::_Copy(r);
+
+        const ConstraintTrajectoryTimingParameters* pother = dynamic_cast<const ConstraintTrajectoryTimingParameters*>(&r);
+        if (!pother) {
+            return;
+        }
+
+        const ConstraintTrajectoryTimingParameters& other = *pother;
+
+        maxlinkspeed = other.maxlinkspeed;
+        maxlinkaccel = other.maxlinkaccel;
+        manipname = other.manipname;
+        maxmanipspeed = other.maxmanipspeed;
+        maxmanipaccel = other.maxmanipaccel;
+        vConstraintManipDir = other.vConstraintManipDir;
+        vConstraintGlobalDir = other.vConstraintGlobalDir;
+        fCosManipAngleThresh = other.fCosManipAngleThresh;
+        mingripperdistance = other.mingripperdistance;
+        velocitydistancethresh = other.velocitydistancethresh;
+        maxmergeiterations = other.maxmergeiterations;
+        minswitchtime = other.minswitchtime;
+        nshortcutcycles = other.nshortcutcycles;
+        fSearchVelAccelMult = other.fSearchVelAccelMult;
+        durationImprovementCutoffRatio = other.durationImprovementCutoffRatio;
     }
 
     dReal maxlinkspeed; ///< max speed in m/s that any point on any link goes. 0 means no speed limit
@@ -702,6 +833,8 @@ public:
         return _penv;
     }
 
+    virtual void _Copy(const PlannerParameters& r) override;
+    
     dReal maxdeviationangle;     ///< the maximum angle the next iksolution can deviate from the expected direction computed by the jacobian
     bool maintaintiming;     ///< maintain timing with input trajectory
     bool greedysearch;     ///< if true, will greeidly choose solutions (can possibly fail even a solution exists)
@@ -730,6 +863,13 @@ class OPENRAVE_API RRTParameters : public PlannerBase::PlannerParameters
 public:
     RRTParameters() : _minimumgoalpaths(1), _bProcessing(false) {
         _vXMLParameters.push_back("minimumgoalpaths");
+    }
+
+    virtual void _Copy(const PlannerParameters& r) override
+    {
+        PlannerParameters::_Copy(r);
+        const RRTParameters& other = dynamic_cast<const RRTParameters&>(r);
+        _minimumgoalpaths = other._minimumgoalpaths;
     }
 
     size_t _minimumgoalpaths; ///< minimum number of goals to connect to before exiting. the goal with the shortest path is returned.
@@ -791,6 +931,20 @@ public:
         _vXMLParameters.push_back("nrrtextenttype");
         _vXMLParameters.push_back("nminiterations");
     }
+
+    virtual void _Copy(const PlannerParameters& r) override
+    {
+        RRTParameters::_Copy(r);
+        const BasicRRTParameters* pother = dynamic_cast<const BasicRRTParameters*>(&r);
+        if (!pother) {
+            return;
+        }
+
+        const BasicRRTParameters& other = *pother;
+        _fGoalBiasProb = other._fGoalBiasProb;
+        _nRRTExtentType = other._nRRTExtentType;
+        _nMinIterations = other._nMinIterations;
+    }    
 
     dReal _fGoalBiasProb;
     int _nRRTExtentType; ///< the rrt extent type. if 0 then extend all the way to the sampled position. if 1, then just extend one step length before sampling again.

--- a/include/openrave/plannerparameters.h
+++ b/include/openrave/plannerparameters.h
@@ -32,16 +32,21 @@ public:
         _vXMLParameters.push_back("expectedsize");
     }
 
-    virtual void _Copy(const PlannerParameters& r) override
+    virtual bool _Copy(const PlannerParameters& r) override
     {
-        PlannerParameters::_Copy(r);
+        if (!PlannerParameters::_Copy(r)) {
+            return false;
+        }
+
         const ExplorationParameters* pother = dynamic_cast<const ExplorationParameters*>(&r);
         if (!pother) {
-            return;
+            return false;
         }
+
         const ExplorationParameters& other = *pother;
         _fExploreProb = other._fExploreProb;
         _nExpectedDataSize = other._nExpectedDataSize;
+        return true;
     }
 
     dReal _fExploreProb; ///< explore close to the neighbors already added
@@ -115,19 +120,24 @@ public:
         _vXMLParameters.push_back("maxsampletries");
     }
 
-    virtual void _Copy(const PlannerParameters& r) override
+    virtual bool _Copy(const PlannerParameters& r) override
     {
-        PlannerParameters::_Copy(r);
+        if (!PlannerParameters::_Copy(r)) {
+            return false;
+        }
+
         const RAStarParameters* pother = dynamic_cast<const RAStarParameters*>(&r);
         if (!pother) {
-            return;
+            return false;
         }
+
         const RAStarParameters& other = *pother;
         fRadius = other.fRadius;
         fDistThresh = other.fDistThresh;
         fGoalCoeff = other.fGoalCoeff;
         nMaxChildren = other.nMaxChildren;
         nMaxSampleTries = other.nMaxSampleTries;
+        return true;
     }
 
     dReal fRadius;          ///< _pDistMetric thresh is the radius that children must be within parents
@@ -207,15 +217,18 @@ public:
         _vXMLParameters.push_back("graspdistthresh");
     }
 
-    virtual void _Copy(const PlannerParameters& r) override
+    virtual bool _Copy(const PlannerParameters& r) override
     {
-        PlannerParameters::_Copy(r);
+        if (!PlannerParameters::_Copy(r)) {
+            return false;
+        }
+        
         const GraspSetParameters* pother = dynamic_cast<const GraspSetParameters*>(&r);
         if (!pother) {
-            return;
+            return false;
         }
+        
         const GraspSetParameters& other = *pother;
-
         _vgrasps = other._vgrasps;
         if (!!other._ptarget) {
             // is this correct to assume that env body index is same for this and other env?
@@ -227,6 +240,8 @@ public:
         _nGradientSamples = other._nGradientSamples;
         _fVisibiltyGraspThresh = other._fVisibiltyGraspThresh;
         _fGraspDistThresh = other._fGraspDistThresh;
+
+        return true;
     }
 
     std::vector<Transform> _vgrasps;     ///< grasps with respect to the target object
@@ -335,13 +350,15 @@ public:
         _bProcessingGrasp = false;
     }
 
-    virtual void _Copy(const PlannerParameters& r) override
+    virtual bool _Copy(const PlannerParameters& r) override
     {
-        PlannerParameters::_Copy(r);
+        if (!PlannerParameters::_Copy(r)) {
+            return false;
+        }
 
         const GraspParameters* pother = dynamic_cast<const GraspParameters*>(&r);
         if (!pother) {
-            return;
+            return false;
         }
         const GraspParameters& other = *pother;
 
@@ -368,6 +385,8 @@ public:
         fgraspingnoise = other.fgraspingnoise;
         vintersectplane = other.vintersectplane;
         vordereddofindices = other.vordereddofindices;
+
+        return true;
     }
     
     dReal fstandoff;     ///< start closing fingers when at this distance
@@ -547,13 +566,15 @@ public:
         _vXMLParameters.push_back("verifyinitialpath");
     }
 
-    virtual void _Copy(const PlannerParameters& r) override
+    virtual bool _Copy(const PlannerParameters& r) override
     {
-        PlannerParameters::_Copy(r);
+        if (!PlannerParameters::_Copy(r)) {
+            return false;
+        }
 
         const TrajectoryTimingParameters* pother = dynamic_cast<const TrajectoryTimingParameters*>(&r);
         if (!pother) {
-            return;
+            return false;
         }
         const TrajectoryTimingParameters& other = *pother;
 
@@ -564,6 +585,8 @@ public:
         _outputaccelchanges = other._outputaccelchanges;
         _multidofinterp = other._multidofinterp;
         verifyinitialpath = other.verifyinitialpath;
+
+        return true;
     }
 
     std::string _interpolation;
@@ -669,13 +692,15 @@ public:
         _vXMLParameters.push_back("durationimprovementcutoffratio");
     }
 
-    virtual void _Copy(const PlannerParameters& r) override
+    virtual bool _Copy(const PlannerParameters& r) override
     {
-        TrajectoryTimingParameters::_Copy(r);
+        if (!TrajectoryTimingParameters::_Copy(r)) {
+            return false;
+        }
 
         const ConstraintTrajectoryTimingParameters* pother = dynamic_cast<const ConstraintTrajectoryTimingParameters*>(&r);
         if (!pother) {
-            return;
+            return false;
         }
 
         const ConstraintTrajectoryTimingParameters& other = *pother;
@@ -695,6 +720,8 @@ public:
         nshortcutcycles = other.nshortcutcycles;
         fSearchVelAccelMult = other.fSearchVelAccelMult;
         durationImprovementCutoffRatio = other.durationImprovementCutoffRatio;
+
+        return true;
     }
 
     dReal maxlinkspeed; ///< max speed in m/s that any point on any link goes. 0 means no speed limit
@@ -833,7 +860,7 @@ public:
         return _penv;
     }
 
-    virtual void _Copy(const PlannerParameters& r) override;
+    virtual bool _Copy(const PlannerParameters& r) override;
     
     dReal maxdeviationangle;     ///< the maximum angle the next iksolution can deviate from the expected direction computed by the jacobian
     bool maintaintiming;     ///< maintain timing with input trajectory
@@ -865,11 +892,21 @@ public:
         _vXMLParameters.push_back("minimumgoalpaths");
     }
 
-    virtual void _Copy(const PlannerParameters& r) override
+    virtual bool _Copy(const PlannerParameters& r) override
     {
-        PlannerParameters::_Copy(r);
-        const RRTParameters& other = dynamic_cast<const RRTParameters&>(r);
+        if (!PlannerParameters::_Copy(r)) {
+            return false;
+        }
+
+        const RRTParameters* pother = dynamic_cast<const RRTParameters*>(&r);
+        if (!pother) {
+            return false;
+        }
+        
+        const RRTParameters& other = *pother;
         _minimumgoalpaths = other._minimumgoalpaths;
+
+        return true;
     }
 
     size_t _minimumgoalpaths; ///< minimum number of goals to connect to before exiting. the goal with the shortest path is returned.
@@ -932,18 +969,23 @@ public:
         _vXMLParameters.push_back("nminiterations");
     }
 
-    virtual void _Copy(const PlannerParameters& r) override
+    virtual bool _Copy(const PlannerParameters& r) override
     {
-        RRTParameters::_Copy(r);
+        if (!RRTParameters::_Copy(r)) {
+            return false;
+        }
+
         const BasicRRTParameters* pother = dynamic_cast<const BasicRRTParameters*>(&r);
         if (!pother) {
-            return;
+            return false;
         }
 
         const BasicRRTParameters& other = *pother;
         _fGoalBiasProb = other._fGoalBiasProb;
         _nRRTExtentType = other._nRRTExtentType;
         _nMinIterations = other._nMinIterations;
+
+        return true;
     }    
 
     dReal _fGoalBiasProb;

--- a/include/openrave/plannerparameters.h
+++ b/include/openrave/plannerparameters.h
@@ -596,7 +596,6 @@ protected:
 
     ProcessElement startElement(const std::string& name, const AttributesList& atts)
     {
-        RAVELOG_WARN_FORMAT("%d:%s", _bProcessing%name);
         if( _bProcessing ) {
             return PE_Ignore;
         }
@@ -607,13 +606,11 @@ protected:
         }
 
         _bProcessing = name=="interpolation" || name=="hastimestamps" || name=="hasvelocities" || name=="pointtolerance" || name=="outputaccelchanges" || name=="multidofinterp"||name=="verifyinitialpath";
-        RAVELOG_WARN_FORMAT("%d:%s", _bProcessing%name);
         return _bProcessing ? PE_Support : PE_Pass;
     }
 
     virtual bool endElement(const std::string& name)
     {
-        RAVELOG_WARN_FORMAT("%d:%s", _bProcessing%name);
         if( _bProcessing ) {
             if( name == "interpolation") {
                 _ss >> _interpolation;

--- a/old/rplanners/graspgradient.cpp
+++ b/old/rplanners/graspgradient.cpp
@@ -40,12 +40,20 @@ public:
     virtual ~GraspGradientPlanner() {
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset();
         boost::shared_ptr<GraspSetParameters> parameters(new GraspSetParameters(GetEnv()));
         parameters->copy(pparams);
+        if (loadExtraParameters) {
+            std::stringstream ss;
+            ss << *pparams;
+            ss >> *parameters;
+        }
+        else {
+            parameters->copy(pparams);
+        }
         _robot = pbase;
         RobotBase::RobotStateSaver savestate(_robot);
 

--- a/old/rplanners/graspgradient.cpp
+++ b/old/rplanners/graspgradient.cpp
@@ -40,20 +40,13 @@ public:
     virtual ~GraspGradientPlanner() {
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset();
         boost::shared_ptr<GraspSetParameters> parameters(new GraspSetParameters(GetEnv()));
         parameters->copy(pparams);
-        if (loadExtraParameters) {
-            std::stringstream ss;
-            ss << *pparams;
-            ss >> *parameters;
-        }
-        else {
-            parameters->copy(pparams);
-        }
+        parameters->LoadExtraParameters(extraParameters);
         _robot = pbase;
         RobotBase::RobotStateSaver savestate(_robot);
 

--- a/plugins/grasper/graspermodule.cpp
+++ b/plugins/grasper/graspermodule.cpp
@@ -328,7 +328,7 @@ public:
         params->SetRobotActiveJoints(_robot);
         _robot->GetActiveDOFValues(params->vinitialconfig);
 
-        if( !_planner->InitPlan(_robot, params, false) ) {
+        if( !_planner->InitPlan(_robot, params, "") ) {
             RAVELOG_WARN("InitPlan failed\n");
             return false;
         }
@@ -986,7 +986,7 @@ public:
                 ptraj->Init(probot->GetActiveConfigurationSpecification());
 
                 // InitPlan/PlanPath
-                if( !planner->InitPlan(probot, params, false) ) {
+                if( !planner->InitPlan(probot, params, "") ) {
                     RAVELOG_DEBUG(str(boost::format("grasp %d: grasper planner failed")%grasp_params->id));
                     continue;
                 }
@@ -1070,7 +1070,7 @@ public:
                         probot->SetActiveDOFs(worker_params->vactiveindices,worker_params->affinedofs,worker_params->affineaxis);
                         params->vinitialconfig.resize(0);
                         ptraj->Init(probot->GetActiveConfigurationSpecification());
-                        if( !planner->InitPlan(probot, params, false) ) {
+                        if( !planner->InitPlan(probot, params, "") ) {
                             RAVELOG_VERBOSE(str(boost::format("grasp %d: grasping noise planner failed")%grasp_params->id));
                             break;
                         }

--- a/plugins/grasper/graspermodule.cpp
+++ b/plugins/grasper/graspermodule.cpp
@@ -328,7 +328,7 @@ public:
         params->SetRobotActiveJoints(_robot);
         _robot->GetActiveDOFValues(params->vinitialconfig);
 
-        if( !_planner->InitPlan(_robot, params) ) {
+        if( !_planner->InitPlan(_robot, params, false) ) {
             RAVELOG_WARN("InitPlan failed\n");
             return false;
         }
@@ -986,7 +986,7 @@ public:
                 ptraj->Init(probot->GetActiveConfigurationSpecification());
 
                 // InitPlan/PlanPath
-                if( !planner->InitPlan(probot, params) ) {
+                if( !planner->InitPlan(probot, params, false) ) {
                     RAVELOG_DEBUG(str(boost::format("grasp %d: grasper planner failed")%grasp_params->id));
                     continue;
                 }
@@ -1070,7 +1070,7 @@ public:
                         probot->SetActiveDOFs(worker_params->vactiveindices,worker_params->affinedofs,worker_params->affineaxis);
                         params->vinitialconfig.resize(0);
                         ptraj->Init(probot->GetActiveConfigurationSpecification());
-                        if( !planner->InitPlan(probot, params) ) {
+                        if( !planner->InitPlan(probot, params, false) ) {
                             RAVELOG_VERBOSE(str(boost::format("grasp %d: grasping noise planner failed")%grasp_params->id));
                             break;
                         }

--- a/plugins/grasper/grasperplanner.cpp
+++ b/plugins/grasper/grasperplanner.cpp
@@ -36,7 +36,7 @@ public:
     GrasperPlanner(EnvironmentBasePtr penv, std::istream& sinput) : PlannerBase(penv), _report(new CollisionReport()) {
         __description = ":Interface Authors: Rosen Diankov, Dmitry Berenson\n\nSimple planner that performs a follow and squeeze operation of a robotic hand.";
     }
-    bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
+    bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters)
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _robot = pbase;

--- a/plugins/grasper/grasperplanner.cpp
+++ b/plugins/grasper/grasperplanner.cpp
@@ -36,7 +36,7 @@ public:
     GrasperPlanner(EnvironmentBasePtr penv, std::istream& sinput) : PlannerBase(penv), _report(new CollisionReport()) {
         __description = ":Interface Authors: Rosen Diankov, Dmitry Berenson\n\nSimple planner that performs a follow and squeeze operation of a robotic hand.";
     }
-    bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters)
+    bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, const std::string& extraParameters)
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _robot = pbase;
@@ -47,6 +47,7 @@ public:
 
         _parameters.reset(new GraspParameters(GetEnv()));
         _parameters->copy(pparams);
+        _parameters->LoadExtraParameters(extraParameters);
 
         if( _parameters->btightgrasp ) {
             RAVELOG_WARN("tight grasping not supported yet\n");

--- a/plugins/rmanipulation/basemanipulation.cpp
+++ b/plugins/rmanipulation/basemanipulation.cpp
@@ -322,7 +322,7 @@ protected:
             return false;
         }
 
-        if( !planner->InitPlan(robot, params) ) {
+        if( !planner->InitPlan(robot, params, false) ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }
@@ -521,7 +521,7 @@ protected:
         RAVELOG_DEBUG("starting planning\n");
         bool bSuccess = false;
         for(int itry = 0; itry < nMaxTries; ++itry) {
-            if( !rrtplanner->InitPlan(robot, params) ) {
+            if( !rrtplanner->InitPlan(robot, params, false) ) {
                 RAVELOG_ERROR("InitPlan failed\n");
                 return false;
             }
@@ -852,7 +852,7 @@ protected:
         RAVELOG_DEBUG("starting planning\n");
 
         for(int iter = 0; iter < nMaxTries; ++iter) {
-            if( !rrtplanner->InitPlan(robot, params) ) {
+            if( !rrtplanner->InitPlan(robot, params, false) ) {
                 RAVELOG_ERROR("InitPlan failed\n");
                 return false;
             }

--- a/plugins/rmanipulation/basemanipulation.cpp
+++ b/plugins/rmanipulation/basemanipulation.cpp
@@ -322,7 +322,7 @@ protected:
             return false;
         }
 
-        if( !planner->InitPlan(robot, params, false) ) {
+        if( !planner->InitPlan(robot, params, "") ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }
@@ -521,7 +521,7 @@ protected:
         RAVELOG_DEBUG("starting planning\n");
         bool bSuccess = false;
         for(int itry = 0; itry < nMaxTries; ++itry) {
-            if( !rrtplanner->InitPlan(robot, params, false) ) {
+            if( !rrtplanner->InitPlan(robot, params, "") ) {
                 RAVELOG_ERROR("InitPlan failed\n");
                 return false;
             }
@@ -852,7 +852,7 @@ protected:
         RAVELOG_DEBUG("starting planning\n");
 
         for(int iter = 0; iter < nMaxTries; ++iter) {
-            if( !rrtplanner->InitPlan(robot, params, false) ) {
+            if( !rrtplanner->InitPlan(robot, params, "") ) {
                 RAVELOG_ERROR("InitPlan failed\n");
                 return false;
             }

--- a/plugins/rmanipulation/commonmanipulation.h
+++ b/plugins/rmanipulation/commonmanipulation.h
@@ -141,7 +141,7 @@ public:
                 return false;
             }
 
-            if( !planner->InitPlan(robot, params) ) {
+            if( !planner->InitPlan(robot, params, false) ) {
                 return false;
             }
             if( !planner->PlanPath(ptraj).GetStatusCode() ) {

--- a/plugins/rmanipulation/commonmanipulation.h
+++ b/plugins/rmanipulation/commonmanipulation.h
@@ -141,7 +141,7 @@ public:
                 return false;
             }
 
-            if( !planner->InitPlan(robot, params, false) ) {
+            if( !planner->InitPlan(robot, params, "") ) {
                 return false;
             }
             if( !planner->PlanPath(ptraj).GetStatusCode() ) {

--- a/plugins/rmanipulation/taskmanipulation.cpp
+++ b/plugins/rmanipulation/taskmanipulation.cpp
@@ -725,7 +725,7 @@ protected:
                     }
                 }
                 
-                if( !_pGrasperPlanner->InitPlan(_robot,graspparams,false) ) {
+                if( !_pGrasperPlanner->InitPlan(_robot,graspparams,"") ) {
                     RAVELOG_DEBUG("grasper planner failed: %d\n", igrasp);
                     continue;
                 }
@@ -1192,7 +1192,7 @@ protected:
         ptraj->Init(_robot->GetActiveConfigurationSpecification());
         ptraj->Insert(0,graspparams->vinitialconfig); // have to add the first point
 
-        if( !graspplanner->InitPlan(_robot, graspparams, false) ) {
+        if( !graspplanner->InitPlan(_robot, graspparams, "") ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }
@@ -1324,7 +1324,7 @@ protected:
         graspparams->bonlycontacttarget = false;
         graspparams->bavoidcontact = true;
 
-        if( !graspplanner->InitPlan(_robot, graspparams, false) ) {
+        if( !graspplanner->InitPlan(_robot, graspparams, "") ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }
@@ -1470,7 +1470,7 @@ protected:
         graspparams->bonlycontacttarget = false;
         graspparams->bavoidcontact = true;
 
-        if( !graspplanner->InitPlan(_robot, graspparams, false) ) {
+        if( !graspplanner->InitPlan(_robot, graspparams, "") ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }
@@ -1725,7 +1725,7 @@ protected:
 
         stringstream ss;
         for(int iter = 0; iter < nMaxTries; ++iter) {
-            if( !_pRRTPlanner->InitPlan(_robot, params, false) ) {
+            if( !_pRRTPlanner->InitPlan(_robot, params, "") ) {
                 RAVELOG_WARN("InitPlan failed\n");
                 ptraj.reset();
                 return ptraj;
@@ -1804,7 +1804,7 @@ protected:
             graspparams->btightgrasp = false;
             graspparams->bavoidcontact = true;
             // TODO: in order to reproduce the same exact conditions as the original grasp, have to also transfer the step sizes
-            if( !_pGrasperPlanner->InitPlan(_robot,graspparams,false) ) {
+            if( !_pGrasperPlanner->InitPlan(_robot,graspparams,"") ) {
                 RAVELOG_DEBUG("grasper planner InitPlan failed\n");
                 return IKRA_Reject;
             }

--- a/plugins/rmanipulation/taskmanipulation.cpp
+++ b/plugins/rmanipulation/taskmanipulation.cpp
@@ -725,7 +725,7 @@ protected:
                     }
                 }
                 
-                if( !_pGrasperPlanner->InitPlan(_robot,graspparams) ) {
+                if( !_pGrasperPlanner->InitPlan(_robot,graspparams,false) ) {
                     RAVELOG_DEBUG("grasper planner failed: %d\n", igrasp);
                     continue;
                 }
@@ -1192,7 +1192,7 @@ protected:
         ptraj->Init(_robot->GetActiveConfigurationSpecification());
         ptraj->Insert(0,graspparams->vinitialconfig); // have to add the first point
 
-        if( !graspplanner->InitPlan(_robot, graspparams) ) {
+        if( !graspplanner->InitPlan(_robot, graspparams, false) ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }
@@ -1324,7 +1324,7 @@ protected:
         graspparams->bonlycontacttarget = false;
         graspparams->bavoidcontact = true;
 
-        if( !graspplanner->InitPlan(_robot, graspparams) ) {
+        if( !graspplanner->InitPlan(_robot, graspparams, false) ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }
@@ -1470,7 +1470,7 @@ protected:
         graspparams->bonlycontacttarget = false;
         graspparams->bavoidcontact = true;
 
-        if( !graspplanner->InitPlan(_robot, graspparams) ) {
+        if( !graspplanner->InitPlan(_robot, graspparams, false) ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }
@@ -1725,7 +1725,7 @@ protected:
 
         stringstream ss;
         for(int iter = 0; iter < nMaxTries; ++iter) {
-            if( !_pRRTPlanner->InitPlan(_robot, params) ) {
+            if( !_pRRTPlanner->InitPlan(_robot, params, false) ) {
                 RAVELOG_WARN("InitPlan failed\n");
                 ptraj.reset();
                 return ptraj;
@@ -1804,7 +1804,7 @@ protected:
             graspparams->btightgrasp = false;
             graspparams->bavoidcontact = true;
             // TODO: in order to reproduce the same exact conditions as the original grasp, have to also transfer the step sizes
-            if( !_pGrasperPlanner->InitPlan(_robot,graspparams) ) {
+            if( !_pGrasperPlanner->InitPlan(_robot,graspparams,false) ) {
                 RAVELOG_DEBUG("grasper planner InitPlan failed\n");
                 return IKRA_Reject;
             }

--- a/plugins/rmanipulation/visualfeedback.cpp
+++ b/plugins/rmanipulation/visualfeedback.cpp
@@ -1379,7 +1379,7 @@ Visibility computation checks occlusion with other objects using ray sampling in
         RAVELOG_INFOA("starting planning\n");
         uint64_t starttime = utils::GetMicroTime();
         for(int iter = 0; iter < 1; ++iter) {
-            if( !planner->InitPlan(_robot, params, false) ) {
+            if( !planner->InitPlan(_robot, params, "") ) {
                 RAVELOG_ERROR("InitPlan failed\n");
                 return false;
             }
@@ -1497,7 +1497,7 @@ Visibility computation checks occlusion with other objects using ray sampling in
         bool bSuccess = false;
         RAVELOG_INFOA("starting planning\n");
         uint64_t starttime = utils::GetMicroTime();
-        if( !planner->InitPlan(_robot, params, false) ) {
+        if( !planner->InitPlan(_robot, params, "") ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }

--- a/plugins/rmanipulation/visualfeedback.cpp
+++ b/plugins/rmanipulation/visualfeedback.cpp
@@ -1379,7 +1379,7 @@ Visibility computation checks occlusion with other objects using ray sampling in
         RAVELOG_INFOA("starting planning\n");
         uint64_t starttime = utils::GetMicroTime();
         for(int iter = 0; iter < 1; ++iter) {
-            if( !planner->InitPlan(_robot, params) ) {
+            if( !planner->InitPlan(_robot, params, false) ) {
                 RAVELOG_ERROR("InitPlan failed\n");
                 return false;
             }
@@ -1497,7 +1497,7 @@ Visibility computation checks occlusion with other objects using ray sampling in
         bool bSuccess = false;
         RAVELOG_INFOA("starting planning\n");
         uint64_t starttime = utils::GetMicroTime();
-        if( !planner->InitPlan(_robot, params) ) {
+        if( !planner->InitPlan(_robot, params, false) ) {
             RAVELOG_ERROR("InitPlan failed\n");
             return false;
         }

--- a/plugins/rplanners/constraintparabolicsmoother.cpp
+++ b/plugins/rplanners/constraintparabolicsmoother.cpp
@@ -105,7 +105,7 @@ public:
         //OPENRAVE_ASSERT_FORMAT0(!!_distancechecker, "need pqp distance checker", ORE_Assert);
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
@@ -114,7 +114,7 @@ public:
         return _InitPlan();
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
+    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());

--- a/plugins/rplanners/constraintparabolicsmoother.cpp
+++ b/plugins/rplanners/constraintparabolicsmoother.cpp
@@ -105,11 +105,12 @@ public:
         //OPENRAVE_ASSERT_FORMAT0(!!_distancechecker, "need pqp distance checker", ORE_Assert);
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
+        _parameters->LoadExtraParameters(extraParameters);
         _probot = pbase;
         return _InitPlan();
     }

--- a/plugins/rplanners/linearshortcutadvanced.cpp
+++ b/plugins/rplanners/linearshortcutadvanced.cpp
@@ -31,22 +31,12 @@ public:
     virtual ~ShortcutLinearPlanner() {
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         _parameters->copy(params);
-
-        if (loadExtraParameters) {
-            std::stringstream ss;
-
-            ss << "<" << params->GetXMLId() << ">" << endl;
-            ss << params->_sExtraParameters << endl;
-            ss << "</" << params->GetXMLId() << ">" << endl;
-
-            ss >> *_parameters;
-        }
-
+        _parameters->LoadExtraParameters(extraParameters);
         _probot = pbase;
         return _InitPlan();
     }
@@ -68,7 +58,7 @@ public:
         if( _parameters->_fStepLength <= 0 ) {
             _parameters->_fStepLength = 0.04;
         }
-        _linearretimer->InitPlan(RobotBasePtr(), _parameters, false);
+        _linearretimer->InitPlan(RobotBasePtr(), _parameters, "");
         _puniformsampler = RaveCreateSpaceSampler(GetEnv(),"mt19937");
         if( !!_puniformsampler ) {
             _puniformsampler->SetSeed(_parameters->_nRandomGeneratorSeed);

--- a/plugins/rplanners/linearshortcutadvanced.cpp
+++ b/plugins/rplanners/linearshortcutadvanced.cpp
@@ -35,9 +35,8 @@ public:
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
-        const std::string originalExtraParameters = _parameters->_sExtraParameters;
-
         _parameters->copy(params);
+
         if (loadExtraParameters) {
             std::stringstream ss;
 
@@ -46,8 +45,6 @@ public:
             ss << "</" << params->GetXMLId() << ">" << endl;
 
             ss >> *_parameters;
-
-            _parameters->_sExtraParameters = originalExtraParameters;
         }
 
         _probot = pbase;

--- a/plugins/rplanners/linearsmoother.cpp
+++ b/plugins/rplanners/linearsmoother.cpp
@@ -34,6 +34,16 @@ public:
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         _parameters->copy(params);
+
+        if (loadExtraParameters) {
+            std::stringstream ss;
+
+            ss << "<" << params->GetXMLId() << ">" << endl;
+            ss << params->_sExtraParameters << endl;
+            ss << "</" << params->GetXMLId() << ">" << endl;
+
+            ss >> *_parameters;
+        }
         _probot = pbase;
         return _InitPlan();
     }

--- a/plugins/rplanners/linearsmoother.cpp
+++ b/plugins/rplanners/linearsmoother.cpp
@@ -29,21 +29,12 @@ public:
     virtual ~LinearSmoother() {
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         _parameters->copy(params);
-
-        if (loadExtraParameters) {
-            std::stringstream ss;
-
-            ss << "<" << params->GetXMLId() << ">" << endl;
-            ss << params->_sExtraParameters << endl;
-            ss << "</" << params->GetXMLId() << ">" << endl;
-
-            ss >> *_parameters;
-        }
+        _parameters->LoadExtraParameters(extraParameters);
         _probot = pbase;
         return _InitPlan();
     }
@@ -69,7 +60,7 @@ public:
         if( !!_puniformsampler ) {
             _puniformsampler->SetSeed(_parameters->_nRandomGeneratorSeed);
         }
-        _linearretimer->InitPlan(RobotBasePtr(), _parameters, false);
+        _linearretimer->InitPlan(RobotBasePtr(), _parameters, "");
 
         _vConfigVelocityLimitInv.resize(_parameters->_vConfigVelocityLimit.size());
         for(int i = 0; i < (int)_vConfigVelocityLimitInv.size(); ++i) {

--- a/plugins/rplanners/linearsmoother.cpp
+++ b/plugins/rplanners/linearsmoother.cpp
@@ -29,7 +29,7 @@ public:
     virtual ~LinearSmoother() {
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
@@ -38,7 +38,7 @@ public:
         return _InitPlan();
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
+    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
@@ -59,7 +59,7 @@ public:
         if( !!_puniformsampler ) {
             _puniformsampler->SetSeed(_parameters->_nRandomGeneratorSeed);
         }
-        _linearretimer->InitPlan(RobotBasePtr(), _parameters);
+        _linearretimer->InitPlan(RobotBasePtr(), _parameters, false);
 
         _vConfigVelocityLimitInv.resize(_parameters->_vConfigVelocityLimit.size());
         for(int i = 0; i < (int)_vConfigVelocityLimitInv.size(); ++i) {

--- a/plugins/rplanners/parabolicsmoother.cpp
+++ b/plugins/rplanners/parabolicsmoother.cpp
@@ -199,30 +199,12 @@ public:
         _feasibilitychecker.SetEnvID(GetEnv()->GetId()); // set envid for logging purpose
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, const std::string& extraParameters)
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
-        const std::string originalExtraParameters = _parameters->_sExtraParameters;
-
         _parameters->copy(params);
-        if (loadExtraParameters) {
-            std::stringstream ss;
-            ss << "<" << params->GetXMLId() << ">" << endl;
-            ss << params->_sExtraParameters << endl;
-            ss << "</" << params->GetXMLId() << ">" << endl;
-
-            //RAVELOG_WARN_FORMAT("ss 2=%s", ss.str());
-
-            ss >> *_parameters;
-
-            // RAVELOG_WARN_FORMAT("_sExtraParameters 2=%s", _parameters->_sExtraParameters);
-            // RAVELOG_WARN_FORMAT("_sPostProcessingPlanner 2=%s", _parameters->_sPostProcessingPlanner);
-            // RAVELOG_WARN_FORMAT("_sPostProcessingParameters 2=%s", _parameters->_sPostProcessingParameters);
-
-            _parameters->_sExtraParameters = originalExtraParameters;
-        }
-
+        _parameters->LoadExtraParameters(extraParameters);
         return _InitPlan();
     }
 

--- a/plugins/rplanners/parabolicsmoother.cpp
+++ b/plugins/rplanners/parabolicsmoother.cpp
@@ -199,11 +199,30 @@ public:
         _feasibilitychecker.SetEnvID(GetEnv()->GetId()); // set envid for logging purpose
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters)
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
+        const std::string originalExtraParameters = _parameters->_sExtraParameters;
+
         _parameters->copy(params);
+        if (loadExtraParameters) {
+            std::stringstream ss;
+            ss << "<" << params->GetXMLId() << ">" << endl;
+            ss << params->_sExtraParameters << endl;
+            ss << "</" << params->GetXMLId() << ">" << endl;
+
+            //RAVELOG_WARN_FORMAT("ss 2=%s", ss.str());
+
+            ss >> *_parameters;
+
+            // RAVELOG_WARN_FORMAT("_sExtraParameters 2=%s", _parameters->_sExtraParameters);
+            // RAVELOG_WARN_FORMAT("_sPostProcessingPlanner 2=%s", _parameters->_sPostProcessingPlanner);
+            // RAVELOG_WARN_FORMAT("_sPostProcessingParameters 2=%s", _parameters->_sPostProcessingParameters);
+
+            _parameters->_sExtraParameters = originalExtraParameters;
+        }
+
         return _InitPlan();
     }
 

--- a/plugins/rplanners/parabolicsmoother2.cpp
+++ b/plugins/rplanners/parabolicsmoother2.cpp
@@ -366,11 +366,12 @@ public:
         _feasibilitychecker.SetEnvID(_environmentid); // set envid for logging purpose
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
+        _parameters->LoadExtraParameters(extraParameters);
         return _InitPlan();
     }
 

--- a/plugins/rplanners/parabolicsmoother2.cpp
+++ b/plugins/rplanners/parabolicsmoother2.cpp
@@ -366,7 +366,7 @@ public:
         _feasibilitychecker.SetEnvID(_environmentid); // set envid for logging purpose
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
@@ -374,7 +374,7 @@ public:
         return _InitPlan();
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
+    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());

--- a/plugins/rplanners/randomized-astar.cpp
+++ b/plugins/rplanners/randomized-astar.cpp
@@ -308,7 +308,7 @@ Rosen Diankov, James Kuffner. \"Randomized Statistical Path Planning. Intl. Conf
 
     // Planning Methods
     ///< manipulator state is also set
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset();

--- a/plugins/rplanners/randomized-astar.cpp
+++ b/plugins/rplanners/randomized-astar.cpp
@@ -308,7 +308,7 @@ Rosen Diankov, James Kuffner. \"Randomized Statistical Path Planning. Intl. Conf
 
     // Planning Methods
     ///< manipulator state is also set
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset();
@@ -316,6 +316,7 @@ Rosen Diankov, James Kuffner. \"Randomized Statistical Path Planning. Intl. Conf
         _robot = pbase;
         boost::shared_ptr<RAStarParameters> parameters(new RAStarParameters());
         parameters->copy(pparams);
+        parameters->LoadExtraParameters(extraParameters);
 
         RobotBase::RobotStateSaver savestate(_robot);
 

--- a/plugins/rplanners/rrt.h
+++ b/plugins/rplanners/rrt.h
@@ -294,7 +294,7 @@ Some python code to display data::\n\
         dReal length;
     };
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new RRTParameters());
@@ -691,7 +691,7 @@ public:
     virtual ~BasicRrtPlanner() {
     }
 
-    bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
+    bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters)
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new BasicRRTParameters());
@@ -953,7 +953,7 @@ public:
     virtual ~ExplorationPlanner() {
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ExplorationParameters());

--- a/plugins/rplanners/rrt.h
+++ b/plugins/rplanners/rrt.h
@@ -294,11 +294,12 @@ Some python code to display data::\n\
         dReal length;
     };
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new RRTParameters());
         _parameters->copy(pparams);
+        _parameters->LoadExtraParameters(extraParameters);
         if( !RrtPlanner<SimpleNode>::_InitPlan(pbase,_parameters) ) {
             _parameters.reset();
             return false;
@@ -691,11 +692,12 @@ public:
     virtual ~BasicRrtPlanner() {
     }
 
-    bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters)
+    bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, const std::string& extraParameters)
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new BasicRRTParameters());
         _parameters->copy(pparams);
+        _parameters->LoadExtraParameters(extraParameters);
         if( !RrtPlanner<SimpleNode>::_InitPlan(pbase,_parameters) ) {
             _parameters.reset();
             return false;
@@ -953,11 +955,12 @@ public:
     virtual ~ExplorationPlanner() {
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ExplorationParameters());
         _parameters->copy(pparams);
+        _parameters->LoadExtraParameters(extraParameters);
         if( !RrtPlanner<SimpleNode>::_InitPlan(pbase,_parameters) ) {
             _parameters.reset();
             return false;

--- a/plugins/rplanners/subparabolicsmoother.cpp
+++ b/plugins/rplanners/subparabolicsmoother.cpp
@@ -30,7 +30,7 @@ public:
         __description = ":Interface Author: Rosen Diankov\n\nInterface to `Indiana University Intelligent Motion Laboratory <http://www.iu.edu/~motion/software.html>`_ parabolic smoothing library (Kris Hauser).\n\n**Note:** The original trajectory will not be preserved at all, don't use this if the robot has to hit all points of the trajectory.\n";
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters)
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
@@ -38,7 +38,7 @@ public:
         return _InitPlan();
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
+    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());

--- a/plugins/rplanners/subparabolicsmoother.cpp
+++ b/plugins/rplanners/subparabolicsmoother.cpp
@@ -30,11 +30,12 @@ public:
         __description = ":Interface Author: Rosen Diankov\n\nInterface to `Indiana University Intelligent Motion Laboratory <http://www.iu.edu/~motion/software.html>`_ parabolic smoothing library (Kris Hauser).\n\n**Note:** The original trajectory will not be preserved at all, don't use this if the robot has to hit all points of the trajectory.\n";
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, const std::string& extraParameters)
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         _parameters->copy(params);
+        _parameters->LoadExtraParameters(extraParameters);
         return _InitPlan();
     }
 

--- a/plugins/rplanners/trajectoryretimer.h
+++ b/plugins/rplanners/trajectoryretimer.h
@@ -50,12 +50,13 @@ public:
         _bmanipconstraints = false;
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         params->Validate();
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
+        _parameters->LoadExtraParameters(extraParameters);
         // reset the cache
         _cachedoldspec = ConfigurationSpecification();
         _cachednewspec = ConfigurationSpecification();

--- a/plugins/rplanners/trajectoryretimer.h
+++ b/plugins/rplanners/trajectoryretimer.h
@@ -50,7 +50,7 @@ public:
         _bmanipconstraints = false;
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         params->Validate();
@@ -62,7 +62,7 @@ public:
         return _InitPlan();
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
+    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());

--- a/plugins/rplanners/trajectoryretimer2.h
+++ b/plugins/rplanners/trajectoryretimer2.h
@@ -17,6 +17,8 @@
 #include "openraveplugindefs.h"
 #include "manipconstraints2.h"
 
+#include <sstream>
+
 #define _(msgid) OpenRAVE::RaveGetLocalizedTextForDomain("openrave_plugins_rplanners", msgid)
 
 namespace rplanners {
@@ -48,19 +50,25 @@ public:
         _bmanipconstraints = false;
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         params->Validate();
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
+        if (loadExtraParameters) {
+            std::stringstream ss;
+            ss << *params;
+            ss >> *_parameters;
+        }
+
         // reset the cache
         _cachedoldspec = ConfigurationSpecification();
         _cachednewspec = ConfigurationSpecification();
         return _InitPlan();
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
+    virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
@@ -96,6 +104,10 @@ public:
     }
 
     virtual PlannerParametersConstPtr GetParameters() const {
+        return _parameters;
+    }
+
+    virtual PlannerParametersPtr GetParameters() {
         return _parameters;
     }
 

--- a/plugins/rplanners/trajectoryretimer2.h
+++ b/plugins/rplanners/trajectoryretimer2.h
@@ -17,8 +17,6 @@
 #include "openraveplugindefs.h"
 #include "manipconstraints2.h"
 
-#include <sstream>
-
 #define _(msgid) OpenRAVE::RaveGetLocalizedTextForDomain("openrave_plugins_rplanners", msgid)
 
 namespace rplanners {
@@ -50,17 +48,13 @@ public:
         _bmanipconstraints = false;
     }
 
-    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
         params->Validate();
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
-        if (loadExtraParameters) {
-            std::stringstream ss;
-            ss << *params;
-            ss >> *_parameters;
-        }
+        _parameters->LoadExtraParameters(extraParameters);
 
         // reset the cache
         _cachedoldspec = ConfigurationSpecification();
@@ -104,10 +98,6 @@ public:
     }
 
     virtual PlannerParametersConstPtr GetParameters() const {
-        return _parameters;
-    }
-
-    virtual PlannerParametersPtr GetParameters() {
         return _parameters;
     }
 

--- a/plugins/rplanners/workspacetrajectorytracker.cpp
+++ b/plugins/rplanners/workspacetrajectorytracker.cpp
@@ -46,12 +46,13 @@ Planner Parameters\n\
     virtual ~WorkspaceTrajectoryTracker() {
     }
 
-    virtual bool InitPlan(RobotBasePtr probot, PlannerParametersConstPtr params, bool loadExtraParameters) override
+    virtual bool InitPlan(RobotBasePtr probot, PlannerParametersConstPtr params, const std::string& extraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
 
         boost::shared_ptr<WorkspaceTrajectoryParameters> parameters(new WorkspaceTrajectoryParameters(GetEnv()));
         parameters->copy(params);
+        parameters->LoadExtraParameters(extraParameters);
         _robot = probot;
         _manip = _robot->GetActiveManipulator();
 
@@ -285,7 +286,7 @@ Planner Parameters\n\
             return PlannerStatus("bPrevInCollision" ,PS_Failed);
         }
 
-        if( !_retimerplanner->InitPlan(RobotBasePtr(),_parameters,false) || !_retimerplanner->PlanPath(poutputtraj).GetStatusCode() ) {
+        if( !_retimerplanner->InitPlan(RobotBasePtr(),_parameters,"") || !_retimerplanner->PlanPath(poutputtraj).GetStatusCode() ) {
             return PlannerStatus(PS_Failed);
         }
 

--- a/plugins/rplanners/workspacetrajectorytracker.cpp
+++ b/plugins/rplanners/workspacetrajectorytracker.cpp
@@ -46,7 +46,7 @@ Planner Parameters\n\
     virtual ~WorkspaceTrajectoryTracker() {
     }
 
-    virtual bool InitPlan(RobotBasePtr probot, PlannerParametersConstPtr params)
+    virtual bool InitPlan(RobotBasePtr probot, PlannerParametersConstPtr params, bool loadExtraParameters) override
     {
         EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
 
@@ -285,7 +285,7 @@ Planner Parameters\n\
             return PlannerStatus("bPrevInCollision" ,PS_Failed);
         }
 
-        if( !_retimerplanner->InitPlan(RobotBasePtr(),_parameters) || !_retimerplanner->PlanPath(poutputtraj).GetStatusCode() ) {
+        if( !_retimerplanner->InitPlan(RobotBasePtr(),_parameters,false) || !_retimerplanner->PlanPath(poutputtraj).GetStatusCode() ) {
             return PlannerStatus(PS_Failed);
         }
 

--- a/python/bindings/openravepy_planner.cpp
+++ b/python/bindings/openravepy_planner.cpp
@@ -240,7 +240,7 @@ bool PyPlannerBase::InitPlan(PyRobotBasePtr pyrobot, PyPlannerParametersPtr ppar
     if( releasegil ) {
         statesaver.reset(new openravepy::PythonThreadSaver());
     }
-    return _pplanner->InitPlan(probot,parameters,false);
+    return _pplanner->InitPlan(probot,parameters,"");
 }
 
 bool PyPlannerBase::InitPlan(PyRobotBasePtr pbase, const string& params)

--- a/python/bindings/openravepy_planner.cpp
+++ b/python/bindings/openravepy_planner.cpp
@@ -240,7 +240,7 @@ bool PyPlannerBase::InitPlan(PyRobotBasePtr pyrobot, PyPlannerParametersPtr ppar
     if( releasegil ) {
         statesaver.reset(new openravepy::PythonThreadSaver());
     }
-    return _pplanner->InitPlan(probot,parameters);
+    return _pplanner->InitPlan(probot,parameters,false);
 }
 
 bool PyPlannerBase::InitPlan(PyRobotBasePtr pbase, const string& params)

--- a/python/bindings/openravepy_planner.cpp
+++ b/python/bindings/openravepy_planner.cpp
@@ -240,7 +240,7 @@ bool PyPlannerBase::InitPlan(PyRobotBasePtr pyrobot, PyPlannerParametersPtr ppar
     if( releasegil ) {
         statesaver.reset(new openravepy::PythonThreadSaver());
     }
-    return _pplanner->InitPlan(probot,parameters,"");
+    return _pplanner->InitPlan(probot,parameters,parameters->_sExtraParameters);
 }
 
 bool PyPlannerBase::InitPlan(PyRobotBasePtr pbase, const string& params)

--- a/src/libopenrave/planner.cpp
+++ b/src/libopenrave/planner.cpp
@@ -328,51 +328,55 @@ PlannerParameters::PlannerParameters(const PlannerParameters &r)
 
 PlannerParameters& PlannerParameters::operator=(const PlannerParameters& r)
 {
-    // reset
-    _costfn = r._costfn;
-    _goalfn = r._goalfn;
-    _distmetricfn = r._distmetricfn;
-    _checkpathvelocityconstraintsfn = r._checkpathvelocityconstraintsfn;
-    _samplefn = r._samplefn;
-    _sampleneighfn = r._sampleneighfn;
-    _samplegoalfn = r._samplegoalfn;
-    _sampleinitialfn = r._sampleinitialfn;
-    _setstatevaluesfn = r._setstatevaluesfn;
-    _getstatefn = r._getstatefn;
-    _diffstatefn = r._diffstatefn;
-    _neighstatefn = r._neighstatefn;
-    _listInternalSamplers = r._listInternalSamplers;
-
-    vinitialconfig.resize(0);
-    _vInitialConfigVelocities.resize(0);
-    _vGoalConfigVelocities.resize(0);
-    vgoalconfig.resize(0);
-    _configurationspecification = ConfigurationSpecification();
-    _vConfigLowerLimit.resize(0);
-    _vConfigUpperLimit.resize(0);
-    _vConfigResolution.resize(0);
-    _vConfigVelocityLimit.resize(0);
-    _vConfigAccelerationLimit.resize(0);
-    _sPostProcessingPlanner = "";
-    _sPostProcessingParameters.resize(0);
-    _sExtraParameters.resize(0);
-    _nMaxIterations = 0;
-    _nMaxPlanningTime = 0;
-    _fStepLength = 0.04f;
-    _nRandomGeneratorSeed = 0;
-    _plannerparametersdepth = 0;
-
-    // transfer data
-    std::stringstream ss;
-    ss << std::setprecision(std::numeric_limits<dReal>::digits10+1); /// have to do this or otherwise precision gets lost and planners' initial conditions can vioalte constraints
-    ss << r;
-    ss >> *this;
+    _Copy(r);
     return *this;
 }
 
 void PlannerParameters::copy(boost::shared_ptr<PlannerParameters const> r)
 {
-    *this = *r;
+    if (!r) {
+        return;
+    }
+    _Copy(*r);
+}
+
+void PlannerParameters::_Copy(const PlannerParameters& other)
+{
+    // reset
+    _costfn = other._costfn;
+    _goalfn = other._goalfn;
+    _distmetricfn = other._distmetricfn;
+    _checkpathvelocityconstraintsfn = other._checkpathvelocityconstraintsfn;
+    _samplefn = other._samplefn;
+    _sampleneighfn = other._sampleneighfn;
+    _samplegoalfn = other._samplegoalfn;
+    _sampleinitialfn = other._sampleinitialfn;
+    _setstatevaluesfn = other._setstatevaluesfn;
+    _getstatefn = other._getstatefn;
+    _diffstatefn = other._diffstatefn;
+    _neighstatefn = other._neighstatefn;
+    _listInternalSamplers = other._listInternalSamplers;
+
+    vinitialconfig = other.vinitialconfig;
+    _vInitialConfigVelocities = other._vInitialConfigVelocities;
+    _vGoalConfigVelocities = other._vGoalConfigVelocities;
+    vgoalconfig = other.vgoalconfig;
+    _configurationspecification = other._configurationspecification;
+    _vConfigLowerLimit = other._vConfigLowerLimit;
+    _vConfigUpperLimit = other._vConfigUpperLimit;
+    _vConfigResolution = other._vConfigResolution;
+    _vConfigVelocityLimit = other._vConfigVelocityLimit;
+    _vConfigAccelerationLimit = other._vConfigAccelerationLimit;
+    _sPostProcessingPlanner = other._sPostProcessingPlanner;
+    _sPostProcessingParameters = other._sPostProcessingParameters;
+    _sExtraParameters = other._sExtraParameters;
+    _nMaxIterations = other._nMaxIterations;
+    _nMaxPlanningTime = other._nMaxPlanningTime;
+    _fStepLength = other._fStepLength;
+    _nRandomGeneratorSeed = other._nRandomGeneratorSeed;
+    _plannerparametersdepth = other._plannerparametersdepth;
+
+    _vXMLParameters = other._vXMLParameters;
 }
 
 int PlannerParameters::SetStateValues(const std::vector<dReal>& values, int options) const

--- a/src/libopenrave/planner.cpp
+++ b/src/libopenrave/planner.cpp
@@ -1124,14 +1124,14 @@ PlannerStatus PlannerBase::_ProcessPostPlanners(RobotBasePtr probot, TrajectoryB
 
     PlannerParametersPtr params(new PlannerParameters());
     params->copy(GetParameters());
-    params->_sExtraParameters += GetParameters()->_sPostProcessingParameters;
+    //params->_sExtraParameters += GetParameters()->_sPostProcessingParameters;
     params->_sPostProcessingPlanner = "";
     params->_sPostProcessingParameters = "";
 
     params->_nMaxIterations = 0; // have to reset since path optimizers also use it and new parameters could be in extra parameters
     //params->_nMaxPlanningTime = 0; // have to reset since path optimizers also use it and new parameters could be in extra parameters??
 
-    if( __cachePostProcessPlanner->InitPlan(probot, params, params->_sExtraParameters) ) {
+    if( __cachePostProcessPlanner->InitPlan(probot, params, params->_sExtraParameters + GetParameters()->_sPostProcessingParameters) ) {
         return __cachePostProcessPlanner->PlanPath(ptraj);
     }
 

--- a/src/libopenrave/planner.cpp
+++ b/src/libopenrave/planner.cpp
@@ -1134,6 +1134,9 @@ PlannerStatus PlannerBase::_ProcessPostPlanners(RobotBasePtr probot, TrajectoryB
     //params->_nMaxPlanningTime = 0; // have to reset since path optimizers also use it and new parameters could be in extra parameters??
 
     if( __cachePostProcessPlanner->InitPlan(probot, params, params->_sExtraParameters + GetParameters()->_sPostProcessingParameters) ) {
+        std::stringstream ss;
+        ss << *__cachePostProcessPlanner->GetParameters();
+        RAVELOG_WARN_FORMAT("env=%s, %s", GetEnv()->GetNameId()%(ss.str()));
         return __cachePostProcessPlanner->PlanPath(ptraj);
     }
 

--- a/src/libopenrave/planner.cpp
+++ b/src/libopenrave/planner.cpp
@@ -340,7 +340,7 @@ void PlannerParameters::copy(boost::shared_ptr<PlannerParameters const> r)
     _Copy(*r);
 }
 
-void PlannerParameters::_Copy(const PlannerParameters& other)
+bool PlannerParameters::_Copy(const PlannerParameters& other)
 {
     // reset
     _costfn = other._costfn;
@@ -375,6 +375,8 @@ void PlannerParameters::_Copy(const PlannerParameters& other)
     _fStepLength = other._fStepLength;
     _nRandomGeneratorSeed = other._nRandomGeneratorSeed;
     _plannerparametersdepth = other._plannerparametersdepth;
+
+    return true;
 }
 
 void PlannerParameters::LoadExtraParameters(const std::string& extraParameters)

--- a/src/libopenrave/plannerparameters.cpp
+++ b/src/libopenrave/plannerparameters.cpp
@@ -37,6 +37,35 @@ typedef bai::base64_from_binary<    // convert binary values to base64 character
             >
         > base64_text;
 
+void WorkspaceTrajectoryParameters::_Copy(const PlannerParameters& r)
+{
+    PlannerParameters::_Copy(r);
+    
+    const WorkspaceTrajectoryParameters* pother = dynamic_cast<const WorkspaceTrajectoryParameters*>(&r);
+
+    if (!pother) {
+        return;
+    }
+
+    const WorkspaceTrajectoryParameters& other = *pother;
+    maxdeviationangle = other.maxdeviationangle;
+    maintaintiming = other.maintaintiming;
+    greedysearch = other.greedysearch;
+    ignorefirstcollision = other.ignorefirstcollision;
+    ignorefirstcollisionee = other.ignorefirstcollisionee;
+    ignorelastcollisionee = other.ignorelastcollisionee;
+    minimumcompletetime = other.minimumcompletetime;
+    if (!!other.workspacetraj) {
+        if( !workspacetraj ) {
+            workspacetraj = RaveCreateTrajectory(_penv,"");
+        }
+        workspacetraj->Clone(other.workspacetraj, 0);
+    }
+    else {
+        workspacetraj.reset();
+    }
+}
+
 WorkspaceTrajectoryParameters::WorkspaceTrajectoryParameters(EnvironmentBasePtr penv) : maxdeviationangle(0.15*PI), maintaintiming(false), greedysearch(true), ignorefirstcollision(0), ignorefirstcollisionee(0), ignorelastcollisionee(0), minimumcompletetime(0), _penv(penv), _bProcessing(false) {
     _vXMLParameters.push_back("maxdeviationangle");
     _vXMLParameters.push_back("maintaintiming");

--- a/src/libopenrave/plannerparameters.cpp
+++ b/src/libopenrave/plannerparameters.cpp
@@ -37,14 +37,15 @@ typedef bai::base64_from_binary<    // convert binary values to base64 character
             >
         > base64_text;
 
-void WorkspaceTrajectoryParameters::_Copy(const PlannerParameters& r)
+bool WorkspaceTrajectoryParameters::_Copy(const PlannerParameters& r)
 {
-    PlannerParameters::_Copy(r);
+    if (!PlannerParameters::_Copy(r)) {
+        return false;
+    }
     
     const WorkspaceTrajectoryParameters* pother = dynamic_cast<const WorkspaceTrajectoryParameters*>(&r);
-
     if (!pother) {
-        return;
+        return false;
     }
 
     const WorkspaceTrajectoryParameters& other = *pother;
@@ -64,6 +65,8 @@ void WorkspaceTrajectoryParameters::_Copy(const PlannerParameters& r)
     else {
         workspacetraj.reset();
     }
+
+    return true;
 }
 
 WorkspaceTrajectoryParameters::WorkspaceTrajectoryParameters(EnvironmentBasePtr penv) : maxdeviationangle(0.15*PI), maintaintiming(false), greedysearch(true), ignorefirstcollision(0), ignorefirstcollisionee(0), ignorelastcollisionee(0), minimumcompletetime(0), _penv(penv), _bProcessing(false) {

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -614,7 +614,7 @@ PlannerStatus _PlanActiveDOFTrajectory(TrajectoryBasePtr traj, RobotBasePtr prob
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters += plannerparameters;
-    if( !planner->InitPlan(probot,params) ) {
+    if( !planner->InitPlan(probot,params, false) ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -643,7 +643,7 @@ ActiveDOFTrajectorySmoother::ActiveDOFTrajectorySmoother(RobotBasePtr robot, con
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
     params->_sExtraParameters += plannerparameters;
-    if( !_planner->InitPlan(_robot,params) ) {
+    if( !_planner->InitPlan(_robot,params, false) ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), plannername%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -684,7 +684,7 @@ void ActiveDOFTrajectorySmoother::_UpdateParameters()
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
     params->_sExtraParameters = _parameters->_sExtraParameters;
-    if( !_planner->InitPlan(_robot,params) ) {
+    if( !_planner->InitPlan(_robot,params, false) ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -706,7 +706,7 @@ ActiveDOFTrajectoryRetimer::ActiveDOFTrajectoryRetimer(RobotBasePtr robot, const
     params->_setstatevaluesfn.clear();
     params->_checkpathvelocityconstraintsfn.clear();
     params->_sExtraParameters = plannerparameters;
-    if( !_planner->InitPlan(_robot,params) ) {
+    if( !_planner->InitPlan(_robot,params, false) ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), plannername%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -729,7 +729,7 @@ PlannerStatus ActiveDOFTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, bool 
     TrajectoryTimingParametersPtr parameters = boost::dynamic_pointer_cast<TrajectoryTimingParameters>(_parameters);
     if( parameters->_hastimestamps != hastimestamps ) {
         parameters->_hastimestamps = hastimestamps;
-        if( !_planner->InitPlan(_robot,parameters) ) {
+        if( !_planner->InitPlan(_robot,parameters, false) ) {
             throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
         }
     }
@@ -748,7 +748,7 @@ void ActiveDOFTrajectoryRetimer::_UpdateParameters()
     params->_setstatevaluesfn.clear();
     params->_checkpathvelocityconstraintsfn.clear();
     params->_sExtraParameters = _parameters->_sExtraParameters;
-    if( !_planner->InitPlan(_robot,params) ) {
+    if( !_planner->InitPlan(_robot,params, false) ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -785,7 +785,7 @@ PlannerStatus _PlanTrajectory(TrajectoryBasePtr traj, bool hastimestamps, dReal 
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters += plannerparameters;
-    if( !planner->InitPlan(RobotBasePtr(),params) ) {
+    if( !planner->InitPlan(RobotBasePtr(),params, false) ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -985,7 +985,7 @@ static PlannerStatus _PlanAffineTrajectory(TrajectoryBasePtr traj, const std::ve
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters = plannerparameters;
 
-    if( !planner->InitPlan(RobotBasePtr(),params) ) {
+    if( !planner->InitPlan(RobotBasePtr(),params, false) ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -1024,7 +1024,7 @@ void AffineTrajectoryRetimer::SetPlanner(const std::string& plannername, const s
         if( !!_parameters ) {
             _parameters->_sExtraParameters = _extraparameters;
             if( !!_planner ) {
-                if( !_planner->InitPlan(RobotBasePtr(), _parameters) ) {
+                if( !_planner->InitPlan(RobotBasePtr(), _parameters, true) ) {
                     throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s"), _plannername, ORE_InvalidArguments);
                 }
             }
@@ -1139,7 +1139,7 @@ PlannerStatus AffineTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, const st
         bInitPlan = true;
     }
     if( bInitPlan ) {
-        if( !_planner->InitPlan(RobotBasePtr(),parameters) ) {
+        if( !_planner->InitPlan(RobotBasePtr(),parameters,false) ) {
             stringstream ss; ss << trajspec;
             throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with affine trajectory spec: %s"), _plannername%ss.str(), ORE_InvalidArguments);
         }
@@ -1468,7 +1468,7 @@ size_t InsertWaypointWithSmoothing(int index, const std::vector<dReal>& dofvalue
     params->_hastimestamps = false;
 
     PlannerBasePtr planner = RaveCreatePlanner(traj->GetEnv(),plannername.size() > 0 ? plannername : string("parabolictrajectoryretimer"));
-    if( !planner->InitPlan(RobotBasePtr(),params) ) {
+    if( !planner->InitPlan(RobotBasePtr(),params,false) ) {
         throw OPENRAVE_EXCEPTION_FORMAT0(_("failed to InitPlan"),ORE_Failed);
     }
 

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -614,7 +614,7 @@ PlannerStatus _PlanActiveDOFTrajectory(TrajectoryBasePtr traj, RobotBasePtr prob
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters += plannerparameters;
-    if( !planner->InitPlan(probot,params, "") ) {
+    if( !planner->InitPlan(probot,params, params->_sExtraParameters) ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -643,7 +643,7 @@ ActiveDOFTrajectorySmoother::ActiveDOFTrajectorySmoother(RobotBasePtr robot, con
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
     params->_sExtraParameters += plannerparameters;
-    if( !_planner->InitPlan(_robot,params, "") ) {
+    if( !_planner->InitPlan(_robot,params, params->_sExtraParameters) ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), plannername%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -684,7 +684,7 @@ void ActiveDOFTrajectorySmoother::_UpdateParameters()
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
     params->_sExtraParameters = _parameters->_sExtraParameters;
-    if( !_planner->InitPlan(_robot,params, "") ) {
+    if( !_planner->InitPlan(_robot,params, params->_sExtraParameters) ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -706,7 +706,7 @@ ActiveDOFTrajectoryRetimer::ActiveDOFTrajectoryRetimer(RobotBasePtr robot, const
     params->_setstatevaluesfn.clear();
     params->_checkpathvelocityconstraintsfn.clear();
     params->_sExtraParameters = plannerparameters;
-    if( !_planner->InitPlan(_robot,params, "") ) {
+    if( !_planner->InitPlan(_robot,params, params->_sExtraParameters) ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), plannername%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -729,7 +729,7 @@ PlannerStatus ActiveDOFTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, bool 
     TrajectoryTimingParametersPtr parameters = boost::dynamic_pointer_cast<TrajectoryTimingParameters>(_parameters);
     if( parameters->_hastimestamps != hastimestamps ) {
         parameters->_hastimestamps = hastimestamps;
-        if( !_planner->InitPlan(_robot,parameters, "") ) {
+        if( !_planner->InitPlan(_robot,parameters, parameters->_sExtraParameters) ) {
             throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
         }
     }
@@ -748,7 +748,7 @@ void ActiveDOFTrajectoryRetimer::_UpdateParameters()
     params->_setstatevaluesfn.clear();
     params->_checkpathvelocityconstraintsfn.clear();
     params->_sExtraParameters = _parameters->_sExtraParameters;
-    if( !_planner->InitPlan(_robot,params, "") ) {
+    if( !_planner->InitPlan(_robot,params, params->_sExtraParameters) ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -785,7 +785,7 @@ PlannerStatus _PlanTrajectory(TrajectoryBasePtr traj, bool hastimestamps, dReal 
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters += plannerparameters;
-    if( !planner->InitPlan(RobotBasePtr(),params, "") ) {
+    if( !planner->InitPlan(RobotBasePtr(),params, params->_sExtraParameters) ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -985,7 +985,7 @@ static PlannerStatus _PlanAffineTrajectory(TrajectoryBasePtr traj, const std::ve
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters = plannerparameters;
 
-    if( !planner->InitPlan(RobotBasePtr(),params, "") ) {
+    if( !planner->InitPlan(RobotBasePtr(),params, params->_sExtraParameters) ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -1139,7 +1139,7 @@ PlannerStatus AffineTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, const st
         bInitPlan = true;
     }
     if( bInitPlan ) {
-        if( !_planner->InitPlan(RobotBasePtr(),parameters,"") ) {
+        if( !_planner->InitPlan(RobotBasePtr(),parameters,parameters->_sExtraParameters) ) {
             stringstream ss; ss << trajspec;
             throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with affine trajectory spec: %s"), _plannername%ss.str(), ORE_InvalidArguments);
         }

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -614,7 +614,7 @@ PlannerStatus _PlanActiveDOFTrajectory(TrajectoryBasePtr traj, RobotBasePtr prob
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters += plannerparameters;
-    if( !planner->InitPlan(probot,params, false) ) {
+    if( !planner->InitPlan(probot,params, "") ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -643,7 +643,7 @@ ActiveDOFTrajectorySmoother::ActiveDOFTrajectorySmoother(RobotBasePtr robot, con
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
     params->_sExtraParameters += plannerparameters;
-    if( !_planner->InitPlan(_robot,params, false) ) {
+    if( !_planner->InitPlan(_robot,params, "") ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), plannername%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -684,7 +684,7 @@ void ActiveDOFTrajectorySmoother::_UpdateParameters()
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = false;
     params->_sExtraParameters = _parameters->_sExtraParameters;
-    if( !_planner->InitPlan(_robot,params, false) ) {
+    if( !_planner->InitPlan(_robot,params, "") ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -706,7 +706,7 @@ ActiveDOFTrajectoryRetimer::ActiveDOFTrajectoryRetimer(RobotBasePtr robot, const
     params->_setstatevaluesfn.clear();
     params->_checkpathvelocityconstraintsfn.clear();
     params->_sExtraParameters = plannerparameters;
-    if( !_planner->InitPlan(_robot,params, false) ) {
+    if( !_planner->InitPlan(_robot,params, "") ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), plannername%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -729,7 +729,7 @@ PlannerStatus ActiveDOFTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, bool 
     TrajectoryTimingParametersPtr parameters = boost::dynamic_pointer_cast<TrajectoryTimingParameters>(_parameters);
     if( parameters->_hastimestamps != hastimestamps ) {
         parameters->_hastimestamps = hastimestamps;
-        if( !_planner->InitPlan(_robot,parameters, false) ) {
+        if( !_planner->InitPlan(_robot,parameters, "") ) {
             throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
         }
     }
@@ -748,7 +748,7 @@ void ActiveDOFTrajectoryRetimer::_UpdateParameters()
     params->_setstatevaluesfn.clear();
     params->_checkpathvelocityconstraintsfn.clear();
     params->_sExtraParameters = _parameters->_sExtraParameters;
-    if( !_planner->InitPlan(_robot,params, false) ) {
+    if( !_planner->InitPlan(_robot,params, "") ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with robot %s"), _planner->GetXMLId()%_robot->GetName(), ORE_InvalidArguments);
     }
     _parameters=params; // necessary because SetRobotActiveJoints builds functions that hold weak_ptr to the parameters
@@ -785,7 +785,7 @@ PlannerStatus _PlanTrajectory(TrajectoryBasePtr traj, bool hastimestamps, dReal 
     params->_sPostProcessingPlanner = ""; // have to turn off the second post processing stage
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters += plannerparameters;
-    if( !planner->InitPlan(RobotBasePtr(),params, false) ) {
+    if( !planner->InitPlan(RobotBasePtr(),params, "") ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -985,7 +985,7 @@ static PlannerStatus _PlanAffineTrajectory(TrajectoryBasePtr traj, const std::ve
     params->_hastimestamps = hastimestamps;
     params->_sExtraParameters = plannerparameters;
 
-    if( !planner->InitPlan(RobotBasePtr(),params, false) ) {
+    if( !planner->InitPlan(RobotBasePtr(),params, "") ) {
         return PlannerStatus("InitPlan failed", PS_Failed);
     }
     PlannerStatus plannerStatus = planner->PlanPath(traj);
@@ -1024,7 +1024,7 @@ void AffineTrajectoryRetimer::SetPlanner(const std::string& plannername, const s
         if( !!_parameters ) {
             _parameters->_sExtraParameters = _extraparameters;
             if( !!_planner ) {
-                if( !_planner->InitPlan(RobotBasePtr(), _parameters, true) ) {
+                if( !_planner->InitPlan(RobotBasePtr(), _parameters, _extraparameters) ) {
                     throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s"), _plannername, ORE_InvalidArguments);
                 }
             }
@@ -1139,7 +1139,7 @@ PlannerStatus AffineTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, const st
         bInitPlan = true;
     }
     if( bInitPlan ) {
-        if( !_planner->InitPlan(RobotBasePtr(),parameters,false) ) {
+        if( !_planner->InitPlan(RobotBasePtr(),parameters,"") ) {
             stringstream ss; ss << trajspec;
             throw OPENRAVE_EXCEPTION_FORMAT(_("failed to init planner %s with affine trajectory spec: %s"), _plannername%ss.str(), ORE_InvalidArguments);
         }
@@ -1468,7 +1468,7 @@ size_t InsertWaypointWithSmoothing(int index, const std::vector<dReal>& dofvalue
     params->_hastimestamps = false;
 
     PlannerBasePtr planner = RaveCreatePlanner(traj->GetEnv(),plannername.size() > 0 ? plannername : string("parabolictrajectoryretimer"));
-    if( !planner->InitPlan(RobotBasePtr(),params,false) ) {
+    if( !planner->InitPlan(RobotBasePtr(),params,"") ) {
         throw OPENRAVE_EXCEPTION_FORMAT0(_("failed to InitPlan"),ORE_Failed);
     }
 


### PR DESCRIPTION
Summary
============

- this MR tries to reduce planning time by optimizing (and separating) assignment and post processing parameter loading 

Production behavior
=====================
- assignment operator was loading members in derived class by serialize->deserialize with xml format. This was taking hundreds of micro seconds.
- assignment operator was doing more than assignment, namely, it was parsing ``_sPostProcessingPlanner`` and ``_sPostProcessingParameters`` from ``_sExtraParameters``

Feature behavior
==============
- assignment operator(``=``) copies members by down casting, without going through xml string.
- parsing of ``_sPostProcessingPlanner`` and ``_sPostProcessingParameters`` are done explicitly by ``LoadExtraParameters``


Discussion points
================
- ``_ptarget`` of ``GraspSetParameters`` is copied by environment body index as it is the behavior in production. Do we have a better identifier such as name or id?

Future TODO
==============
- start using json string instead of xml.