### PR TITLE
clarify and fix _listNonCollidingLinks

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -5721,12 +5721,14 @@ void KinBody::_PostprocessChangedParameters(uint32_t parameters)
             }
             else {
                 // add since it is disabled?
-                FOREACH(itgrabbed,_vGrabbedBodies) {
-                    GrabbedPtr pgrabbed = boost::dynamic_pointer_cast<Grabbed>(*itgrabbed);
-                    if( find(pgrabbed->GetRigidlyAttachedLinks().begin(),pgrabbed->GetRigidlyAttachedLinks().end(), *itlink) == pgrabbed->GetRigidlyAttachedLinks().end() ) {
-                        if( find(pgrabbed->_listNonCollidingLinks.begin(),pgrabbed->_listNonCollidingLinks.end(),*itlink) == pgrabbed->_listNonCollidingLinks.end() ) {
-                            if( pgrabbed->WasLinkNonColliding(*itlink) != 0 ) {
-                                pgrabbed->_listNonCollidingLinks.push_back(*itlink);
+                for ( const UserDataPtr& pGrabbedUserData : _vGrabbedBodies) {
+                    Grabbed& grabbed = *(boost::dynamic_pointer_cast<Grabbed>(pGrabbedUserData));
+                    const std::vector<KinBody::LinkPtr>& attachedLinks = grabbed.GetRigidlyAttachedLinks();
+                    if( find(attachedLinks.begin(),attachedLinks.end(), *itlink) == attachedLinks.end() ) {
+                        std::list<KinBody::LinkConstPtr>& nonCollidingLinks = grabbed._listNonCollidingLinks;
+                        if( find(nonCollidingLinks.begin(),nonCollidingLinks.end(),*itlink) == nonCollidingLinks.end() ) {
+                            if( grabbed.WasLinkNonColliding(*itlink) != 0 ) {
+                                nonCollidingLinks.push_back(*itlink);
                             }
                         }
                     }

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -2316,7 +2316,7 @@ void Grabbed::ProcessCollidingLinks(const std::set<int>& setRobotLinksToIgnore)
 
     if( pgrabbedbody->IsEnabled() ) {
         FOREACH(itnoncolliding, _mapLinkIsNonColliding) {
-            if( itnoncolliding->second && itnoncolliding->first->IsEnabled() ) {
+            if( itnoncolliding->second ) {
                 //RAVELOG_VERBOSE(str(boost::format("non-colliding link %s for grabbed body %s")%(*itlink)->GetName()%pgrabbedbody->GetName()));
                 _listNonCollidingLinks.push_back(itnoncolliding->first);
             }
@@ -2430,7 +2430,7 @@ void Grabbed::UpdateCollidingLinks()
             }
         }
 
-        if( itnoncolliding->second && itnoncolliding->first->IsEnabled() ) {
+        if( itnoncolliding->second ) {
             _listNonCollidingLinks.push_back(itnoncolliding->first);
         }
         ++itnoncolliding;

--- a/src/libopenrave/libopenrave.h
+++ b/src/libopenrave/libopenrave.h
@@ -318,7 +318,7 @@ public:
     }
     KinBodyWeakPtr _pgrabbedbody;         ///< the grabbed body
     KinBody::LinkPtr _plinkrobot;         ///< robot link that is grabbing the body
-    std::list<KinBody::LinkConstPtr> _listNonCollidingLinks;         ///< links that are not colliding with the grabbed body at the time of Grab
+    std::list<KinBody::LinkConstPtr> _listNonCollidingLinks;         ///< links that are not colliding with the grabbed body at the time of Grab. Even if a link is disabled, it is considered as non-colliding as long as it is not colliiding with grabbed body
     Transform _troot;         ///< root transform (of first link of body) relative to plinkrobot's transform. In other words, pbody->GetTransform() == plinkrobot->GetTransform()*troot
     std::set<int> _setRobotLinksToIgnore; ///< original links of the robot to force ignoring
 


### PR DESCRIPTION
There was following inconsistency
- In ``KinBody::_PostprocessChangedParameters``, a link is considered non colliding even if it is disabled.
- In ``Grabbed::ProcessCollidingLinks``, a link is not considered non colliding if it is disabled.

As a result, following was observed in production.
```
robot.Enable(True)
link0 = robot.GetLinks()[0]
link0.Enable(False)
robot.Grab(body)
assert link0.GetName() in robot.GetGrabbedInfo()[0].SerializeJSON()['ignoreRobotLinkNames']
link1 = robot.GetLinks()[1]
link1.Enable(False) # trigger ProcessCollidingLinks, link0 remain disabled.
assert link0.GetName() in robot.GetGrabbedInfo()[0].SerializeJSON()['ignoreRobotLinkNames'] # assert fails, link0 is not in ``ignoreRobotLinkNames`` anymore
```

In this MR, ``link0`` is not in ``ignoreRobotLinkNames`` right after Grab, and remain so when ``ProcessCollidingLinks`` is called.