### PR TITLE
Require C++14 and drop redundant braces for Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ cmake_policy(SET CMP0002 NEW)
 # http://www.cmake.org/cmake/help/cmake-2.6.html#policy:CMP0003
 cmake_policy(SET CMP0003 NEW)
 
+set(CMAKE_CXX_STANDARD 14) # C++14 for std::shared_timed_mutex
 # Use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
@@ -394,7 +395,6 @@ foreach(ldir ${Boost_LIBRARY_DIRS})
   endif()
 endforeach()
 
-add_definitions(-std=gnu++14) # with -std=c++14, typeof is not defined, so use gnu++14 for now
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG )
   add_definitions(-fPIC) # this is a very important switch and some libraries seem now to have it....
   set(EXTRA_COMPILE_FLAGS "-fPIC")

--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -389,7 +389,7 @@ inline py::object toPyArray3(const std::vector<RaveVector<T> >& v)
 inline py::object toPyVector2(Vector v)
 {
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-    py::array_t<dReal> pyvec({2});
+    py::array_t<dReal> pyvec(2);
     py::buffer_info buf = pyvec.request();
     dReal* pvec = (dReal*) buf.ptr;
     pvec[0] = v.x;
@@ -404,7 +404,7 @@ inline py::object toPyVector2(Vector v)
 inline py::object toPyVector3(Vector v)
 {
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-    py::array_t<dReal> pyvec({3});
+    py::array_t<dReal> pyvec(3);
     py::buffer_info buf = pyvec.request();
     dReal* pvec = (dReal*) buf.ptr;
     pvec[0] = v.x;
@@ -420,7 +420,7 @@ inline py::object toPyVector3(Vector v)
 inline py::object toPyVector4(Vector v)
 {
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-    py::array_t<dReal> pyvec({4});
+    py::array_t<dReal> pyvec(4);
     py::buffer_info buf = pyvec.request();
     dReal* pvec = (dReal*) buf.ptr;
     pvec[0] = v.x;

--- a/python/bindings/openravepy_collisionchecker.cpp
+++ b/python/bindings/openravepy_collisionchecker.cpp
@@ -544,7 +544,7 @@ object PyCollisionCheckerBase::CheckCollisionRays(object rays, PyKinBodyPtr pbod
     py::buffer_info bufpos = pypos.request();
     dReal* ppos = (dReal*) bufpos.ptr;
 
-    py::array_t<bool> pycollision({num});
+    py::array_t<bool> pycollision(num);
     py::buffer_info bufcollision = pycollision.request();
     bool* pcollision = (bool*) bufcollision.ptr;
 #else // USE_PYBIND11_PYTHON_BINDINGS

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -466,7 +466,7 @@ object toPyArray(const TransformMatrix& t)
 object toPyArray(const Transform& t)
 {
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-    py::array_t<dReal> pyvalues({7});
+    py::array_t<dReal> pyvalues(7);
     py::buffer_info buf = pyvalues.request();
     dReal* pvalue = (dReal*) buf.ptr;
     pvalue[0] = t.rot.x;
@@ -1603,7 +1603,7 @@ object PyEnvironmentBase::CheckCollisionRays(py::numeric::array rays, PyKinBodyP
     dReal* ppos = (dReal*) bufpos.ptr;
 
     // collision
-    py::array_t<bool> pycollision({nRays});
+    py::array_t<bool> pycollision(nRays);
     py::buffer_info bufcollision = pycollision.request();
     bool* pcollision = (bool*) bufcollision.ptr;
     if( nRays > 0 ) {

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -690,7 +690,7 @@ object PyRobotBase::PyManipulator::GetTransformPose() const {
 object PyRobotBase::PyManipulator::GetVelocity() const {
     const std::pair<Vector, Vector> velocity = _pmanip->GetVelocity();
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-    py::array_t<dReal> pyvalues({6});
+    py::array_t<dReal> pyvalues(6);
     py::buffer_info buf = pyvalues.request();
     dReal* pvalue = (dReal*) buf.ptr;
     pvalue[0] = velocity.first.x;

--- a/python/bindings/pyann.cpp
+++ b/python/bindings/pyann.cpp
@@ -152,12 +152,12 @@ object search(ANNkd_tree& kdtree, object q, int k, double eps, bool priority = f
 
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
     // distance
-    py::array_t<ANNdist> pydists({k});
+    py::array_t<ANNdist> pydists(k);
     py::buffer_info bufdists = pydists.request();
     ANNdist* pdists = (ANNdist*) bufdists.ptr;
 
     // index
-    py::array_t<ANNidx> pyidx({k});
+    py::array_t<ANNidx> pyidx(k);
     py::buffer_info bufidx = pyidx.request();
     ANNidx* pidx = (ANNidx*) bufidx.ptr;
 #else // USE_PYBIND11_PYTHON_BINDINGS
@@ -269,12 +269,12 @@ object k_fixed_radius_search(ANNkd_tree& kdtree, object q, double sqRad, int k, 
     const int numel = std::min(k, kball);
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
     // distance
-    py::array_t<ANNdist> pydists({numel});
+    py::array_t<ANNdist> pydists(numel);
     py::buffer_info bufdists = pydists.request();
     ANNdist* pdists = (ANNdist*) bufdists.ptr;
 
     // index
-    py::array_t<ANNidx> pyidx({numel});
+    py::array_t<ANNidx> pyidx(numel);
     py::buffer_info bufidx = pyidx.request();
     ANNidx* pidx = (ANNidx*) bufidx.ptr;
 #else // USE_PYBIND11_PYTHON_BINDINGS    
@@ -317,7 +317,7 @@ object k_fixed_radius_search_array(ANNkd_tree& kdtree, object qarray, double sqR
     BOOST_ASSERT(len(qarray[0])==kdtree.theDim());
     ANNpointManaged annq(kdtree.theDim());
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-    py::array_t<int> pykball({N});
+    py::array_t<int> pykball(N);
     py::buffer_info bufkball = pykball.request();
     int* pkball = (int*) bufkball.ptr;
 #else // USE_PYBIND11_PYTHON_BINDINGS


### PR DESCRIPTION
OpenRAVE cannot be compiled with Clang (tested with 9 and 11) after the last merge to master. There are two issues this patch aims to fix:

* Commit https://github.com/rdiankov/openrave/commit/0d27e082d67a2dda08236018c5c1ed6d7cc500b6 switched the C++11 requirement to C++14, but it did so by forcing the `-std=gnu++14` compiler flag in a way that affects both C and C++ sources:
  https://github.com/rdiankov/openrave/blob/748891e955b01c660afd4d9e869ded32f03b2205/CMakeLists.txt#L397
  This is causing trouble on C files compiled with Clang, seeing lots of `invalid argument '-std=gnu++14' not allowed with 'C'` errors. I don't know why `typeof` is mentioned in the comment, that commit seems to be related to the introduction of `std::shared_timed_mutex` only (standard C++14). I'm bringing back the `CMAKE_CXX_STANDARD` variable.
* The syntax `py::array_t<T> arr({value})` produces several "braces around scalar initializer" warnings (said braces are needless) and can escalate to an error if implicit narrowing conversions are involved, e.g. `non-constant-expression cannot be narrowed from type 'int' to 'pybind11::size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]`.