### PR TITLE
Improve OSG viewer HUD text appearance

### DIFF
--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -923,9 +923,9 @@ void QOSGViewerWidget::HandleRayPick(const osgUtil::LineSegmentIntersector::Inte
 
             if( !!item ) {
                 osg::Vec3d pos = intersection.getWorldIntersectPoint();
-                pos *= 1000.0;
+                pos *= 1000.0 * _metersinunit;
                 osg::Vec3d normal = intersection.getWorldIntersectNormal();
-                normal *= 1000.0;
+                normal *= 1000.0 * _metersinunit;
                 KinBody::LinkPtr link = item->GetLinkFromOSG(node);
                 std::string linkname;
                 if( !!link ) {
@@ -953,7 +953,7 @@ void QOSGViewerWidget::UpdateFromOSG()
         // have to update the underlying openrave model since dragger is most likely changing the positions
         _selectedItem->UpdateFromOSG();
         Transform t = _selectedItem->GetTransform();
-        Vector trans = 1000.0*t.trans;
+        Vector trans = 1000.0 * _metersinunit * t.trans;
         _strSelectedItemText = str(boost::format("Selected\xa0%s. trans=(%.5f,\xa0%.5f,\xa0%.5f)")%_selectedItem->GetName()%trans.x%trans.y%trans.z);
         std::replace(_strSelectedItemText.begin(), _strSelectedItemText.end(), '-', '\xac');
     }

--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -936,7 +936,7 @@ void QOSGViewerWidget::HandleRayPick(const osgUtil::LineSegmentIntersector::Inte
                 if( !!geom ) {
                     geomname = geom->GetName();
                 }
-                _strRayInfoText = str(boost::format("mouse\xa0on\xa0%s:%s:%s: (%.5f,\xa0%.5f,\xa0%.5f), n=(%.5f,\xa0%.5f,\xa0%.5f)")%item->GetName()%linkname%geomname%pos.x()%pos.y()%pos.z()%normal.x()%normal.y()%normal.z());
+                _strRayInfoText = str(boost::format("mouse\xa0on\xa0%s:%s:%s: (%.2f,\xa0%.2f,\xa0%.2f), n=(%.2f,\xa0%.2f,\xa0%.2f)")%item->GetName()%linkname%geomname%pos.x()%pos.y()%pos.z()%normal.x()%normal.y()%normal.z());
                 std::replace(_strRayInfoText.begin(), _strRayInfoText.end(), '-', '\xac');
             }
             else {
@@ -954,7 +954,7 @@ void QOSGViewerWidget::UpdateFromOSG()
         _selectedItem->UpdateFromOSG();
         Transform t = _selectedItem->GetTransform();
         Vector trans = 1000.0 * _metersinunit * t.trans;
-        _strSelectedItemText = str(boost::format("Selected\xa0%s. trans=(%.5f,\xa0%.5f,\xa0%.5f)")%_selectedItem->GetName()%trans.x%trans.y%trans.z);
+        _strSelectedItemText = str(boost::format("Selected\xa0%s. trans=(%.2f,\xa0%.2f,\xa0%.2f)")%_selectedItem->GetName()%trans.x%trans.y%trans.z);
         std::replace(_strSelectedItemText.begin(), _strSelectedItemText.end(), '-', '\xac');
     }
     else {

--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -663,9 +663,13 @@ QOSGViewerWidget::QOSGViewerWidget(EnvironmentBasePtr penv, const std::string& u
         _osgHudText->setBackdropColor(osg::Vec4(1,1,1,1));
         //setBackdropOffset
         _osgHudText->setColor(osg::Vec4(0,0,0,1));
-        //use prettier font
-        osg::ref_ptr<osgText::Font> font = osgText::readRefFontFile("./fonts/NotoSans-Regular.ttf");
-        _osgHudText->setFont(font);
+        // use prettier font
+        QFile fontFile(":/fonts/NotoSans-Regular.ttf");
+        fontFile.open(QIODevice::ReadOnly | QIODevice::Unbuffered);
+        QByteArray ba = fontFile.readAll();
+        std::istringstream fontStream(ba.toStdString());
+        _osgHudText->setFont(osgText::readFontStream(fontStream));
+        fontFile.close();
 
         _osgHudText->getOrCreateStateSet()->setMode(GL_LIGHTING, osg::StateAttribute::OFF|osg::StateAttribute::OVERRIDE ); // need to do this, otherwise will be using the light sources
 


### PR DESCRIPTION
### **Background**

* The `osgText::Text` instance `_osgHudText`, used to display various types of HUD text around the top of the viewer screen in `osgviewerwidget.cpp`, did not use line breaking behavior, which resulted in the HUD text running out of the screen if too much text is present in a line of HUD text.
* The HUD text used default font and typically displays units in meters.

### **Changes**

* Enforced a maximum width on the HUD text, which causes OSG to break any lines of text exceeding the width.
* Changed HUD text font to be the same as the one used for labels, and changed displayed units to millimeters in order to improve appearance and readibility of the text.
* By default, OSG will try to break lines early based on any spaces or hyphens found. As such, in order to make line breaking behavior less intrusive on text readability, spaces inside coordinate pairs and other segments of the HUD text string are replaced with non-breakable spaces, and hyphens (which are used in negative numbers) are replaced with a logical negation (¬) sign.
  * Not too sure if this is the best solution in this case, but similar substitutes for the hyphen are rather limited inside the single-byte character space (the improved font used here is a Unicode font, but multi-byte characters do not render properly in the HUD text.)