### PR TITLE
Smoother HUD font on initialization in qtosg

### DIFF
--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -931,7 +931,6 @@ void QOSGViewerWidget::HandleRayPick(const osgUtil::LineSegmentIntersector::Inte
                 osg::Vec3d pos = intersection.getWorldIntersectPoint();
                 pos *= 1000.0 * _metersinunit;
                 osg::Vec3d normal = intersection.getWorldIntersectNormal();
-                normal *= 1000.0 * _metersinunit;
                 KinBody::LinkPtr link = item->GetLinkFromOSG(node);
                 std::string linkname;
                 if( !!link ) {
@@ -942,7 +941,7 @@ void QOSGViewerWidget::HandleRayPick(const osgUtil::LineSegmentIntersector::Inte
                 if( !!geom ) {
                     geomname = geom->GetName();
                 }
-                _strRayInfoText = str(boost::format("mouse\xa0on\xa0%s:%s:%s: (%.2f,\xa0%.2f,\xa0%.2f), n=(%.2f,\xa0%.2f,\xa0%.2f)")%item->GetName()%linkname%geomname%pos.x()%pos.y()%pos.z()%normal.x()%normal.y()%normal.z());
+                _strRayInfoText = str(boost::format("mouse\xa0on\xa0%s:%s:%s: (%.2f,\xa0%.2f,\xa0%.2f), n=(%.5f,\xa0%.5f,\xa0%.5f)")%item->GetName()%linkname%geomname%pos.x()%pos.y()%pos.z()%normal.x()%normal.y()%normal.z());
                 std::replace(_strRayInfoText.begin(), _strRayInfoText.end(), '-', '\xac');
             }
             else {

--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -581,6 +581,12 @@ private:
 //    }
 //}
 
+osg::ref_ptr<osgText::Font> QOSGViewerWidget::OSG_FONT;
+
+void QOSGViewerWidget::SetFont(osgText::Font* font) {
+    QOSGViewerWidget::OSG_FONT = font;
+}
+
 QOSGViewerWidget::QOSGViewerWidget(EnvironmentBasePtr penv, const std::string& userdatakey,
                                    const boost::function<bool(int)>& onKeyDown, double metersinunit,
                                    QWidget* parent) : QOpenGLWidget(parent), _onKeyDown(onKeyDown)
@@ -657,21 +663,21 @@ QOSGViewerWidget::QOSGViewerWidget(EnvironmentBasePtr penv, const std::string& u
 
         _osgHudText = new osgText::Text();
 
-        //Set the screen alignment - always face the screen
-        _osgHudText->setAxisAlignment(osgText::Text::SCREEN);
-        _osgHudText->setBackdropType(osgText::Text::DROP_SHADOW_BOTTOM_RIGHT);
-        _osgHudText->setBackdropColor(osg::Vec4(1,1,1,1));
-        //setBackdropOffset
-        _osgHudText->setColor(osg::Vec4(0,0,0,1));
-        // use prettier font
-        QFile fontFile(":/fonts/NotoSans-Regular.ttf");
-        fontFile.open(QIODevice::ReadOnly | QIODevice::Unbuffered);
-        QByteArray ba = fontFile.readAll();
-        std::istringstream fontStream(ba.toStdString());
-        _osgHudText->setFont(osgText::readFontStream(fontStream));
-        fontFile.close();
+        if (QOSGViewerWidget::OSG_FONT.valid()) {
+            _osgHudText->setFont(QOSGViewerWidget::OSG_FONT.get());
+        }
 
-        _osgHudText->getOrCreateStateSet()->setMode(GL_LIGHTING, osg::StateAttribute::OFF|osg::StateAttribute::OVERRIDE ); // need to do this, otherwise will be using the light sources
+        _osgHudText->setDrawMode( osgText::Text::TEXT );
+        _osgHudText->setColor(osg::Vec4(0,0,0,1));
+        _osgHudText->setBackdropColor( osg::Vec4( 1.0, 1.0f, 1.0f, 1.0f ) );
+        _osgHudText->setBackdropType( osgText::Text::OUTLINE );
+        _osgHudText->setAxisAlignment( osgText::Text::SCREEN );
+
+        // need to turn blending on since hud text lives in hud camera graph
+        // otherwise, text will initialize appearing aliased
+        _osgHudText->getOrCreateStateSet()->setAttributeAndModes(new osg::BlendFunc(osg::BlendFunc::SRC_ALPHA, osg::BlendFunc::ONE_MINUS_SRC_ALPHA ));
+        _osgHudText->getOrCreateStateSet()->setMode(GL_LIGHTING, osg::StateAttribute::PROTECTED | osg::StateAttribute::OFF ); // need to do this, otherwise will be using the light sources
+        _osgHudText->getOrCreateStateSet()->setMode(GL_BLEND, osg::StateAttribute::ON);
 
         osg::ref_ptr<osg::Geode> geodetext = new osg::Geode;
         geodetext->addDrawable(_osgHudText);
@@ -1158,6 +1164,7 @@ void QOSGViewerWidget::SetViewport(int width, int height)
     double textheight = 18*scale;
     _osgHudText->setPosition(osg::Vec3(-width * scale / 2 + 10, height * scale / 2 - textheight, -50));
     _osgHudText->setCharacterSize(textheight);
+    _osgHudText->setFontResolution(textheight, textheight);
     // Set maximum width in order to enforce word wrapping
     _osgHudText->setMaximumWidth(width * scale - 20);
     _UpdateHUDAxisTransform(width, height);

--- a/plugins/qtosgrave/osgviewerwidget.h
+++ b/plugins/qtosgrave/osgviewerwidget.h
@@ -200,6 +200,8 @@ public:
         _bSwitchMouseLeftMiddleButton = !_bSwitchMouseLeftMiddleButton;
     }
 
+    static void SetFont(osgText::Font *font);
+
 protected:
     /// \brief handles a key press and looks at the modifier keys
     bool HandleOSGKeyDown(const osgGA::GUIEventAdapter &ea, osgGA::GUIActionAdapter &aa);
@@ -339,6 +341,10 @@ protected:
     double _currentOrthoFrustumSize; ///< coordinate for the right vertical clipping plane 
 
     void GetSwitchedButtonValue(unsigned int &button);
+
+    private:
+        /// font for HUD text
+        static osg::ref_ptr<osgText::Font> OSG_FONT;
 };
 
 class QtOSGKeyEventTranslator

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -183,18 +183,20 @@ QtOSGViewer::QtOSGViewer(EnvironmentBasePtr penv, std::istream& sinput) : QMainW
     _mapGUIFunctionListLimits[ViewerCommandPriority::MEDIUM] = 1000;
     _mapGUIFunctionListLimits[ViewerCommandPriority::LOW] = 1000;
 
-    _bLockEnvironment = true;
-    _InitGUI(bCreateStatusBar, bCreateMenu);
-    _bUpdateEnvironment = true;
-    _bExternalLoop = false;
-
     // Read copy QT resource to temp location and later stream that into OSG to use when making labels
     QFile fontFile(":/fonts/NotoSans-Regular.ttf");
     fontFile.open(QIODevice::ReadOnly | QIODevice::Unbuffered);
     QByteArray ba = fontFile.readAll();
-    std::istringstream fontStream(ba.toStdString());
-    OSGLODLabel::SetFont(osgText::readFontStream(fontStream));
+    std::istringstream lodFontStream(ba.toStdString());
+    OSGLODLabel::SetFont(osgText::readFontStream(lodFontStream));
+    std::istringstream widgetFontStream(ba.toStdString());
+    QOSGViewerWidget::SetFont(osgText::readFontStream(widgetFontStream));
     fontFile.close();
+
+    _bLockEnvironment = true;
+    _InitGUI(bCreateStatusBar, bCreateMenu);
+    _bUpdateEnvironment = true;
+    _bExternalLoop = false;
 }
 
 QtOSGViewer::~QtOSGViewer()


### PR DESCRIPTION
**Background:**
PR #1022 introduces an improved font for the HUD in qtosg. However, it was discovered during more testing that it is possible for the HUD font to be initialized in an aliased, jagged state if there are no pre-existing labels in the loaded scene. This is because GL blending is by default turned off in the HUD section of the scene graph.

**Changes:**
* Make `QOSGViewerWidget` use `OSGLODLabel`'s approach of loading the font to a static member so that all needed font loading can be performed in one spot inside `QtOSGViewer::QtOSGViewer`.
* Adjusted font resolution and enabled GL blending for HUD text to fix initialization aliasing issue.
* As suggested by Puttichai in #1022, removed mm scaling from normal vector when displayed in HUD text.