### PR TITLE
set py_err_class to propagate std::runtime_error properly

### DIFF
--- a/python/openravepy.__init__.py
+++ b/python/openravepy.__init__.py
@@ -44,7 +44,7 @@ Available methods for an exception e are
 if openravepy_int.__pythonbinding__ == 'pybind11':
     from .openravepy_int import _OpenRAVEException as OpenRAVEException
 else:
-    from .openravepy_int import _OpenRAVEException
+    from .openravepy_int import _OpenRAVEException, _std_runtime_error_
     
     class openrave_exception_helper(Exception):
         # wrap up the C++ openrave_exception
@@ -92,6 +92,7 @@ else:
     
     OpenRAVEException = openrave_exception_helper
     _OpenRAVEException.py_err_class = openrave_exception_helper
+    _std_runtime_error_.py_err_class = runtime_error
 
 openrave_exception = OpenRAVEException # for back compat
 


### PR DESCRIPTION
@rdiankov 
 When `std::runtime_error` is thrown, boost::python cannot propagate error message properly as "_std_runtime_error_" doesn't have attribute "py_error_class".

The error message caught in client is as follows:
```
'_std_runtime_error_' object has no attribute 'py_err_class'
```


