### PR TITLE
Fix OpenRAVEException.message signature in pybind11 build

### DIFF
--- a/python/openravepy.__init__.py
+++ b/python/openravepy.__init__.py
@@ -43,6 +43,7 @@ Available methods for an exception e are
 """
 if openravepy_int.__pythonbinding__ == 'pybind11':
     from .openravepy_int import _OpenRAVEException as OpenRAVEException
+    OpenRAVEException.message = lambda self: str(self)
 else:
     from .openravepy_int import _OpenRAVEException, _std_runtime_error_
     


### PR DESCRIPTION
In OpenRAVEException, message is a method. However, in Python Exception, it is a getter. **PyOpenRAVEException does not conform Python Exception.**
In pybind11, in openrave_int.cpp message is defined by def_property_readonly, **which is not compatible with boost::python build**.

Actually I wanted to fix this matter by changing openrave_int.cpp from def_property_readonly to def, but it caused `Cannot overload existing non-function object "message" with a function of the same name` pybind11 error. This happens because of pybind11 field check and the field check is correct itself.
The only way is to _hack_ openravepy.\_\_init\_\_.py. Otherwise we need to change all our codebase.