### PR TITLE
[quick] handle loading of GT_None

### DIFF
--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -974,6 +974,9 @@ void KinBody::GeometryInfo::DeserializeJSON(const rapidjson::Value &value, const
         else if (typestr == "calibrationboard") {
             type = GT_CalibrationBoard;
         }
+        else if (typestr.empty()) {
+            type = GT_None;
+        }
         else {
             throw OPENRAVE_EXCEPTION_FORMAT("failed to deserialize json, unsupported geometry type \"%s\"", typestr, ORE_InvalidArguments);
         }


### PR DESCRIPTION
Issue this PR is fixing
======================
When we saved a scene with ``GT_None`` geom type to a file, the saved file could not be opened by openrave.

Resolution
==============
``GT_None`` is serialized to empty string by ``_GetGeometryTypeString`` via ``KinBody::GeometryInfo::SerializeJSON``, however, ``KinBody::GeometryInfo::DeserializeJSON`` was throwing exception on empty string.

In this PR, empty string for geom type is parsed as ``GT_None`` so that serialization and deserialization behave in consistent manner.