### PR TITLE
fixed unexpected invalidargument error from env.CheckCollision(link1, link2, report=collisionReport)

### DIFF
--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -1360,8 +1360,7 @@ bool PyEnvironmentBase::CheckCollision(object o1, object o2, PyCollisionReportPt
                 throw OPENRAVE_EXCEPTION_FORMAT0(_("invalid argument 2"),ORE_InvalidArguments);
             }
         }
-    }
-    {
+    } else {
         KinBodyConstPtr pbody = openravepy::GetKinBody(o1);
         if( !!pbody ) {
             KinBody::LinkConstPtr plink2 = openravepy::GetKinBodyLinkConst(o2);


### PR DESCRIPTION
Fixed `bool PyEnvironmentBase::CheckCollision(object o1, object o2, PyCollisionReportPtr pReport)` python bindings when checking collision between links.

Before this change, `env.CheckCollision(link1, link2, report=report)` fails with `invalid argument 1` message.
After this change, it is expected to return True/False without failure.