### PR TITLE
Use py::list for vLinkInfo etc

### DIFF
--- a/python/bindings/include/openravepy/openravepy_kinbody.h
+++ b/python/bindings/include/openravepy/openravepy_kinbody.h
@@ -137,19 +137,16 @@ public:
         py::object SerializeJSON(dReal fUnitScale=1.0, py::object options=py::none_());
         void DeserializeJSON(py::object obj, dReal fUnitScale=1.0, py::object options=py::none_());
         KinBody::KinBodyInfoPtr GetKinBodyInfo() const;
+        py::object _vLinkInfos = py::none_();
+        py::object _vJointInfos = py::none_();
+        py::object _vGrabbedInfos = py::none_();
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-        std::vector<KinBody::LinkInfoPtr> _vLinkInfos;
-        std::vector<KinBody::JointInfoPtr> _vJointInfos;
-        std::vector<KinBody::GrabbedInfoPtr> _vGrabbedInfos;
         std::string _uri;
         std::string _id;
         std::string _name;
         std::string _interfaceType;
         std::string _referenceUri;
 #else
-        py::object _vLinkInfos = py::none_();
-        py::object _vJointInfos = py::none_();
-        py::object _vGrabbedInfos = py::none_();
         py::object _uri = py::none_();
         py::object _referenceUri = py::none_();
         py::object _id = py::none_();

--- a/python/bindings/include/openravepy/openravepy_robotbase.h
+++ b/python/bindings/include/openravepy/openravepy_robotbase.h
@@ -39,17 +39,10 @@ public:
     py::object SerializeJSON(dReal fUnitScale=1.0, py::object options=py::none_());
     void DeserializeJSON(py::object obj, dReal fUnitScale=1.0, py::object options=py::none_());
 
-#ifdef USE_PYBIND11_PYTHON_BINDINGS
-    std::vector<RobotBase::ManipulatorInfoPtr> _vManipulatorInfos;
-    std::vector<RobotBase::AttachedSensorInfoPtr> _vAttachedSensorInfos;
-    std::vector<RobotBase::ConnectedBodyInfoPtr> _vConnectedBodyInfos;
-    std::vector<RobotBase::GripperInfoPtr> _vGripperInfos;
-#else
     py::object _vManipulatorInfos = py::none_();
     py::object _vAttachedSensorInfos = py::none_();
     py::object _vConnectedBodyInfos = py::none_();
     py::object _vGripperInfos = py::none_();
-#endif
     virtual std::string __str__();
     virtual py::object __unicode__();
 

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -2290,9 +2290,6 @@ KinBody::KinBodyInfoPtr PyKinBody::PyKinBodyInfo::GetKinBodyInfo() const {
     pInfo->_name = _name;
     pInfo->_uri = _uri;
     pInfo->_referenceUri = _referenceUri;
-    pInfo->_vLinkInfos = std::vector<KinBody::LinkInfoPtr>(begin(_vLinkInfos), end(_vLinkInfos));
-    pInfo->_vJointInfos = std::vector<KinBody::JointInfoPtr>(begin(_vJointInfos), end(_vJointInfos));
-    pInfo->_vGrabbedInfos = std::vector<KinBody::GrabbedInfoPtr>(begin(_vGrabbedInfos), end(_vGrabbedInfos));
 #else
     if (!IS_PYTHONOBJECT_NONE(_id)) {
         pInfo->_id = py::extract<std::string>(_id);
@@ -2306,6 +2303,7 @@ KinBody::KinBodyInfoPtr PyKinBody::PyKinBodyInfo::GetKinBodyInfo() const {
     if (!IS_PYTHONOBJECT_NONE(_referenceUri)) {
         pInfo->_referenceUri = py::extract<std::string>(_referenceUri);
     }
+#endif
     std::vector<KinBody::LinkInfoPtr> vLinkInfo = ExtractLinkInfoArray(_vLinkInfos);
     pInfo->_vLinkInfos.clear();
     pInfo->_vLinkInfos.reserve(vLinkInfo.size());
@@ -2324,7 +2322,6 @@ KinBody::KinBodyInfoPtr PyKinBody::PyKinBodyInfo::GetKinBodyInfo() const {
     FOREACHC(it, vGrabbedInfos) {
         pInfo->_vGrabbedInfos.push_back(*it);
     }
-#endif
     pInfo->_transform = ExtractTransform(_transform);
     pInfo->_dofValues = ExtractDOFValuesArray(_dofValues);
     pInfo->_isRobot = _isRobot;
@@ -2358,15 +2355,13 @@ void PyKinBody::PyKinBodyInfo::_Update(const KinBody::KinBodyInfo& info) {
     _uri = info._uri;
     _interfaceType = info._interfaceType;
     _referenceUri = info._referenceUri;
-    _vLinkInfos = std::vector<KinBody::LinkInfoPtr>(begin(info._vLinkInfos), end(info._vLinkInfos));
-    _vJointInfos = std::vector<KinBody::JointInfoPtr>(begin(info._vJointInfos), end(info._vJointInfos));
-    _vGrabbedInfos = std::vector<KinBody::GrabbedInfoPtr>(begin(info._vGrabbedInfos), end(info._vGrabbedInfos));
 #else
     _id = ConvertStringToUnicode(info._id);
     _name = ConvertStringToUnicode(info._name);
     _uri = ConvertStringToUnicode(info._uri);
     _referenceUri = ConvertStringToUnicode(info._referenceUri);
     _interfaceType = ConvertStringToUnicode(info._interfaceType);
+#endif
     py::list vLinkInfos;
     FOREACHC(itLinkInfo, info._vLinkInfos) {
         PyLinkInfo info = PyLinkInfo(**itLinkInfo);
@@ -2387,7 +2382,6 @@ void PyKinBody::PyKinBodyInfo::_Update(const KinBody::KinBodyInfo& info) {
         vGrabbedInfos.append(info);
     }
     _vGrabbedInfos = vGrabbedInfos;
-#endif
     _transform = ReturnTransform(info._transform);
     _isRobot = info._isRobot;
     _isPartial = info._isPartial;

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -409,11 +409,6 @@ void PyRobotBase::PyRobotBaseInfo::DeserializeJSON(py::object obj, dReal fUnitSc
 
 void PyRobotBase::PyRobotBaseInfo::_Update(const RobotBase::RobotBaseInfo& info) {
     PyKinBody::PyKinBodyInfo::_Update(info);
-#ifdef USE_PYBIND11_PYTHON_BINDINGS
-    _vManipulatorInfos = info._vManipulatorInfos;
-    _vAttachedSensorInfos = info._vAttachedSensorInfos;
-    _vConnectedBodyInfos = info._vConnectedBodyInfos;
-#else
     py::list vManipulatorInfos;
     FOREACHC(itManipulatorInfo, info._vManipulatorInfos) {
         PyManipulatorInfoPtr pmanipinfo = toPyManipulatorInfo(**itManipulatorInfo);
@@ -444,7 +439,6 @@ void PyRobotBase::PyRobotBaseInfo::_Update(const RobotBase::RobotBaseInfo& info)
         vGripperInfos.append(toPyObject(rGripperInfo));
     }
     _vGripperInfos = vGripperInfos;
-#endif
 }
 
 
@@ -560,13 +554,6 @@ RobotBase::RobotBaseInfoPtr PyRobotBase::PyRobotBaseInfo::GetRobotBaseInfo() con
     pInfo->_interfaceType = _interfaceType;
     pInfo->_uri = _uri;
     pInfo->_referenceUri = _referenceUri;
-    pInfo->_vLinkInfos = std::vector<KinBody::LinkInfoPtr>(begin(_vLinkInfos), end(_vLinkInfos));
-    pInfo->_vJointInfos = std::vector<KinBody::JointInfoPtr>(begin(_vJointInfos), end(_vJointInfos));
-    pInfo->_vGrabbedInfos = std::vector<KinBody::GrabbedInfoPtr>(begin(_vGrabbedInfos), end(_vGrabbedInfos));
-    pInfo->_vManipulatorInfos = std::vector<RobotBase::ManipulatorInfoPtr>(begin(_vManipulatorInfos), end(_vManipulatorInfos));
-    pInfo->_vAttachedSensorInfos = std::vector<RobotBase::AttachedSensorInfoPtr>(begin(_vAttachedSensorInfos), end(_vAttachedSensorInfos));
-    pInfo->_vConnectedBodyInfos = std::vector<RobotBase::ConnectedBodyInfoPtr>(begin(_vConnectedBodyInfos), end(_vConnectedBodyInfos));
-    pInfo->_vGripperInfos = std::vector<RobotBase::GripperInfoPtr>(begin(_vGripperInfos), end(_vGripperInfos));
 #else
     if (!IS_PYTHONOBJECT_NONE(_id)) {
         pInfo->_id = py::extract<std::string>(_id);
@@ -583,6 +570,7 @@ RobotBase::RobotBaseInfoPtr PyRobotBase::PyRobotBaseInfo::GetRobotBaseInfo() con
     if (!IS_PYTHONOBJECT_NONE(_referenceUri)) {
         pInfo->_referenceUri = py::extract<std::string>(_referenceUri);
     }
+#endif
     pInfo->_isRobot = true;
     std::vector<KinBody::LinkInfoPtr> vLinkInfos = ExtractLinkInfoArray(_vLinkInfos);
     pInfo->_vLinkInfos.clear();
@@ -627,7 +615,6 @@ RobotBase::RobotBaseInfoPtr PyRobotBase::PyRobotBaseInfo::GetRobotBaseInfo() con
     FOREACHC(it, vGripperInfos) {
         pInfo->_vGripperInfos.push_back(*it);
     }
-#endif
     pInfo->_transform = ExtractTransform(_transform);
     pInfo->_dofValues = ExtractDOFValuesArray(_dofValues);
     pInfo->_mReadableInterfaces = ExtractReadableInterfaces(_readableInterfaces);


### PR DESCRIPTION
- KinBody::LinkInfoPtr cannot be converted to Python type
- Even if I fix the type (see 374f88a6d), `bodyInfo._vLinkInfos.append()` will not work. But fixing in stl.h way (using PYBIND11_MAKE_OPAQUE / py::bind_vector, see 6cdd5eeb3 and 5b2eb55a8) now breaks `bodyInfo._vLinkInfos=[]` (both see RealTimeRobotTask3.UpdateObjects).

We have to use py::object (or py::list).

test_yxx was failing due to this issue.