### PR TITLE
disabled isBranching condition

### DIFF
--- a/plugins/rplanners/linearsmoother.cpp
+++ b/plugins/rplanners/linearsmoother.cpp
@@ -128,17 +128,21 @@ public:
             dReal totaldist = 0;
 
             bool isBranching = false;
-            if(!!_probot && _nUseSingleDOFSmoothing == 1) {
-                std::set<KinBody::LinkConstPtr> setJoints;
-                FOREACHC(it, _probot->GetActiveDOFIndices()) {
-                    KinBody::JointPtr pjoint = _probot->GetJointFromDOFIndex(*it);
-                    bool canInsert = setJoints.insert(pjoint->GetHierarchyParentLink()).second;
-                    if(!canInsert) {
-                        isBranching = true;
-                        break;
-                    }
-                }
-            }
+            // The following code is commented out because _OptimizePathSingleGroupShift only works
+            // with some specific kinds of robots, as it assumes certain kinematics structures, and
+            // isBranching is not a sufficient condition to detect such robots.
+
+            // if(!!_probot && _nUseSingleDOFSmoothing == 1) {
+            //     std::set<KinBody::LinkConstPtr> setJoints;
+            //     FOREACHC(it, _probot->GetActiveDOFIndices()) {
+            //         KinBody::JointPtr pjoint = _probot->GetJointFromDOFIndex(*it);
+            //         bool canInsert = setJoints.insert(pjoint->GetHierarchyParentLink()).second;
+            //         if(!canInsert) {
+            //             isBranching = true;
+            //             break;
+            //         }
+            //     }
+            // }
 
             if( _nUseSingleDOFSmoothing == 3 or (isBranching and _nUseSingleDOFSmoothing == 1)) {
                 uint32_t basetime1 = utils::GetMilliTime();


### PR DESCRIPTION
### Summary

The function `_OptimizePathSingleGroupShift` in `linearsmoother.cpp` is a function specifically written to work with robots with certain kinematics structure. 

It seems that originally the cases in which this function should be used were detected by the condition `_nUseSingleDOFSmoothing == 3`. Then `isBranching` was added later. However, as it turns out, `isBranching` is not a sufficient condition to decide whether `_OptimizePathSingleGroupShift` should be called. This new variable may lead to unexpected calls to `_OptimizePathSingleGroupShift`, which in the end may result in a problematic path.

I think it is best to disable the use of `isBranching` for now.

cc. @AntoineRyu @kanbouchou @eisoku9618 
