### PR TITLE
propate body removal to self collision checker

### DIFF
--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -3223,6 +3223,12 @@ protected:
         if( !!_pCurrentChecker ) {
             _pCurrentChecker->RemoveKinBody(pbodyref);
         }
+        {
+            CollisionCheckerBasePtr pSelfColChecker = body.GetSelfCollisionChecker();
+            if (!!pSelfColChecker && pSelfColChecker != _pCurrentChecker) {
+                pSelfColChecker->RemoveKinBody(pbodyref);
+            }
+        }
         if( !!_pPhysicsEngine ) {
             _pPhysicsEngine->RemoveKinBody(pbodyref);
         }


### PR DESCRIPTION
Background
===============
- In https://github.com/rdiankov/openrave/pull/1051, there was a fix to update fclcache properly when kinbody is removed from env.
- However, following message was observed occasionally ``env=123 body xxx has envBodyIndex=yyy, but stored at wrong index=zzz`` which was not supposed to happen. Message indicates fcl cache was not updated properly when kinbody removal happened. It is from https://github.com/rdiankov/openrave/blob/production/plugins/fclrave/fclmanagercache.h#L542

Investigation
===========
- self collision checker was not being informed of kin body removal from env, so this MR notifies it.
- test for self collision checker is submitted separately.