### PR TITLE
fixed drawplane compilation on pybind11

### DIFF
--- a/python/bindings/include/openravepy/openravepy_environmentbase.h
+++ b/python/bindings/include/openravepy/openravepy_environmentbase.h
@@ -253,8 +253,13 @@ public:
     object drawbox(object opos, object oextents, object ocolor=py::none_());
     object drawboxarray(object opos, object oextents, object ocolor=py::none_());
 
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+    object drawplane(object otransform, object oextents, const std::vector<std::vector<dReal> >&_vtexture);
+    object drawplane(object otransform, object oextents, const std::vector<std::vector<std::vector<dReal> > >&vtexture);
+#else
     object drawplane(object otransform, object oextents, const boost::multi_array<float,2>&_vtexture);
     object drawplane(object otransform, object oextents, const boost::multi_array<float,3>&vtexture);
+#endif
 
     object drawtrimesh(object opoints, object oindices=py::none_(), object ocolors=py::none_());
 

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -2490,7 +2490,58 @@ object PyEnvironmentBase::drawboxarray(object opos, object oextents, object ocol
     return toPyGraphHandle(_penv->drawboxarray(vvectors,ExtractVector3(oextents)));
 }
 
-
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+object PyEnvironmentBase::drawplane(object otransform, object oextents, const std::vector<std::vector<dReal> >&_vtexture)
+{
+    size_t x = _vtexture.size();
+    if(x<1){
+        throw OpenRAVEException(_("_vtexture is empty"), ORE_InvalidArguments);
+    }
+    size_t y = _vtexture[0].size();
+    if(y<1){
+        throw OpenRAVEException(_("_vtexture[0] is empty"), ORE_InvalidArguments);
+    }
+    boost::multi_array<float,3> vtexture(boost::extents[x][y][1]);
+    for(int i=0; i<x; i++){
+        if(_vtexture[i].size() != y){
+            throw OpenRAVEException(boost::str(boost::format(_("_vtexture[%d] size is different"))%i), ORE_InvalidArguments);
+        }
+        for(int j=0; j<y; j++){
+            vtexture[i][j][0] = _vtexture[i][j];
+        }
+    }
+    return toPyGraphHandle(_penv->drawplane(RaveTransform<float>(ExtractTransform(otransform)), RaveVector<float>(extract<float>(oextents[0]),extract<float>(oextents[1]),0), vtexture));
+}
+object PyEnvironmentBase::drawplane(object otransform, object oextents, const std::vector<std::vector<std::vector<dReal> > >&_vtexture){
+    size_t x = _vtexture.size();
+    if(x<1){
+        throw OpenRAVEException(_("_vtexture is empty"), ORE_InvalidArguments);
+    }
+    size_t y = _vtexture[0].size();
+    if(y<1){
+        throw OpenRAVEException(_("_vtexture[0] is empty"), ORE_InvalidArguments);
+    }
+    size_t z = _vtexture[0][0].size();
+    if(z<1){
+        throw OpenRAVEException(_("_vtexture[0][0] is empty"), ORE_InvalidArguments);
+    }
+    boost::multi_array<float,3> vtexture(boost::extents[x][y][1]);
+    for(int i=0; i<x; i++){
+        if(_vtexture[i].size() != y){
+            throw OpenRAVEException(boost::str(boost::format(_("_vtexture[%d] size is different"))%i), ORE_InvalidArguments);
+        }
+        for(int j=0; j<y; j++){
+            if(_vtexture[i][j].size() != z){
+                throw OpenRAVEException(boost::str(boost::format(_("_vtexture[%d][%d] size is different"))%i%j), ORE_InvalidArguments);
+            }
+            for(int k=0; k<z; k++){
+                vtexture[i][j][k] = _vtexture[i][j][k];
+            }
+        }
+    }
+    return toPyGraphHandle(_penv->drawplane(RaveTransform<float>(ExtractTransform(otransform)), RaveVector<float>(extract<float>(oextents[0]),extract<float>(oextents[1]),0), vtexture));
+}
+#else
 object PyEnvironmentBase::drawplane(object otransform, object oextents, const boost::multi_array<float,2>&_vtexture)
 {
     boost::multi_array<float,3> vtexture(boost::extents[1][_vtexture.shape()[0]][_vtexture.shape()[1]]);
@@ -2503,6 +2554,7 @@ object PyEnvironmentBase::drawplane(object otransform, object oextents, const bo
 {
     return toPyGraphHandle(_penv->drawplane(RaveTransform<float>(ExtractTransform(otransform)), RaveVector<float>(extract<float>(oextents[0]),extract<float>(oextents[1]),0), vtexture));
 }
+#endif
 
 object PyEnvironmentBase::drawtrimesh(object opoints, object oindices, object ocolors)
 {
@@ -3263,9 +3315,13 @@ Because race conditions can pop up when trying to lock the openrave environment 
         void (PyEnvironmentBase::*Lock1)() = &PyEnvironmentBase::Lock;
         bool (PyEnvironmentBase::*Lock2)(float) = &PyEnvironmentBase::Lock;
 
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        object (PyEnvironmentBase::*drawplane1)(object, object, const std::vector<std::vector<dReal> >&) = &PyEnvironmentBase::drawplane;
+        object (PyEnvironmentBase::*drawplane2)(object, object, const std::vector<std::vector<std::vector<dReal> > >&) = &PyEnvironmentBase::drawplane;
+#else
         object (PyEnvironmentBase::*drawplane1)(object, object, const boost::multi_array<float,2>&) = &PyEnvironmentBase::drawplane;
         object (PyEnvironmentBase::*drawplane2)(object, object, const boost::multi_array<float,3>&) = &PyEnvironmentBase::drawplane;
-
+#endif
         void (PyEnvironmentBase::*addkinbody1)(PyKinBodyPtr) = &PyEnvironmentBase::AddKinBody;
         void (PyEnvironmentBase::*addkinbody2)(PyKinBodyPtr,bool) = &PyEnvironmentBase::AddKinBody;
         void (PyEnvironmentBase::*addrobot1)(PyRobotBasePtr) = &PyEnvironmentBase::AddRobot;


### PR DESCRIPTION
test code

```
extents = array([0.49, 0.34])
transform = array([[ 0.99703115, -0.07347584,  0.02302558,  0.39231188],
       [-0.07516176, -0.99364269,  0.08381456, -0.0539431 ],
       [ 0.01672085, -0.08529638, -0.99621528,  1.74948456],
       [ 0.        ,  0.        ,  0.        ,  1.        ]])
h = env.drawplane(transform, extents, transform)

del h
```

without the patch this error happens

```
TypeError: drawplane(): incompatible function arguments. The following argument types are supported:
    1. (self: openravepy._openravepy_0_89.openravepy_int.Environment, transform: object, extents: object, texture: boost::multi_array<float, 2ul, std::allocator<float> >) -> object
    2. (self: openravepy._openravepy_0_89.openravepy_int.Environment, transform: object, extents: object, texture: boost::multi_array<float, 3ul, std::allocator<float> >) -> object

Invoked with: RaveGetEnvironment(1), array([[ 0.99703115, -0.07347584,  0.02302558,  0.39231188],
       [-0.07516176, -0.99364269,  0.08381456, -0.0539431 ],
       [ 0.01672085, -0.08529638, -0.99621528,  1.74948456],
       [ 0.        ,  0.        ,  0.        ,  1.        ]]), array([0.49, 0.34]), array([[ 0.99703115, -0.07347584,  0.02302558,  0.39231188],
       [-0.07516176, -0.99364269,  0.08381456, -0.0539431 ],
       [ 0.01672085, -0.08529638, -0.99621528,  1.74948456],
       [ 0.        ,  0.        ,  0.        ,  1.        ]])

Did you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,
<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic
conversions are optional and require extra headers to be included
when compiling your pybind11 module.
```

/cc @osbertngok (thank you for reporting)