### PR TITLE
fix wrong description

### DIFF
--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -900,7 +900,7 @@ public:
         }
 
 private:
-        Transform _t; ///< the current transformation of the link with respect to the body coordinate system
+        Transform _t; ///< the current transformation of the link with respect to the world coordinate system
 
         uint32_t _modifiedFields = 0xffffffff; ///< a bitmap of LinkInfoField, for supported fields, indicating which fields are touched, otherwise they can be skipped in UpdateFromInfo. By default, assume all fields are modified.
 


### PR DESCRIPTION
`OpenRAVE::Link::GetTransform()` has this description,

```cpp
        /// \brief Return the current transformation of the link in the world coordinate system.
        inline const Transform& GetTransform() const {
            return _info._t;
        }
```

while `OpenRAVE::LinkInfo::_t` has this description.

```cpp
        Transform _t; ///< the current transformation of the link with respect to the body coordinate system
```

Based on the current implementation, the former description is correct.


```python
body.SetTransform([1, 0, 0, 0, 0, 0, 0])
print(body.GetLinks()[0].GetInfo().SerializeJSON()['transform'])
# [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

body.SetTransform([1, 0, 0, 0, 0, 0, 1]);
print(body.GetLinks()[0].GetInfo().SerializeJSON()['transform'])
# [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
```

`_t` is not with respect to the body frame but with respect to the world frame.