### PR TITLE
fix: HUD text offset and control button avoidance

### DIFF
--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -644,7 +644,7 @@ QOSGViewerWidget::QOSGViewerWidget(EnvironmentBasePtr penv, const std::string& u
 
     _osgWorldAxis->addChild(CreateOSGXYZAxes(32.0, 2.0));
 
-    _vecTextScreenOffset = new osg::Vec2d(10.0, 0.0);
+    _vecTextScreenOffset = osg::Vec2d(10.0, 0.0);
 
     if( !!_osgCameraHUD ) {
         // in order to get the axes to render without lighting:
@@ -1165,30 +1165,30 @@ void QOSGViewerWidget::SetViewport(int width, int height)
     double textheight = 18*scale;
     _osgHudText->setCharacterSize(textheight);
     _osgHudText->setFontResolution(textheight, textheight);
-    SetHUDTextOffset(_vecTextScreenOffset->x(), _vecTextScreenOffset->y());
+    SetHUDTextOffset(_vecTextScreenOffset.x(), _vecTextScreenOffset.y());
     _UpdateHUDAxisTransform(width, height);
 }
 
-osg::Vec2d* QOSGViewerWidget::GetHUDTextOffset()
+osg::Vec2d QOSGViewerWidget::GetHUDTextOffset()
 {
-    return new osg::Vec2d(_vecTextScreenOffset->x(), _vecTextScreenOffset->y());
+    return osg::Vec2d(_vecTextScreenOffset.x(), _vecTextScreenOffset.y());
 }
 
 void QOSGViewerWidget::SetHUDTextOffset(double xOffset, double yOffset)
 {
-    _vecTextScreenOffset->set(xOffset, yOffset);
+    _vecTextScreenOffset.set(xOffset, yOffset);
 
     double scale = this->devicePixelRatio();
     double textheight = 18*scale;
     _osgHudText->setPosition(
         osg::Vec3(
-            -_osgview->getCamera()->getViewport()->width() / 2 + _vecTextScreenOffset->x(),
-            _osgview->getCamera()->getViewport()->height() / 2 - textheight - _vecTextScreenOffset->y(),
+            -_osgview->getCamera()->getViewport()->width() / 2 + _vecTextScreenOffset.x(),
+            _osgview->getCamera()->getViewport()->height() / 2 - textheight - _vecTextScreenOffset.y(),
             -50
         )
     );
     // Set maximum width in order to enforce word wrapping
-    _osgHudText->setMaximumWidth(_osgview->getCamera()->getViewport()->width() - 10 - _vecTextScreenOffset->x());
+    _osgHudText->setMaximumWidth(_osgview->getCamera()->getViewport()->width() - 10 - _vecTextScreenOffset.x());
 }
 
 void QOSGViewerWidget::_UpdateHUDAxisTransform(int width, int height)

--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -644,7 +644,7 @@ QOSGViewerWidget::QOSGViewerWidget(EnvironmentBasePtr penv, const std::string& u
 
     _osgWorldAxis->addChild(CreateOSGXYZAxes(32.0, 2.0));
 
-    _vecTextScreenOffset = osg::Vec2d(10.0, 0.0);
+    _vecTextScreenOffset = osg::Vec2(10.0, 0.0);
 
     if( !!_osgCameraHUD ) {
         // in order to get the axes to render without lighting:
@@ -1169,9 +1169,9 @@ void QOSGViewerWidget::SetViewport(int width, int height)
     _UpdateHUDAxisTransform(width, height);
 }
 
-osg::Vec2d QOSGViewerWidget::GetHUDTextOffset()
+osg::Vec2 QOSGViewerWidget::GetHUDTextOffset()
 {
-    return osg::Vec2d(_vecTextScreenOffset.x(), _vecTextScreenOffset.y());
+    return osg::Vec2(_vecTextScreenOffset.x(), _vecTextScreenOffset.y());
 }
 
 void QOSGViewerWidget::SetHUDTextOffset(double xOffset, double yOffset)

--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -644,6 +644,8 @@ QOSGViewerWidget::QOSGViewerWidget(EnvironmentBasePtr penv, const std::string& u
 
     _osgWorldAxis->addChild(CreateOSGXYZAxes(32.0, 2.0));
 
+    _vecTextScreenOffset = new osg::Vec2d(10.0, 0.0);
+
     if( !!_osgCameraHUD ) {
         // in order to get the axes to render without lighting:
 
@@ -1161,12 +1163,32 @@ void QOSGViewerWidget::SetViewport(int width, int height)
     hudcamera->setViewport(0, 0, width * scale, height * scale);
 
     double textheight = 18*scale;
-    _osgHudText->setPosition(osg::Vec3(-width * scale / 2 + 10, height * scale / 2 - textheight, -50));
     _osgHudText->setCharacterSize(textheight);
     _osgHudText->setFontResolution(textheight, textheight);
-    // Set maximum width in order to enforce word wrapping
-    _osgHudText->setMaximumWidth(width * scale - 20);
+    SetHUDTextOffset(_vecTextScreenOffset->x(), _vecTextScreenOffset->y());
     _UpdateHUDAxisTransform(width, height);
+}
+
+osg::Vec2d* QOSGViewerWidget::GetHUDTextOffset()
+{
+    return new osg::Vec2d(_vecTextScreenOffset->x(), _vecTextScreenOffset->y());
+}
+
+void QOSGViewerWidget::SetHUDTextOffset(double xOffset, double yOffset)
+{
+    _vecTextScreenOffset->set(xOffset, yOffset);
+
+    double scale = this->devicePixelRatio();
+    double textheight = 18*scale;
+    _osgHudText->setPosition(
+        osg::Vec3(
+            -_osgview->getCamera()->getViewport()->width() / 2 + _vecTextScreenOffset->x(),
+            _osgview->getCamera()->getViewport()->height() / 2 - textheight - _vecTextScreenOffset->y(),
+            -50
+        )
+    );
+    // Set maximum width in order to enforce word wrapping
+    _osgHudText->setMaximumWidth(_osgview->getCamera()->getViewport()->width() - 10 - _vecTextScreenOffset->x());
 }
 
 void QOSGViewerWidget::_UpdateHUDAxisTransform(int width, int height)

--- a/plugins/qtosgrave/osgviewerwidget.h
+++ b/plugins/qtosgrave/osgviewerwidget.h
@@ -129,7 +129,7 @@ public:
     void SetViewport(int width, int height);
 
     /// \brief gets the screen offset of HUD text (default with no control buttons is (10.0, 0.0))
-    osg::Vec2d GetHUDTextOffset();
+    osg::Vec2 GetHUDTextOffset();
 
     /// \brief sets the screen offset of HUD text (default with no control buttons is (10.0, 0.0))
     void SetHUDTextOffset(double xOffset, double yOffset);
@@ -331,7 +331,7 @@ protected:
 
     osg::ref_ptr<osgText::Text> _osgHudText; ///< the HUD text in the upper left corner
     std::string _strUserText, _strSelectedItemText, _strRayInfoText, _strTrackInfoText; ///< the user hud text
-    osg::Vec2d _vecTextScreenOffset; ///< hud text screen offset
+    osg::Vec2 _vecTextScreenOffset; ///< hud text screen offset
 
     osg::ref_ptr<Skybox> _osgSkybox;  ///< the skybox moving together with camera
 

--- a/plugins/qtosgrave/osgviewerwidget.h
+++ b/plugins/qtosgrave/osgviewerwidget.h
@@ -129,7 +129,7 @@ public:
     void SetViewport(int width, int height);
 
     /// \brief gets the screen offset of HUD text (default with no control buttons is (10.0, 0.0))
-    osg::Vec2d* GetHUDTextOffset();
+    osg::Vec2d GetHUDTextOffset();
 
     /// \brief sets the screen offset of HUD text (default with no control buttons is (10.0, 0.0))
     void SetHUDTextOffset(double xOffset, double yOffset);
@@ -331,7 +331,7 @@ protected:
 
     osg::ref_ptr<osgText::Text> _osgHudText; ///< the HUD text in the upper left corner
     std::string _strUserText, _strSelectedItemText, _strRayInfoText, _strTrackInfoText; ///< the user hud text
-    osg::Vec2d* _vecTextScreenOffset; ///< hud text screen offset
+    osg::Vec2d _vecTextScreenOffset; ///< hud text screen offset
 
     osg::ref_ptr<Skybox> _osgSkybox;  ///< the skybox moving together with camera
 

--- a/plugins/qtosgrave/osgviewerwidget.h
+++ b/plugins/qtosgrave/osgviewerwidget.h
@@ -128,6 +128,12 @@ public:
     /// \brief called when the qt window size changes
     void SetViewport(int width, int height);
 
+    /// \brief gets the screen offset of HUD text (default with no control buttons is (10.0, 0.0))
+    osg::Vec2d* GetHUDTextOffset();
+
+    /// \brief sets the screen offset of HUD text (default with no control buttons is (10.0, 0.0))
+    void SetHUDTextOffset(double xOffset, double yOffset);
+
     /// \brief sets user-controlled hud text
     void SetUserHUDText(const std::string &text);
 
@@ -324,7 +330,8 @@ protected:
     osg::ref_ptr<OpenRAVETracker> _osgTrackModeManipulator; //< manipulator used by TrackLink and TrackManip commands
 
     osg::ref_ptr<osgText::Text> _osgHudText; ///< the HUD text in the upper left corner
-    std::string _strUserText, _strSelectedItemText, _strRayInfoText, _strTrackInfoText;; ///< the user hud text
+    std::string _strUserText, _strSelectedItemText, _strRayInfoText, _strTrackInfoText; ///< the user hud text
+    osg::Vec2d* _vecTextScreenOffset; ///< hud text screen offset
 
     osg::ref_ptr<Skybox> _osgSkybox;  ///< the skybox moving together with camera
 

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -867,8 +867,8 @@ void QtOSGViewer::_CreateControlButtons()
     qvBoxLayout->heightForWidth(40);
 
     //  Move HUD text out of way of control buttons if needed
-    osg::Vec2d hudTextOffset = _posgWidget->GetHUDTextOffset();
-    _posgWidget->SetHUDTextOffset(std::max(60.0, hudTextOffset.x()), hudTextOffset.y());
+    osg::Vec2 hudTextOffset = _posgWidget->GetHUDTextOffset();
+    _posgWidget->SetHUDTextOffset(std::max(60.0f, hudTextOffset.x()), hudTextOffset.y());
 
     QPushButton *zoomInButton = new QPushButton("+");
     connect(zoomInButton, &QPushButton::pressed, [=](){

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -170,9 +170,6 @@ QtOSGViewer::QtOSGViewer(EnvironmentBasePtr penv, std::istream& sinput) : QMainW
     RegisterCommand("RotateCameraYDirection", boost::bind(&QtOSGViewer::_RotateCameraYDirectionCommand, this, _1, _2),
     "Rotates the camera around the current focal point in the direction of the screen y vector (in world coordinates). The argument thetaY is in radians -pi < dy < pi.");
 
-    RegisterCommand("SetHUDTextOffset", boost::bind(&QtOSGViewer::_SetHUDTextOffsetCommand, this, _1, _2),
-    "Sets the screen offset of the HUD's text. Default value when no control buttons are present is (10.0, 0.0).");
-
     // Pan commands. This commands will be ignored if currently in TrackLink or TrackManipulator mode (e.g: using osgviewerwidget NodeTrackManipulator or activating TrackLink or TrackManipulator commands)
     // since pan is not a valid operation during track mode, because when tracking we always keep focus in the tracked object.
     RegisterCommand("PanCameraXDirection", boost::bind(&QtOSGViewer::_PanCameraXDirectionCommand, this, _1, _2),
@@ -1327,17 +1324,6 @@ bool QtOSGViewer::_PanCameraYDirectionCommand(ostream& sout, istream& sinput)
     sinput >> dy;
 
     _PostToGUIThread(boost::bind(&QtOSGViewer::_PanCameraYDirection, this, dy), ViewerCommandPriority::LOW);
-    return true;
-}
-
-bool QtOSGViewer::_SetHUDTextOffsetCommand(ostream& sout, istream& sinput)
-{
-    double xOffset = 10.0;
-    sinput >> xOffset;
-
-    double yOffset = 0.0;
-    sinput >> yOffset;
-    _PostToGUIThread(boost::bind(&QtOSGViewer::_SetHUDTextOffset, this, xOffset, yOffset), ViewerCommandPriority::LOW);
     return true;
 }
 

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -1327,7 +1327,6 @@ bool QtOSGViewer::_PanCameraYDirectionCommand(ostream& sout, istream& sinput)
     return true;
 }
 
-
 void QtOSGViewer::_SetProjectionMode(const std::string& projectionMode)
 {
     if (projectionMode == "orthogonal")

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -867,8 +867,8 @@ void QtOSGViewer::_CreateControlButtons()
     qvBoxLayout->heightForWidth(40);
 
     //  Move HUD text out of way of control buttons if needed
-    osg::Vec2d* hudTextOffset = _posgWidget->GetHUDTextOffset();
-    _posgWidget->SetHUDTextOffset(std::max(60.0, hudTextOffset->x()), hudTextOffset->y());
+    osg::Vec2d hudTextOffset = _posgWidget->GetHUDTextOffset();
+    _posgWidget->SetHUDTextOffset(std::max(60.0, hudTextOffset.x()), hudTextOffset.y());
 
     QPushButton *zoomInButton = new QPushButton("+");
     connect(zoomInButton, &QPushButton::pressed, [=](){

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -275,6 +275,10 @@ void QtOSGViewer::_InitGUI(bool bCreateStatusBar, bool bCreateMenu)
 
     if (!bCreateMenu && !bCreateMenu) {
         _CreateControlButtons();
+
+        // move HUD text out of way of control buttons if needed
+        osg::Vec2 hudTextOffset = _posgWidget->GetHUDTextOffset();
+        _posgWidget->SetHUDTextOffset(std::max(60.0f, hudTextOffset.x()), hudTextOffset.y());
     }
 
     resize(1024, 768);
@@ -865,10 +869,6 @@ void QtOSGViewer::_CreateControlButtons()
     qvBoxLayout->setSpacing(5);
     qvBoxLayout->setAlignment(Qt::AlignTop);
     qvBoxLayout->heightForWidth(40);
-
-    //  Move HUD text out of way of control buttons if needed
-    osg::Vec2 hudTextOffset = _posgWidget->GetHUDTextOffset();
-    _posgWidget->SetHUDTextOffset(std::max(60.0f, hudTextOffset.x()), hudTextOffset.y());
 
     QPushButton *zoomInButton = new QPushButton("+");
     connect(zoomInButton, &QPushButton::pressed, [=](){

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -317,6 +317,9 @@ public:
     /// \brief reset the camera depending on its mode
     virtual void _UpdateViewport();
 
+    /// \brief set screen offset of hud text (default is (10, 0))
+    virtual void _SetHUDTextOffset(double xOffset, double yOffset);
+
     virtual OSGSwitchPtr _CreateGraphHandle();
     virtual void _CloseGraphHandle(OSGSwitchPtr handle);
     virtual void _SetGraphTransform(OSGSwitchPtr handle, const RaveTransform<float> t);
@@ -407,6 +410,7 @@ public:
     bool _RotateCameraYDirectionCommand(ostream& sout, istream& sinput);
     bool _PanCameraXDirectionCommand(ostream& sout, istream& sinput);
     bool _PanCameraYDirectionCommand(ostream& sout, istream& sinput);
+    bool _SetHUDTextOffsetCommand(ostream& sout, istream& sinput);
 
     //@{ Message Queue
     std::map<ViewerCommandPriority, list<GUIThreadFunctionPtr>> _mapGUIFunctionLists; ///< map between priority and sublist for given priority level. protected by _mutexGUIFunctions

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -410,7 +410,6 @@ public:
     bool _RotateCameraYDirectionCommand(ostream& sout, istream& sinput);
     bool _PanCameraXDirectionCommand(ostream& sout, istream& sinput);
     bool _PanCameraYDirectionCommand(ostream& sout, istream& sinput);
-    bool _SetHUDTextOffsetCommand(ostream& sout, istream& sinput);
 
     //@{ Message Queue
     std::map<ViewerCommandPriority, list<GUIThreadFunctionPtr>> _mapGUIFunctionLists; ///< map between priority and sublist for given priority level. protected by _mutexGUIFunctions


### PR DESCRIPTION
This PR fixes a bug where the HUD text in `osgviewerwidget` will render underneath the control buttons that can be optionally added via `QtOSGViewer::_CreateControlButtons`, obstructing some of the displayed text.

**Changes**

* Maintain a 2d vector offset property within `osgviewerwidget` that can be access and modified via a getter/setter pattern.
  * This property, `_vecTextScreenOffset`, affects the position of the upper left corner of the HUD text area (which will subsequently adjust its width as to cover available space going towards the right side).
* Use the getter/setter of  `_vecTextScreenOffset` to offset the HUD text away from the control buttons when `QtOSGViewer::_CreateControlButtons` is called.
* Expose `SetHUDTextOffset` as a viewer command for testing or external application use.