### PR TITLE
WIP: Do not assume all-zero/initial robot pose as non-self-colliding pose and make non-self-colliding pose configurable

### DIFF
--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -2045,6 +2045,13 @@ public:
         void SerializeJSON(rapidjson::Value& value, rapidjson::Document::AllocatorType& allocator, dReal fUnitScale, int options=0) const override;
         void DeserializeJSON(const rapidjson::Value& value, dReal fUnitScale, int options) override;
 
+        inline const std::string& GetId() const {
+            return _id;
+        }
+        inline const std::string& GetName() const {
+            return name;
+        }
+
         bool operator==(const PositionConfiguration& other) const;
         bool operator!=(const PositionConfiguration& other) const;
 
@@ -2253,6 +2260,8 @@ public:
 
         std::vector<LinkInfoPtr> _vLinkInfos; ///< list of pointers to LinkInfo
         std::vector<JointInfoPtr> _vJointInfos; ///< list of pointers to JointInfo
+
+        std::vector<PositionConfigurationPtr> _vNonSelfCollidingPositionConfigurations; ///< list of non-self-colliding position configurations
 
         std::map<std::string, ReadablePtr> _mReadableInterfaces; ///< readable interface mapping
 

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -3493,7 +3493,7 @@ protected:
 
     void _SetAdjacentLinksInternal(int linkindex0, int linkindex1);
 
-    void _CalculateAdjacentLinkFlagsFromNonSelfCollidingPositionConfigurations(std::vector<bool>& adjacentLinkFlags);
+    void _CalculateAdjacentLinkFlagsFromNonSelfCollidingPositionConfigurations(std::vector<bool>& adjacentLinkFlags) const;
 
     /// \brief Returns a full list of DOFs which values are determinable given an initial list of such DOFs
     /// \param[in,out] isDOFValueDeterminableList List of flags which indicate whether DOF values are determinable. Takes an initial list as input, and returns a full list as output. Size must match GetDOF().
@@ -3529,8 +3529,8 @@ protected:
     mutable boost::array<std::vector<int>, 4> _vNonAdjacentLinks; ///< contains cached versions of the non-adjacent links depending on values in AdjacentOptions. Declared as mutable since data is cached.
     mutable boost::array<std::set<int>, 4> _cacheSetNonAdjacentLinks; ///< used for caching return value of GetNonAdjacentLinks.
     mutable int _nNonAdjacentLinkCache; ///< specifies what information is currently valid in the AdjacentOptions.  Declared as mutable since data is cached. If 0x80000000 (ie < 0), then everything needs to be recomputed including _setNonAdjacentLinks[0].
-    std::vector<Transform> _vInitialLinkTransformations; ///< the initial transformations of each link specifying at least one pose where the robot is collision free
-    std::vector<PositionConfigurationPtr> _vNonSelfCollidingPositionConfigurations; ///< list of non-self-colliding position configurations
+    typedef std::pair<PositionConfigurationPtr, std::vector<Transform> > PositionConfigurationAndLinkTransformations;
+    std::vector<PositionConfigurationAndLinkTransformations> _vNonSelfCollidingPositionConfigurationsAndLinkTransformations; ///< list of non-self-colliding position configurations and corresponding link transformations
 
     mutable std::vector<int8_t> _vAttachedVisitedCache; ///< cache
     mutable std::vector<std::pair<Vector,Vector> > _vVelocitiesCache;

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -2496,6 +2496,9 @@ private:
     /// \param dofindices the dof indices to return the values for. If empty, will compute for all the dofs
     void GetDOFVelocities(std::vector<dReal>& v, const std::vector<int>& dofindices = std::vector<int>()) const;
 
+    /// \brief Returns the current position configuration
+    virtual void GetPositionConfiguration(PositionConfiguration& positionConfiguration) const;
+
     /// \brief Returns all the joint limits as organized by the DOF indices.
     ///
     /// \param dofindices the dof indices to return the values for. If empty, will compute for all the dofs

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -2077,10 +2077,10 @@ public:
             std::string GetResolvedJointName() const;
 
             std::string _id; ///< id of joint configuration state, for incremental update
-            std::string jointName; ///< name of the joint. If the joint belong to a connectedBody, then it's resolved name is connectedBodyName+"_"+jointName
+            std::string jointName; ///< name of the joint. If the joint belong to a connectedBody, then its resolved name is connectedBodyName+"_"+jointName
             int jointAxis = 0;
             dReal jointValue = 0.0;
-            std::string connectedBodyName; ///< the connected body name the jointName comes from
+            std::string connectedBodyName; ///< Name of the connected body the joint comes from. Set to empty if the joint belongs to a robot, not a connected body.
         };
         typedef boost::shared_ptr<JointConfigurationState> JointConfigurationStatePtr;
         typedef boost::shared_ptr<JointConfigurationState const> JointConfigurationStateConstPtr;

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -2074,6 +2074,8 @@ public:
             bool operator==(const JointConfigurationState& other) const;
             bool operator!=(const JointConfigurationState& other) const;
 
+            std::string GetResolvedJointName() const;
+
             std::string _id; ///< id of joint configuration state, for incremental update
             std::string jointName; ///< name of the joint. If the joint belong to a connectedBody, then it's resolved name is connectedBodyName+"_"+jointName
             int jointAxis = 0;
@@ -3491,6 +3493,13 @@ protected:
 
     void _SetAdjacentLinksInternal(int linkindex0, int linkindex1);
 
+    void _CalculateAdjacentLinkFlagsFromNonSelfCollidingPositionConfigurations(std::vector<bool>& adjacentLinkFlags);
+
+    /// \brief Returns a full list of DOFs which values are determinable given an initial list of such DOFs
+    /// \param[in,out] isDOFValueDeterminableList List of flags which indicate whether DOF values are determinable. Takes an initial list as input, and returns a full list as output. Size must match GetDOF().
+    /// \return True if the list of DOFs has been converged, otherwise false.
+    bool _ResolveDOFValueDeterminableFlags(std::vector<bool>& isDOFValueDeterminableList, int maxNumIterations) const;
+
     std::string _name; ///< name of body
 
     std::vector<JointPtr> _vecjoints; ///< \see GetJoints
@@ -3521,6 +3530,7 @@ protected:
     mutable boost::array<std::set<int>, 4> _cacheSetNonAdjacentLinks; ///< used for caching return value of GetNonAdjacentLinks.
     mutable int _nNonAdjacentLinkCache; ///< specifies what information is currently valid in the AdjacentOptions.  Declared as mutable since data is cached. If 0x80000000 (ie < 0), then everything needs to be recomputed including _setNonAdjacentLinks[0].
     std::vector<Transform> _vInitialLinkTransformations; ///< the initial transformations of each link specifying at least one pose where the robot is collision free
+    std::vector<PositionConfigurationPtr> _vNonSelfCollidingPositionConfigurations; ///< list of non-self-colliding position configurations
 
     mutable std::vector<int8_t> _vAttachedVisitedCache; ///< cache
     mutable std::vector<std::pair<Vector,Vector> > _vVelocitiesCache;

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -2035,8 +2035,6 @@ private:
     typedef boost::weak_ptr<KinBody::Joint> JointWeakPtr;
 
     /// \brief Holds a joint value set representing a KinBody/Robot pose
-    ///
-    /// Currently, this structure supports only joints which have single DoF
     class OPENRAVE_API PositionConfiguration : public InfoBase
     {
 public:
@@ -2071,6 +2069,7 @@ public:
 
             std::string _id; ///< id of joint configuration state, for incremental update
             std::string jointName; ///< name of the joint. If the joint belong to a connectedBody, then it's resolved name is connectedBodyName+"_"+jointName
+            int jointAxis = 0;
             dReal jointValue = 0.0;
             std::string connectedBodyName; ///< the connected body name the jointName comes from
         };

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -2034,6 +2034,56 @@ private:
     typedef boost::shared_ptr<KinBody::Joint const> JointConstPtr;
     typedef boost::weak_ptr<KinBody::Joint> JointWeakPtr;
 
+    /// \brief Holds a joint value set representing a KinBody/Robot pose
+    ///
+    /// Currently, this structure supports only joints which have single DoF
+    class OPENRAVE_API PositionConfiguration : public InfoBase
+    {
+public:
+        PositionConfiguration() = default;
+        virtual ~PositionConfiguration() = default;
+
+        void Reset() override;
+        void SerializeJSON(rapidjson::Value& value, rapidjson::Document::AllocatorType& allocator, dReal fUnitScale, int options=0) const override;
+        void DeserializeJSON(const rapidjson::Value& value, dReal fUnitScale, int options) override;
+
+        bool operator==(const PositionConfiguration& other) const;
+        bool operator!=(const PositionConfiguration& other) const;
+
+        inline void Swap(PositionConfiguration& rhs) {
+            _id.swap(rhs._id);
+            name.swap(rhs.name);
+            jointConfigurationStates.swap(rhs.jointConfigurationStates);
+        }
+
+        class JointConfigurationState : public InfoBase
+        {
+public:
+            JointConfigurationState() = default;
+            virtual ~JointConfigurationState() = default;
+
+            void Reset() override;
+            void SerializeJSON(rapidjson::Value& value, rapidjson::Document::AllocatorType& allocator, dReal fUnitScale, int options=0) const override;
+            void DeserializeJSON(const rapidjson::Value& value, dReal fUnitScale, int options) override;
+
+            bool operator==(const JointConfigurationState& other) const;
+            bool operator!=(const JointConfigurationState& other) const;
+
+            std::string _id; ///< id of joint configuration state, for incremental update
+            std::string jointName; ///< name of the joint. If the joint belong to a connectedBody, then it's resolved name is connectedBodyName+"_"+jointName
+            dReal jointValue = 0.0;
+            std::string connectedBodyName; ///< the connected body name the jointName comes from
+        };
+        typedef boost::shared_ptr<JointConfigurationState> JointConfigurationStatePtr;
+        typedef boost::shared_ptr<JointConfigurationState const> JointConfigurationStateConstPtr;
+
+        std::string _id; ///< unique id of the configuration used to identify it when changing it.
+        std::string name; ///< name of the configuration
+        std::vector<JointConfigurationState> jointConfigurationStates; ///< joint name to joint values mapping
+    };
+    typedef boost::shared_ptr<PositionConfiguration> PositionConfigurationPtr;
+    typedef boost::shared_ptr<PositionConfiguration const> PositionConfigurationConstPtr;
+
     /// \brief holds all user-set attached sensor information used to initialize the AttachedSensor class.
     ///
     /// This is serializable and independent of environment.

--- a/include/openrave/robot.h
+++ b/include/openrave/robot.h
@@ -993,6 +993,9 @@ private:
     /// \brief initializes a robot with info structure
     virtual bool InitFromRobotInfo(const RobotBaseInfo& info);
 
+    /// \brief Returns the current position configuration
+    virtual void GetPositionConfiguration(PositionConfiguration& positionConfiguration) const;
+
     /// \brief Returns the manipulators of the robot
     virtual const std::vector<ManipulatorPtr>& GetManipulators() const;
 

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -490,6 +490,52 @@ public:
     int __hash__();
 };
 
+class PyPositionConfiguration_JointConfigurationState
+{
+public:
+    PyPositionConfiguration_JointConfigurationState() = default;
+    PyPositionConfiguration_JointConfigurationState(const KinBody::PositionConfiguration::JointConfigurationState& jointConfigurationState);
+
+    KinBody::PositionConfiguration::JointConfigurationStatePtr GetJointConfigurationState() const;
+    object SerializeJSON(dReal fUnitScale = 1.0, object options = py::none_());
+    void DeserializeJSON(object obj, dReal fUnitScale = 1.0, object options = py::none_());
+
+    std::string __str__();
+    bool __eq__(OPENRAVE_SHARED_PTR<PyPositionConfiguration_JointConfigurationState> p);
+    bool __ne__(OPENRAVE_SHARED_PTR<PyPositionConfiguration_JointConfigurationState> p);
+
+    object _id = py::none_();
+    object jointName = py::none_();
+    dReal jointValue = 0.0;
+    object connectedBodyName = py::none_();
+
+private:
+    void _Update(const KinBody::PositionConfiguration::JointConfigurationState& jointConfigurationState);
+};
+typedef OPENRAVE_SHARED_PTR<PyPositionConfiguration_JointConfigurationState> PyPositionConfiguration_JointConfigurationStatePtr;
+
+class PyPositionConfiguration
+{
+public:
+    PyPositionConfiguration() = default;
+    PyPositionConfiguration(const KinBody::PositionConfiguration& positionConfiguration);
+
+    KinBody::PositionConfigurationPtr GetPositionConfiguration() const;
+    object SerializeJSON(dReal fUnitScale = 1.0, object options = py::none_());
+    void DeserializeJSON(object obj, dReal fUnitScale = 1.0, object options = py::none_());
+
+    std::string __str__();
+    bool __eq__(OPENRAVE_SHARED_PTR<PyPositionConfiguration> p);
+    bool __ne__(OPENRAVE_SHARED_PTR<PyPositionConfiguration> p);
+
+    object _id = py::none_();
+    object name = py::none_();
+    py::list jointConfigurationStates;
+
+private:
+    void _Update(const KinBody::PositionConfiguration& positionConfiguration);
+};
+
 class PyKinBodyStateSaver
 {
     PyEnvironmentBasePtr _pyenv;

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -506,6 +506,7 @@ public:
 
     object _id = py::none_();
     object jointName = py::none_();
+    int jointAxis = 0;
     dReal jointValue = 0.0;
     object connectedBodyName = py::none_();
 

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -536,6 +536,7 @@ public:
 private:
     void _Update(const KinBody::PositionConfiguration& positionConfiguration);
 };
+typedef OPENRAVE_SHARED_PTR<PyPositionConfiguration> PyPositionConfigurationPtr;
 
 class PyKinBodyStateSaver
 {

--- a/python/bindings/include/openravepy/openravepy_kinbody.h
+++ b/python/bindings/include/openravepy/openravepy_kinbody.h
@@ -157,6 +157,7 @@ public:
         bool _isRobot = false;
         bool _isPartial = true;
         py::object _dofValues = py::none_();
+        py::object _vNonSelfCollidingPositionConfigurations = py::none_();
         py::object _readableInterfaces = py::none_();
         virtual std::string __str__();
         virtual py::object __unicode__();

--- a/python/bindings/include/openravepy/openravepy_kinbody.h
+++ b/python/bindings/include/openravepy/openravepy_kinbody.h
@@ -202,6 +202,7 @@ public:
     py::object GetDOFValues(py::object oindices) const;
     py::object GetDOFVelocities() const;
     py::object GetDOFVelocities(py::object oindices) const;
+    py::object GetPositionConfiguration() const;
     py::object GetDOFLimits() const;
     py::object GetDOFVelocityLimits() const;
     py::object GetDOFAccelerationLimits() const;

--- a/python/bindings/include/openravepy/openravepy_kinbody.h
+++ b/python/bindings/include/openravepy/openravepy_kinbody.h
@@ -328,6 +328,7 @@ public:
     py::object GetURI() const;
     py::object GetNonAdjacentLinks() const;
     py::object GetNonAdjacentLinks(int adjacentoptions) const;
+    bool AreAdjacentLinks(int linkindex0, int linkindex1) const;
     void SetAdjacentLinks(int linkindex0, int linkindex1);
     void SetAdjacentLinksCombinations(py::object olinkIndices);
     py::object GetAdjacentLinks() const;

--- a/python/bindings/include/openravepy/openravepy_robotbase.h
+++ b/python/bindings/include/openravepy/openravepy_robotbase.h
@@ -297,6 +297,8 @@ public:
 
     bool Init(object olinkinfos, object ojointinfos, object omanipinfos, object oattachedsensorinfos, const std::string& uri=std::string());
 
+    py::object GetPositionConfiguration() const;
+
     object GetManipulators();
 
     object GetManipulators(const std::string& manipname);

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -2071,6 +2071,167 @@ PyGeometryInfoPtr toPyGeometryInfo(const KinBody::GeometryInfo& geominfo)
     return PyGeometryInfoPtr(new PyGeometryInfo(geominfo));
 }
 
+PyPositionConfiguration::PyPositionConfiguration(const KinBody::PositionConfiguration& positionConfiguration)
+{
+    _Update(positionConfiguration);
+}
+
+KinBody::PositionConfigurationPtr PyPositionConfiguration::GetPositionConfiguration() const
+{
+    KinBody::PositionConfigurationPtr positionConfiguration(new KinBody::PositionConfiguration());
+    if( !IS_PYTHONOBJECT_NONE(_id) ) {
+        positionConfiguration->_id = py::extract<std::string>(_id);
+    }
+    if( !IS_PYTHONOBJECT_NONE(name) ) {
+        positionConfiguration->name = py::extract<std::string>(name);
+    }
+    positionConfiguration->jointConfigurationStates.resize(len(jointConfigurationStates));
+    for( int jointConfigurationIndex = 0; jointConfigurationIndex < len(jointConfigurationStates); ++jointConfigurationIndex ) {
+        PyPositionConfiguration_JointConfigurationStatePtr pyJointConfigurationState = py::extract<PyPositionConfiguration_JointConfigurationStatePtr>(jointConfigurationStates[jointConfigurationIndex]);
+        positionConfiguration->jointConfigurationStates[jointConfigurationIndex] = *(pyJointConfigurationState->GetJointConfigurationState());
+    }
+    return positionConfiguration;
+}
+
+object PyPositionConfiguration::SerializeJSON(dReal fUnitScale, object options)
+{
+    rapidjson::Document doc;
+    KinBody::PositionConfigurationPtr positionConfiguration = GetPositionConfiguration();
+    positionConfiguration->SerializeJSON(doc, doc.GetAllocator(), fUnitScale, pyGetIntFromPy(options, 0));
+    return toPyObject(doc);
+}
+
+void PyPositionConfiguration::DeserializeJSON(object obj, dReal fUnitScale, object options)
+{
+    rapidjson::Document doc;
+    toRapidJSONValue(obj, doc, doc.GetAllocator());
+    KinBody::PositionConfiguration positionConfiguration;
+    positionConfiguration.DeserializeJSON(doc, fUnitScale, pyGetIntFromPy(options, 0));
+    _Update(positionConfiguration);
+}
+
+std::string PyPositionConfiguration::__str__()
+{
+    std::stringstream ss;
+    ss << "<PositionConfiguration";
+    if( !IS_PYTHONOBJECT_NONE(name) ) {
+        ss << " name=\"" << (const std::string&)py::extract<std::string>(name) << "\"";
+    }
+    ss << " jointConfigurationStates=[";
+    for( int jointConfigurationIndex = 0; jointConfigurationIndex < len(jointConfigurationStates); ++jointConfigurationIndex ) {
+        PyPositionConfiguration_JointConfigurationStatePtr pyJointConfigurationState = py::extract<PyPositionConfiguration_JointConfigurationStatePtr>(jointConfigurationStates[jointConfigurationIndex]);
+        if( jointConfigurationIndex > 0 ) {
+            ss << ", ";
+        }
+        ss << pyJointConfigurationState->__str__();
+    }
+    ss << "]>";
+    return ss.str();
+}
+
+bool PyPositionConfiguration::__eq__(OPENRAVE_SHARED_PTR<PyPositionConfiguration> p)
+{
+    if( !p ) {
+        return false;
+    }
+    KinBody::PositionConfigurationConstPtr positionConfiguration0 = GetPositionConfiguration();
+    KinBody::PositionConfigurationConstPtr positionConfiguration1 = p->GetPositionConfiguration();
+    return *positionConfiguration0 == *positionConfiguration1;
+}
+
+bool PyPositionConfiguration::__ne__(OPENRAVE_SHARED_PTR<PyPositionConfiguration> p)
+{
+    return !__eq__(p);
+}
+
+void PyPositionConfiguration::_Update(const KinBody::PositionConfiguration& positionConfiguration)
+{
+    _id = ConvertStringToUnicode(positionConfiguration._id);
+    name = ConvertStringToUnicode(positionConfiguration.name);
+
+    py::list newJointConfigurationStates;
+    for( const KinBody::PositionConfiguration::JointConfigurationState& cppJointConfiguration : positionConfiguration.jointConfigurationStates ) {
+        newJointConfigurationStates.append(PyPositionConfiguration_JointConfigurationStatePtr(new PyPositionConfiguration_JointConfigurationState(cppJointConfiguration)));
+    }
+    jointConfigurationStates = newJointConfigurationStates;
+}
+
+PyPositionConfiguration_JointConfigurationState::PyPositionConfiguration_JointConfigurationState(const KinBody::PositionConfiguration::JointConfigurationState& jointConfigurationState)
+{
+    _Update(jointConfigurationState);
+}
+
+KinBody::PositionConfiguration::JointConfigurationStatePtr PyPositionConfiguration_JointConfigurationState::GetJointConfigurationState() const
+{
+    KinBody::PositionConfiguration::JointConfigurationStatePtr jointConfigurationState(new KinBody::PositionConfiguration::JointConfigurationState());
+    if( !IS_PYTHONOBJECT_NONE(_id) ) {
+        jointConfigurationState->_id = py::extract<std::string>(_id);
+    }
+    if( !IS_PYTHONOBJECT_NONE(jointName) ) {
+        jointConfigurationState->jointName = py::extract<std::string>(jointName);
+    }
+    jointConfigurationState->jointValue = jointValue;
+    if( !IS_PYTHONOBJECT_NONE(connectedBodyName) ) {
+        jointConfigurationState->connectedBodyName = py::extract<std::string>(connectedBodyName);
+    }
+    return jointConfigurationState;
+}
+
+object PyPositionConfiguration_JointConfigurationState::SerializeJSON(dReal fUnitScale, object options)
+{
+    rapidjson::Document doc;
+    KinBody::PositionConfiguration::JointConfigurationStatePtr jointConfigurationState = GetJointConfigurationState();
+    jointConfigurationState->SerializeJSON(doc, doc.GetAllocator(), fUnitScale, pyGetIntFromPy(options, 0));
+    return toPyObject(doc);
+}
+
+void PyPositionConfiguration_JointConfigurationState::DeserializeJSON(object obj, dReal fUnitScale, object options)
+{
+    rapidjson::Document doc;
+    toRapidJSONValue(obj, doc, doc.GetAllocator());
+    KinBody::PositionConfiguration::JointConfigurationState jointConfigurationState;
+    jointConfigurationState.DeserializeJSON(doc, fUnitScale, pyGetIntFromPy(options, 0));
+    _Update(jointConfigurationState);
+}
+
+std::string PyPositionConfiguration_JointConfigurationState::__str__()
+{
+    std::stringstream ss;
+    ss << "<JointConfigurationState jointName=\"";
+    if( !IS_PYTHONOBJECT_NONE(jointName) ) {
+        ss << (const std::string&) py::extract<std::string>(jointName);
+    }
+    ss << "\" jointValue=" << jointValue << " connectedBodyName=\"";
+    if( !IS_PYTHONOBJECT_NONE(connectedBodyName) ) {
+        ss << (const std::string&) py::extract<std::string>(connectedBodyName);
+    }
+    ss << "\">";
+    return ss.str();
+}
+
+bool PyPositionConfiguration_JointConfigurationState::__eq__(OPENRAVE_SHARED_PTR<PyPositionConfiguration_JointConfigurationState> p)
+{
+    if( !p ) {
+        return false;
+    }
+    KinBody::PositionConfiguration::JointConfigurationStateConstPtr jointConfigurationState0 = GetJointConfigurationState();
+    KinBody::PositionConfiguration::JointConfigurationStateConstPtr jointConfigurationState1 = p->GetJointConfigurationState();
+    return *jointConfigurationState0 == *jointConfigurationState1;
+}
+
+bool PyPositionConfiguration_JointConfigurationState::__ne__(OPENRAVE_SHARED_PTR<PyPositionConfiguration_JointConfigurationState> p)
+{
+    return !__eq__(p);
+}
+
+void PyPositionConfiguration_JointConfigurationState::_Update(const KinBody::PositionConfiguration::JointConfigurationState& jointConfigurationState)
+{
+    _id = ConvertStringToUnicode(jointConfigurationState._id);
+    jointName = ConvertStringToUnicode(jointConfigurationState.jointName);
+    jointValue = jointConfigurationState.jointValue;
+    connectedBodyName = ConvertStringToUnicode(jointConfigurationState.connectedBodyName);
+}
+
 PyKinBodyStateSaver::PyKinBodyStateSaver(PyKinBodyPtr pybody) : _pyenv(pybody->GetEnv()), _state(pybody->GetBody()) {
     // python should not support restoring on destruction since there's garbage collection
     _state.SetRestoreOnDestructor(false);
@@ -4429,6 +4590,56 @@ public:
     }
 };
 
+class PositionConfiguration_JointConfigurationState_pickle_suite
+#ifndef USE_PYBIND11_PYTHON_BINDINGS
+    : public pickle_suite
+#endif
+{
+public:
+    static py::tuple getstate(const PyPositionConfiguration_JointConfigurationState& r)
+    {
+        return py::make_tuple(r._id, r.jointName, r.jointValue, r.connectedBodyName);
+    }
+    static void setstate(PyPositionConfiguration_JointConfigurationState& r, py::tuple state) {
+        r._id = state[0];
+        r.jointName = state[1];
+        r.jointValue = py::extract<double>(state[2]);
+        r.connectedBodyName = state[3];
+    }
+};
+
+class PositionConfiguration_pickle_suite
+#ifndef USE_PYBIND11_PYTHON_BINDINGS
+    : public pickle_suite
+#endif
+{
+public:
+    static py::tuple getstate(const PyPositionConfiguration& r)
+    {
+        py::list pickledJointConfigurationStates;
+        for( int jointConfigurationIndex = 0; jointConfigurationIndex < len(r.jointConfigurationStates); ++jointConfigurationIndex ) {
+            PyPositionConfiguration_JointConfigurationStatePtr pyJointConfigurationState = py::extract<PyPositionConfiguration_JointConfigurationStatePtr>(r.jointConfigurationStates[jointConfigurationIndex]);
+            pickledJointConfigurationStates.append(PositionConfiguration_JointConfigurationState_pickle_suite::getstate(*pyJointConfigurationState));
+        }
+
+        return py::make_tuple(r._id, r.name, pickledJointConfigurationStates);
+    }
+    static void setstate(PyPositionConfiguration& r, py::tuple state) {
+        r._id = state[0];
+        r.name = state[1];
+
+        py::list pickledJointConfigurationStateList = py::list(state[2]);
+        py::list newJointConfigurationStates;
+        for( int jointConfigurationIndex = 0; jointConfigurationIndex < len(pickledJointConfigurationStateList); ++jointConfigurationIndex ) {
+            PyPositionConfiguration_JointConfigurationStatePtr pyJointConfigurationState(new PyPositionConfiguration_JointConfigurationState());
+            PositionConfiguration_JointConfigurationState_pickle_suite::setstate(*pyJointConfigurationState, py::tuple(pickledJointConfigurationStateList[jointConfigurationIndex]));
+            newJointConfigurationStates.append(pyJointConfigurationState);
+        }
+
+        r.jointConfigurationStates = newJointConfigurationStates;
+    }
+};
+
 class GrabbedInfo_pickle_suite
 #ifndef USE_PYBIND11_PYTHON_BINDINGS
     : public pickle_suite
@@ -4503,6 +4714,8 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyElectricMotorActuatorInfo_SerializeJSON
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyGeometryInfo_SerializeJSON_overloads, SerializeJSON, 0, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyLinkInfo_SerializeJSON_overloads, SerializeJSON, 0, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyJointInfo_SerializeJSON_overloads, SerializeJSON, 0, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyPositionConfiguration_SerializeJSON_overloads, SerializeJSON, 0, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyPositionConfiguration_JointConfigurationState_SerializeJSON_overloads, SerializeJSON, 0, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyGrabbedInfo_SerializeJSON_overloads, SerializeJSON, 0, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyKinBodyInfo_SerializeJSON_overloads, SerializeJSON, 0, 2)
 // DeserializeJSON
@@ -4510,6 +4723,8 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyElectricMotorActuatorInfo_DeserializeJS
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyGeometryInfo_DeserializeJSON_overloads, DeserializeJSON, 1, 3)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyLinkInfo_DeserializeJSON_overloads, DeserializeJSON, 1, 3)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyJointInfo_DeserializeJSON_overloads, DeserializeJSON, 1, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyPositionConfiguration_DeserializeJSON_overloads, DeserializeJSON, 1, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyPositionConfiguration_JointConfigurationState_DeserializeJSON_overloads, DeserializeJSON, 1, 3)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyGrabbedInfo_DeserializeJSON_overloads, DeserializeJSON, 1, 3)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(PyKinBodyInfo_DeserializeJSON_overloads, DeserializeJSON, 1, 3)
 // end of JSON
@@ -5027,6 +5242,117 @@ void init_openravepy_kinbody()
         })
 #else
                        .def_pickle(JointInfo_pickle_suite())
+#endif
+    ;
+
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+    object positionconfiguration_jointconfigurationstate = class_<PyPositionConfiguration_JointConfigurationState, OPENRAVE_SHARED_PTR<PyPositionConfiguration_JointConfigurationState> >(m, "PositionConfiguration_JointConfigurationState", DOXY_CLASS(KinBody::PositionConfiguration::JointConfigurationState))
+        .def(init<>())
+#else
+    object positionconfiguration_jointconfigurationstate = class_<PyPositionConfiguration_JointConfigurationState, OPENRAVE_SHARED_PTR<PyPositionConfiguration_JointConfigurationState> >("PositionConfiguration_JointConfigurationState", DOXY_CLASS(KinBody::PositionConfiguration::JointConfigurationState))
+#endif
+        .def_readwrite("_id", &PyPositionConfiguration_JointConfigurationState::_id)
+        .def_readwrite("jointName",&PyPositionConfiguration_JointConfigurationState::jointName)
+        .def_readwrite("jointValue",&PyPositionConfiguration_JointConfigurationState::jointValue)
+        .def_readwrite("connectedBodyName",&PyPositionConfiguration_JointConfigurationState::connectedBodyName)
+        .def("__str__", &PyPositionConfiguration_JointConfigurationState::__str__)
+        .def("__eq__", &PyPositionConfiguration_JointConfigurationState::__eq__)
+        .def("__ne__", &PyPositionConfiguration_JointConfigurationState::__ne__)
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        .def("SerializeJSON", &PyPositionConfiguration_JointConfigurationState::SerializeJSON,
+             "unitScale"_a = 1.0,
+             "options"_a = py::none_(),
+             DOXY_FN(KinBody::PositionConfiguration::JointConfigurationState, SerializeJSON)
+             )
+        .def("DeserializeJSON", &PyPositionConfiguration_JointConfigurationState::DeserializeJSON,
+             "obj"_a,
+             "unitScale"_a = 1.0,
+             "options"_a = py::none_(),
+             DOXY_FN(KinBody::PositionConfiguration::JointConfigurationState, DeserializeJSON)
+             )
+#else
+        .def("SerializeJSON", &PyPositionConfiguration_JointConfigurationState::SerializeJSON, PyPositionConfiguration_JointConfigurationState_SerializeJSON_overloads(PY_ARGS("unitScale", "options") DOXY_FN(KinBody::PositionConfiguration::JointConfigurationState, SerializeJSON)))
+        .def("DeserializeJSON", &PyPositionConfiguration_JointConfigurationState::DeserializeJSON, PyPositionConfiguration_JointConfigurationState_DeserializeJSON_overloads(PY_ARGS("obj", "unitScale", "options") DOXY_FN(KinBody::PositionConfiguration::JointConfigurationState, DeserializeJSON)))
+#endif
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        .def(py::pickle(
+            [](const PyPositionConfiguration_JointConfigurationState &pyJointConfigurationState) {
+                // __getstate__
+                return PositionConfiguration_JointConfigurationState_pickle_suite::getstate(pyJointConfigurationState);
+            },
+            [](py::tuple state) {
+                PyPositionConfiguration_JointConfigurationState &pyJointConfigurationState;
+                PositionConfiguration_JointConfigurationState_pickle_suite::setstate(pyJointConfigurationState, state);
+                return pyJointConfigurationState;
+            }))
+        .def("__copy__",
+            [](const PyPositionConfiguration_JointConfigurationState& self) {
+                return self;
+            })
+        .def("__deepcopy__",
+            [](const PyPositionConfiguration_JointConfigurationState &pyJointConfigurationState, const py::dict& memo) {
+                auto state = PositionConfiguration_JointConfigurationState_pickle_suite::getstate(pyJointConfigurationState);
+                PyPositionConfiguration_JointConfigurationState pyJointConfigurationState_new;
+                PositionConfiguration_JointConfigurationState_pickle_suite::setstate(pyJointConfigurationState_new, state);
+                return pyJointConfigurationState_new;
+            })
+#else
+        .def_pickle(PositionConfiguration_JointConfigurationState_pickle_suite())
+#endif
+    ;
+
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+    object positionconfiguration = class_<PyPositionConfiguration, OPENRAVE_SHARED_PTR<PyPositionConfiguration> >(m, "PositionConfiguration", DOXY_CLASS(KinBody::PositionConfiguration))
+        .def(init<>())
+#else
+    object positionconfiguration = class_<PyPositionConfiguration, OPENRAVE_SHARED_PTR<PyPositionConfiguration> >("PositionConfiguration", DOXY_CLASS(KinBody::PositionConfiguration))
+#endif
+        .def_readwrite("_id", &PyPositionConfiguration::_id)
+        .def_readwrite("name",&PyPositionConfiguration::name)
+        .def_readwrite("jointConfigurationStates",&PyPositionConfiguration::jointConfigurationStates)
+        .def("__str__", &PyPositionConfiguration::__str__)
+        .def("__eq__", &PyPositionConfiguration::__eq__)
+        .def("__ne__", &PyPositionConfiguration::__ne__)
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+            .def("SerializeJSON", &PyPositionConfiguration::SerializeJSON,
+             "unitScale"_a = 1.0,
+             "options"_a = py::none_(),
+             DOXY_FN(KinBody::PositionConfiguration, SerializeJSON)
+             )
+        .def("DeserializeJSON", &PyPositionConfiguration::DeserializeJSON,
+             "obj"_a,
+             "unitScale"_a = 1.0,
+             "options"_a = py::none_(),
+             DOXY_FN(KinBody::PositionConfiguration, DeserializeJSON)
+             )
+#else
+        .def("SerializeJSON", &PyPositionConfiguration::SerializeJSON, PyPositionConfiguration_SerializeJSON_overloads(PY_ARGS("unitScale", "options") DOXY_FN(KinBody::PositionConfiguration, SerializeJSON)))
+        .def("DeserializeJSON", &PyPositionConfiguration::DeserializeJSON, PyPositionConfiguration_DeserializeJSON_overloads(PY_ARGS("obj", "unitScale", "options") DOXY_FN(KinBody::PositionConfiguration, DeserializeJSON)))
+#endif
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+            .def(py::pickle(
+            [](const PyPositionConfiguration &pyPositionConfiguration) {
+                // __getstate__
+                return PositionConfiguration_pickle_suite::getstate(pyPositionConfiguration);
+            },
+            [](py::tuple state) {
+                PyPositionConfiguration &pyPositionConfiguration;
+                PositionConfiguration_pickle_suite::setstate(pyPositionConfiguration, state);
+                return pyPositionConfiguration;
+            }))
+        .def("__copy__",
+            [](const PyPositionConfiguration& self) {
+                return self;
+            })
+        .def("__deepcopy__",
+            [](const PyPositionConfiguration &pyPositionConfiguration, const py::dict& memo) {
+                auto state = PositionConfiguration_pickle_suite::getstate(pyPositionConfiguration);
+                PyPositionConfiguration pyPositionConfiguration_new;
+                PositionConfiguration_pickle_suite::setstate(pyPositionConfiguration_new, state);
+                return pyPositionConfiguration_new;
+            })
+#else
+        .def_pickle(PositionConfiguration_pickle_suite())
 #endif
     ;
 

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -2170,6 +2170,7 @@ KinBody::PositionConfiguration::JointConfigurationStatePtr PyPositionConfigurati
     if( !IS_PYTHONOBJECT_NONE(jointName) ) {
         jointConfigurationState->jointName = py::extract<std::string>(jointName);
     }
+    jointConfigurationState->jointAxis = jointAxis;
     jointConfigurationState->jointValue = jointValue;
     if( !IS_PYTHONOBJECT_NONE(connectedBodyName) ) {
         jointConfigurationState->connectedBodyName = py::extract<std::string>(connectedBodyName);
@@ -2201,7 +2202,7 @@ std::string PyPositionConfiguration_JointConfigurationState::__str__()
     if( !IS_PYTHONOBJECT_NONE(jointName) ) {
         ss << (const std::string&) py::extract<std::string>(jointName);
     }
-    ss << "\" jointValue=" << jointValue << " connectedBodyName=\"";
+    ss << "\" jointAxis=" << jointAxis << " jointValue=" << jointValue << " connectedBodyName=\"";
     if( !IS_PYTHONOBJECT_NONE(connectedBodyName) ) {
         ss << (const std::string&) py::extract<std::string>(connectedBodyName);
     }
@@ -2228,6 +2229,7 @@ void PyPositionConfiguration_JointConfigurationState::_Update(const KinBody::Pos
 {
     _id = ConvertStringToUnicode(jointConfigurationState._id);
     jointName = ConvertStringToUnicode(jointConfigurationState.jointName);
+    jointAxis = jointConfigurationState.jointAxis;
     jointValue = jointConfigurationState.jointValue;
     connectedBodyName = ConvertStringToUnicode(jointConfigurationState.connectedBodyName);
 }
@@ -4598,13 +4600,14 @@ class PositionConfiguration_JointConfigurationState_pickle_suite
 public:
     static py::tuple getstate(const PyPositionConfiguration_JointConfigurationState& r)
     {
-        return py::make_tuple(r._id, r.jointName, r.jointValue, r.connectedBodyName);
+        return py::make_tuple(r._id, r.jointName, r.jointAxis, r.jointValue, r.connectedBodyName);
     }
     static void setstate(PyPositionConfiguration_JointConfigurationState& r, py::tuple state) {
         r._id = state[0];
         r.jointName = state[1];
-        r.jointValue = py::extract<double>(state[2]);
-        r.connectedBodyName = state[3];
+        r.jointAxis = py::extract<int>(state[2]);
+        r.jointValue = py::extract<double>(state[3]);
+        r.connectedBodyName = state[4];
     }
 };
 
@@ -5253,6 +5256,7 @@ void init_openravepy_kinbody()
 #endif
         .def_readwrite("_id", &PyPositionConfiguration_JointConfigurationState::_id)
         .def_readwrite("jointName",&PyPositionConfiguration_JointConfigurationState::jointName)
+        .def_readwrite("jointAxis",&PyPositionConfiguration_JointConfigurationState::jointAxis)
         .def_readwrite("jointValue",&PyPositionConfiguration_JointConfigurationState::jointValue)
         .def_readwrite("connectedBodyName",&PyPositionConfiguration_JointConfigurationState::connectedBodyName)
         .def("__str__", &PyPositionConfiguration_JointConfigurationState::__str__)

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -4103,6 +4103,11 @@ object PyKinBody::GetNonAdjacentLinks(int adjacentoptions) const
     return ononadjacent;
 }
 
+bool PyKinBody::AreAdjacentLinks(int linkindex0, int linkindex1) const
+{
+    return _pbody->AreAdjacentLinks(linkindex0, linkindex1);
+}
+
 void PyKinBody::SetAdjacentLinks(int linkindex0, int linkindex1)
 {
     _pbody->SetAdjacentLinks(linkindex0, linkindex1);
@@ -5953,6 +5958,7 @@ void init_openravepy_kinbody()
                          .def("GetXMLFilename",&PyKinBody::GetURI, DOXY_FN(InterfaceBase,GetURI))
                          .def("GetNonAdjacentLinks",GetNonAdjacentLinks1, DOXY_FN(KinBody,GetNonAdjacentLinks))
                          .def("GetNonAdjacentLinks",GetNonAdjacentLinks2, PY_ARGS("adjacentoptions") DOXY_FN(KinBody,GetNonAdjacentLinks))
+                         .def("AreAdjacentLinks",&PyKinBody::AreAdjacentLinks, PY_ARGS("linkindex0", "linkindex1") DOXY_FN(KinBody,AreAdjacentLinks))
                          .def("SetAdjacentLinks",&PyKinBody::SetAdjacentLinks, PY_ARGS("linkindex0", "linkindex1") DOXY_FN(KinBody,SetAdjacentLinks))
                          .def("SetAdjacentLinksCombinations",&PyKinBody::SetAdjacentLinksCombinations, PY_ARGS("linkIndices") DOXY_FN(KinBody,SetAdjacentLinksCombinations))
                          .def("GetAdjacentLinks",&PyKinBody::GetAdjacentLinks, DOXY_FN(KinBody,GetAdjacentLinks))

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -2490,6 +2490,16 @@ KinBody::KinBodyInfoPtr PyKinBody::PyKinBodyInfo::GetKinBodyInfo() const {
     pInfo->_isRobot = _isRobot;
     pInfo->_isPartial = _isPartial;
 
+    pInfo->_vNonSelfCollidingPositionConfigurations.clear();
+    if (!IS_PYTHONOBJECT_NONE(_vNonSelfCollidingPositionConfigurations)) {
+        for (int positionConfigurationIndex = 0; positionConfigurationIndex < len(_vNonSelfCollidingPositionConfigurations); ++positionConfigurationIndex) {
+            PyPositionConfigurationPtr pyPositionConfiguration = py::extract<PyPositionConfigurationPtr>(_vNonSelfCollidingPositionConfigurations[positionConfigurationIndex]);
+            if (!!pyPositionConfiguration) {
+                pInfo->_vNonSelfCollidingPositionConfigurations.push_back(pyPositionConfiguration->GetPositionConfiguration());
+            }
+        }
+    }
+
     pInfo->_mReadableInterfaces = ExtractReadableInterfaces(_readableInterfaces);
     return pInfo;
 }
@@ -2549,6 +2559,14 @@ void PyKinBody::PyKinBodyInfo::_Update(const KinBody::KinBodyInfo& info) {
     _isRobot = info._isRobot;
     _isPartial = info._isPartial;
     _dofValues = ReturnDOFValues(info._dofValues);
+
+    py::list vNonSelfCollidingPositionConfigurations;
+    for( const KinBody::PositionConfigurationPtr& positionConfiguration : info._vNonSelfCollidingPositionConfigurations ) {
+        PyPositionConfiguration pyPositionConfiguration(*positionConfiguration);
+        vNonSelfCollidingPositionConfigurations.append(pyPositionConfiguration);
+    }
+    _vNonSelfCollidingPositionConfigurations = vNonSelfCollidingPositionConfigurations;
+
     _readableInterfaces = ReturnReadableInterfaces(info._mReadableInterfaces);
 }
 

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -2825,6 +2825,13 @@ object PyKinBody::GetDOFVelocities(object oindices) const
     return toPyArray(values);
 }
 
+object PyKinBody::GetPositionConfiguration() const
+{
+    KinBody::PositionConfiguration positionConfiguration;
+    _pbody->GetPositionConfiguration(positionConfiguration);
+    return object(PyPositionConfigurationPtr(new PyPositionConfiguration(positionConfiguration)));
+}
+
 object PyKinBody::GetDOFLimits() const
 {
     std::vector<dReal> vlower, vupper;
@@ -5618,6 +5625,7 @@ void init_openravepy_kinbody()
                          .def("GetDOFValues",getdofvalues2,PY_ARGS("indices") DOXY_FN(KinBody,GetDOFValues))
                          .def("GetDOFVelocities",getdofvelocities1, DOXY_FN(KinBody,GetDOFVelocities))
                          .def("GetDOFVelocities",getdofvelocities2, PY_ARGS("indices") DOXY_FN(KinBody,GetDOFVelocities))
+                         .def("GetPositionConfiguration",&PyKinBody::GetPositionConfiguration,DOXY_FN(KinBody,GetPositionConfiguration))
                          .def("GetDOFLimits",getdoflimits1, DOXY_FN(KinBody,GetDOFLimits))
                          .def("GetDOFLimits",getdoflimits2, PY_ARGS("indices") DOXY_FN(KinBody,GetDOFLimits))
                          .def("GetDOFVelocityLimits",getdofvelocitylimits1, DOXY_FN(KinBody,GetDOFVelocityLimits))

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -1591,6 +1591,13 @@ bool PyRobotBase::Init(object olinkinfos, object ojointinfos, object omanipinfos
     return _probot->Init(vlinkinfos, vjointinfos, vmanipinfos, vattachedsensorinfos, uri);
 }
 
+object PyRobotBase::GetPositionConfiguration() const
+{
+    KinBody::PositionConfiguration positionConfiguration;
+    _probot->GetPositionConfiguration(positionConfiguration);
+    return object(PyPositionConfigurationPtr(new PyPositionConfiguration(positionConfiguration)));
+}
+
 object PyRobotBase::GetManipulators()
 {
     py::list manips;
@@ -2550,6 +2557,7 @@ void init_openravepy_robot()
 #else
                        .def("Init", initrobot, Init_overloads(PY_ARGS("linkinfos", "jointinfos", "manipinfos", "attachedsensorinfos", "uri") DOXY_FN(RobotBase, Init)))
 #endif
+                       .def("GetPositionConfiguration",&PyRobotBase::GetPositionConfiguration, DOXY_FN(RobotBase,GetPositionConfiguration))
                        .def("GetManipulators",GetManipulators1, DOXY_FN(RobotBase,GetManipulators))
                        .def("GetManipulators",GetManipulators2, PY_ARGS("manipname") DOXY_FN(RobotBase,GetManipulators))
                        .def("GetManipulator",&PyRobotBase::GetManipulator,PY_ARGS("manipname") "Return the manipulator whose name matches")

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -5364,8 +5364,26 @@ int8_t KinBody::DoesDOFAffectLink(int dofindex, int linkindex ) const
 void KinBody::SetNonCollidingConfiguration()
 {
     _ResetInternalCollisionCache();
+
+    PositionConfigurationPtr positionConfiguration(new PositionConfiguration());
+    GetPositionConfiguration(*positionConfiguration);
+    positionConfiguration->name = "_configuration_added_by_SetNonCollidingConfiguration_";
+
+    std::vector<Transform> linkTransforms;
     vector<dReal> vdoflastsetvalues;
-    //GetLinkTransformations(_vInitialLinkTransformations, vdoflastsetvalues);
+    GetLinkTransformations(linkTransforms, vdoflastsetvalues);
+
+    // Overwrites an entry in _vNonSelfCollidingPositionConfigurationsAndLinkTransformations if already exists under the same name
+    for( PositionConfigurationAndLinkTransformations& positionConfigurationAndLinkTransformations : _vNonSelfCollidingPositionConfigurationsAndLinkTransformations ) {
+        if( positionConfigurationAndLinkTransformations.first->name == positionConfiguration->name ) {
+            positionConfigurationAndLinkTransformations.first.swap(positionConfiguration);
+            positionConfigurationAndLinkTransformations.second.swap(linkTransforms);
+            return;
+        }
+    }
+
+    // Adds a new entry
+    _vNonSelfCollidingPositionConfigurationsAndLinkTransformations.emplace_back(positionConfiguration, linkTransforms);
 }
 
 void KinBody::_ResetInternalCollisionCache()

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -890,6 +890,21 @@ void KinBody::GetDOFVelocities(std::vector<dReal>& v, const std::vector<int>& do
     }
 }
 
+void KinBody::GetPositionConfiguration(PositionConfiguration& positionConfiguration) const
+{
+    positionConfiguration.jointConfigurationStates.clear();
+    positionConfiguration.jointConfigurationStates.reserve(GetDOF());
+    for( JointPtr joint : _vDOFOrderedJoints ) {
+        for( int jointAxis = 0; jointAxis < joint->GetDOF(); ++jointAxis ) {
+            PositionConfiguration::JointConfigurationState jointConfigurationState;
+            jointConfigurationState.jointName = joint->GetName();
+            jointConfigurationState.jointAxis = jointAxis;
+            jointConfigurationState.jointValue = joint->GetValue(jointAxis);
+            positionConfiguration.jointConfigurationStates.push_back(jointConfigurationState);
+        }
+    }
+}
+
 void KinBody::GetDOFLimits(std::vector<dReal>& vLowerLimit, std::vector<dReal>& vUpperLimit, const std::vector<int>& dofindices) const
 {
     if( dofindices.size() == 0 ) {

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -4866,32 +4866,6 @@ void KinBody::_ComputeInternalInformation()
     }
 
     _nHierarchyComputed = 2;
-    /*
-    // because of mimic joints, need to call SetDOFValues at least once, also use this to check for links that are off
-    {
-        vector<Transform> vprevtrans, vnewtrans;
-        vector<dReal> vprevdoflastsetvalues, vnewdoflastsetvalues;
-        GetLinkTransformations(vprevtrans, vprevdoflastsetvalues);
-        vector<dReal> vcurrentvalues;
-        // unfortunately if SetDOFValues is overloaded by the robot, it could call the robot's _UpdateGrabbedBodies, which is a problem during environment cloning since the grabbed bodies might not be initialized. Therefore, call KinBody::SetDOFValues
-        GetDOFValues(vcurrentvalues);
-        std::vector<GrabbedPtr> vGrabbedBodies; vGrabbedBodies.swap(_vGrabbedBodies); // swap to get rid of _vGrabbedBodies
-        KinBody::SetDOFValues(vcurrentvalues,CLA_CheckLimits, std::vector<int>());
-        vGrabbedBodies.swap(_vGrabbedBodies); // swap back
-        GetLinkTransformations(vnewtrans, vnewdoflastsetvalues);
-        for(size_t i = 0; i < vprevtrans.size(); ++i) {
-            if( TransformDistanceFast(vprevtrans[i],vnewtrans[i]) > 1e-5 ) {
-                RAVELOG_VERBOSE(str(boost::format("link %d has different transformation after SetDOFValues (error=%f), this could be due to mimic joint equations kicking into effect.")%_veclinks.at(i)->GetName()%TransformDistanceFast(vprevtrans[i],vnewtrans[i])));
-            }
-        }
-        for(int i = 0; i < GetDOF(); ++i) {
-            if( vprevdoflastsetvalues.at(i) != vnewdoflastsetvalues.at(i) ) {
-                RAVELOG_VERBOSE(str(boost::format("dof %d has different values after SetDOFValues %d!=%d, this could be due to mimic joint equations kicking into effect.")%i%vprevdoflastsetvalues.at(i)%vnewdoflastsetvalues.at(i)));
-            }
-        }
-        _vInitialLinkTransformations = vnewtrans;
-    }
-    */
     {
         KinBodyStateSaver linkTransformSaver(shared_kinbody(), Save_LinkTransformation);
         vector<dReal> dofValues;

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2960,4 +2960,14 @@ bool KinBody::PositionConfiguration::JointConfigurationState::operator!=(const K
     return !operator==(other);
 }
 
+std::string KinBody::PositionConfiguration::JointConfigurationState::GetResolvedJointName() const
+{
+    if( connectedBodyName.empty() ) {
+        return jointName;
+    }
+    else {
+        return connectedBodyName + "_" + jointName;
+    }
+}
+
 }

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2929,7 +2929,9 @@ void KinBody::PositionConfiguration::JointConfigurationState::SerializeJSON(rapi
     }
     OpenRAVE::orjson::SetJsonValueByKey(value, "jointName", jointName, allocator);
     OpenRAVE::orjson::SetJsonValueByKey(value, "jointValue", jointValue, allocator);
-    OpenRAVE::orjson::SetJsonValueByKey(value, "connectedBodyName", connectedBodyName, allocator);
+    if( !connectedBodyName.empty() ) {
+        OpenRAVE::orjson::SetJsonValueByKey(value, "connectedBodyName", connectedBodyName, allocator);
+    }
 }
 
 void KinBody::PositionConfiguration::JointConfigurationState::DeserializeJSON(const rapidjson::Value& value, dReal fUnitScale, int options)

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2918,6 +2918,7 @@ void KinBody::PositionConfiguration::JointConfigurationState::Reset()
 {
     _id.clear();
     jointName.clear();
+    jointAxis = 0;
     jointValue = 0.0;
     connectedBodyName.clear();
 }
@@ -2928,6 +2929,7 @@ void KinBody::PositionConfiguration::JointConfigurationState::SerializeJSON(rapi
         OpenRAVE::orjson::SetJsonValueByKey(value, "id", _id, allocator);
     }
     OpenRAVE::orjson::SetJsonValueByKey(value, "jointName", jointName, allocator);
+    OpenRAVE::orjson::SetJsonValueByKey(value, "jointAxis", jointAxis, allocator);
     OpenRAVE::orjson::SetJsonValueByKey(value, "jointValue", jointValue, allocator);
     if( !connectedBodyName.empty() ) {
         OpenRAVE::orjson::SetJsonValueByKey(value, "connectedBodyName", connectedBodyName, allocator);
@@ -2939,6 +2941,7 @@ void KinBody::PositionConfiguration::JointConfigurationState::DeserializeJSON(co
     Reset();
     OpenRAVE::orjson::LoadJsonValueByKey(value, "id", _id);
     OpenRAVE::orjson::LoadJsonValueByKey(value, "jointName", jointName);
+    OpenRAVE::orjson::LoadJsonValueByKey(value, "jointAxis", jointAxis);
     OpenRAVE::orjson::LoadJsonValueByKey(value, "jointValue", jointValue);
     OpenRAVE::orjson::LoadJsonValueByKey(value, "connectedBodyName", connectedBodyName);
 }
@@ -2947,6 +2950,7 @@ bool KinBody::PositionConfiguration::JointConfigurationState::operator==(const K
 {
     static constexpr dReal jointValueEpsilon = 1.0e-6;
     return jointName == other.jointName
+           && jointAxis == other.jointAxis
            && connectedBodyName == other.connectedBodyName
            && OpenRAVE::RaveFabs(jointValue - other.jointValue) < jointValueEpsilon;
 }

--- a/src/libopenrave/kinbodyjoint.cpp
+++ b/src/libopenrave/kinbodyjoint.cpp
@@ -2854,5 +2854,104 @@ void KinBody::MimicInfo::DeserializeJSON(const rapidjson::Value& value, dReal fU
     orjson::LoadJsonValueByKey(value, "equations", _equations);
 }
 
+void KinBody::PositionConfiguration::Reset()
+{
+    _id.clear();
+    name.clear();
+    jointConfigurationStates.clear();
+}
+
+void KinBody::PositionConfiguration::SerializeJSON(rapidjson::Value& value, rapidjson::Document::AllocatorType& allocator, dReal fUnitScale, int options) const
+{
+    if( !value.IsObject() ) {
+        value.SetObject();
+    }
+
+    rapidjson::Value rJointConfigurationStates;
+    rJointConfigurationStates.SetArray();
+    rJointConfigurationStates.Reserve(jointConfigurationStates.size(), allocator);
+    for( const JointConfigurationState& jointConfigurationState : jointConfigurationStates ) {
+        rapidjson::Value rJointConfigurationState;
+        rJointConfigurationState.SetObject();
+        jointConfigurationState.SerializeJSON(rJointConfigurationState, allocator, fUnitScale, options);
+        rJointConfigurationStates.PushBack(rJointConfigurationState, allocator);
+    }
+
+    if( !_id.empty() ) {
+        OpenRAVE::orjson::SetJsonValueByKey(value, "id", _id, allocator);
+    }
+    OpenRAVE::orjson::SetJsonValueByKey(value, "name", name, allocator);
+    OpenRAVE::orjson::SetJsonValueByKey(value, "jointConfigurationStates", rJointConfigurationStates, allocator);
+}
+
+void KinBody::PositionConfiguration::DeserializeJSON(const rapidjson::Value& value, dReal fUnitScale, int options)
+{
+    Reset();
+    OpenRAVE::orjson::LoadJsonValueByKey(value, "id", _id);
+    OpenRAVE::orjson::LoadJsonValueByKey(value, "name", name);
+
+    if( value.HasMember("jointConfigurationStates") && value["jointConfigurationStates"].IsArray() ) {
+        jointConfigurationStates.reserve(value["jointConfigurationStates"].GetArray().Size());
+        for( const rapidjson::Value& rJointConfigurationState : value["jointConfigurationStates"].GetArray() ) {
+            if( rJointConfigurationState.HasMember("jointName") && rJointConfigurationState.HasMember("jointValue") ) {
+                JointConfigurationState jointConfigurationState = JointConfigurationState();
+                jointConfigurationState.DeserializeJSON(rJointConfigurationState, fUnitScale, options);
+                jointConfigurationStates.push_back(jointConfigurationState);
+            }
+        }
+    }
+}
+
+bool KinBody::PositionConfiguration::operator==(const PositionConfiguration& other) const
+{
+    return _id == other._id
+           && name == other.name
+           && jointConfigurationStates == other.jointConfigurationStates;
+}
+
+bool KinBody::PositionConfiguration::operator!=(const PositionConfiguration& other) const
+{
+    return !operator==(other);
+}
+
+void KinBody::PositionConfiguration::JointConfigurationState::Reset()
+{
+    _id.clear();
+    jointName.clear();
+    jointValue = 0.0;
+    connectedBodyName.clear();
+}
+
+void KinBody::PositionConfiguration::JointConfigurationState::SerializeJSON(rapidjson::Value& value, rapidjson::Document::AllocatorType& allocator, dReal fUnitScale, int options) const
+{
+    if( !_id.empty() ) {
+        OpenRAVE::orjson::SetJsonValueByKey(value, "id", _id, allocator);
+    }
+    OpenRAVE::orjson::SetJsonValueByKey(value, "jointName", jointName, allocator);
+    OpenRAVE::orjson::SetJsonValueByKey(value, "jointValue", jointValue, allocator);
+    OpenRAVE::orjson::SetJsonValueByKey(value, "connectedBodyName", connectedBodyName, allocator);
+}
+
+void KinBody::PositionConfiguration::JointConfigurationState::DeserializeJSON(const rapidjson::Value& value, dReal fUnitScale, int options)
+{
+    Reset();
+    OpenRAVE::orjson::LoadJsonValueByKey(value, "id", _id);
+    OpenRAVE::orjson::LoadJsonValueByKey(value, "jointName", jointName);
+    OpenRAVE::orjson::LoadJsonValueByKey(value, "jointValue", jointValue);
+    OpenRAVE::orjson::LoadJsonValueByKey(value, "connectedBodyName", connectedBodyName);
+}
+
+bool KinBody::PositionConfiguration::JointConfigurationState::operator==(const KinBody::PositionConfiguration::JointConfigurationState& other) const
+{
+    static constexpr dReal jointValueEpsilon = 1.0e-6;
+    return jointName == other.jointName
+           && connectedBodyName == other.connectedBodyName
+           && OpenRAVE::RaveFabs(jointValue - other.jointValue) < jointValueEpsilon;
+}
+
+bool KinBody::PositionConfiguration::JointConfigurationState::operator!=(const KinBody::PositionConfiguration::JointConfigurationState& other) const
+{
+    return !operator==(other);
+}
 
 }

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -830,6 +830,9 @@ bool RobotBase::InitFromRobotInfo(const RobotBaseInfo& info)
     FOREACH(it, info._mReadableInterfaces) {
         SetReadableInterface(it->first, it->second);
     }
+
+    _vNonSelfCollidingPositionConfigurations = info._vNonSelfCollidingPositionConfigurations;  // Shallow copy
+
     return true;
 }
 

--- a/src/libopenrave/robot.cpp
+++ b/src/libopenrave/robot.cpp
@@ -831,7 +831,10 @@ bool RobotBase::InitFromRobotInfo(const RobotBaseInfo& info)
         SetReadableInterface(it->first, it->second);
     }
 
-    _vNonSelfCollidingPositionConfigurations = info._vNonSelfCollidingPositionConfigurations;  // Shallow copy
+    _vNonSelfCollidingPositionConfigurationsAndLinkTransformations.clear();
+    for( const PositionConfigurationPtr& positionConfiguration : info._vNonSelfCollidingPositionConfigurations ) {
+        _vNonSelfCollidingPositionConfigurationsAndLinkTransformations.emplace_back(positionConfiguration, std::vector<Transform>());  // Shallow copy
+    }
 
     return true;
 }


### PR DESCRIPTION
This patch addresses the problem that a robot link pair which is in a collision when a robot is at its initial pose or a pose that all DOF values are zeros is excluded from self collision checking unintentionally (regardless of whether the pair is marked as adjacent).

## How it happens

* Self collision checking is performed only on pairs listed in `robot.GetNonAdjacentLinks()`
* The list excludes robot link pairs which are in a self collision when links transformations are set to `_vInitialLinkTransformations`
* `_vInitialLinkTransformations` are set to link transforms of when a robot is added to an environment in `KinBody::_ComputeInternalInformation()`, 

## Changes made in this patch

1. Drops the assumption that a robot pose that all DOF values are zeros or an initial robot pose are non-self-colliding poses
2. Adds a new data structure `KinBody::PositionConfiguration` which represents a pose of a robot with arbitrary connected body active states
3. Adds a new parameter `nonSelfCollidingRobotConfigurations` in `KinBody`, which type is `List[PositionConfiguration]`. It's an empty list by default.

Note that this patch includes a compatibility-breaking change (the first item in the list above). Some robot models may need additional adjacent link pair specifications or an entry in `nonSelfCollidingRobotConfigurations`.
