### PR TITLE
[quick] fix uninitialized _bTrackActiveDOF

### DIFF
--- a/plugins/fclrave/fclmanagercache.h
+++ b/plugins/fclrave/fclmanagercache.h
@@ -167,7 +167,7 @@ class FCLCollisionManagerInstance : public boost::enable_shared_from_this<FCLCol
     };
 
 public:
-    FCLCollisionManagerInstance(FCLSpace& fclspace, BroadPhaseCollisionManagerPtr pmanager) : _fclspace(fclspace), pmanager(pmanager) {
+    FCLCollisionManagerInstance(FCLSpace& fclspace, BroadPhaseCollisionManagerPtr pmanager) : _fclspace(fclspace), pmanager(pmanager), _bTrackActiveDOF(false) {
         _lastSyncTimeStamp = OpenRAVE::utils::GetMilliTime();
     }
     ~FCLCollisionManagerInstance() {


### PR DESCRIPTION
In ``_GetEnvManager``, after ``p`` is newly created, ``_bTrackActiveDOF`` remains uninitialized until ``Synchronize`` is called where ``_bTrackActiveDOF`` is read.

In practice, ``_bTrackActiveDOF`` is used with ``_ptrackingbody`` and it is expired for ``_envmanagers``, so this fix does not change behavior of the system.

Thanks to @yoshikikanemoto for discovering the issue.

```
        EnvManagersMap::iterator it = _envmanagers.find(excludedBodyEnvIndices);
        if( it == _envmanagers.end() ) {
            FCLCollisionManagerInstancePtr p(new FCLCollisionManagerInstance(*_fclspace, _CreateManager()));
            vector<int8_t> vecExcludedBodyEnvIndices(GetEnv()->GetMaxEnvironmentBodyIndex() + 1, 0);
            for (int excludeBodyIndex : excludedBodyEnvIndices) {
                vecExcludedBodyEnvIndices.at(excludeBodyIndex) = 1;
            }

            p->InitEnvironment(vecExcludedBodyEnvIndices);
            it = _envmanagers.insert(EnvManagersMap::value_type(excludedBodyEnvIndices, p)).first;

            if ((int) _envmanagers.size() > _maxNumEnvManagers) {
                RAVELOG_VERBOSE_FORMAT("env=%s, exceeded previous max number of env managers, now %d.", GetEnv()->GetNameId()%_envmanagers.size());
                _maxNumEnvManagers = _envmanagers.size();
            }
        }
        it->second->EnsureBodies(_fclspace->GetEnvBodies());
        it->second->Synchronize();
```