### PR TITLE
WIP: remove user data on BodyRemoved

### DIFF
--- a/plugins/oderave/odespace.h
+++ b/plugins/oderave/odespace.h
@@ -200,6 +200,7 @@ public:
 
             _geometrycallback.reset();
             _staticcallback.reset();
+            _bodyremovedcallback.reset();
         }
 
         KinBodyPtr GetBody() {
@@ -215,7 +216,7 @@ public:
         ///< the pointer to this Link is the userdata
         vector<dJointID> vjoints;
         vector<dJointFeedback> vjointfeedback;
-        OpenRAVE::UserDataPtr _geometrycallback, _staticcallback;
+        OpenRAVE::UserDataPtr _geometrycallback, _staticcallback, _bodyremovedcallback;
         boost::weak_ptr<ODESpace> _odespace;
 
         dSpaceID space;                             ///< space that contanis all the collision objects of this chain
@@ -482,6 +483,7 @@ private:
         if( _bUsingPhysics ) {
             pinfo->_staticcallback = pbody->RegisterChangeCallback(KinBody::Prop_LinkStatic|KinBody::Prop_LinkDynamics, boost::bind(&ODESpace::_ResetKinBodyCallback,boost::bind(&OpenRAVE::utils::sptr_from<ODESpace>, weak_space()),boost::weak_ptr<KinBody const>(pbody)));
         }
+        pinfo->_bodyremovedcallback = pbody->RegisterChangeCallback(KinBody::Prop_BodyRemoved, boost::bind(&ODESpace::RemoveUserData, boost::bind(&OpenRAVE::utils::sptr_from<ODESpace>, weak_space()), boost::bind(&OpenRAVE::utils::sptr_from<const KinBody>, boost::weak_ptr<const KinBody>(pbody))));
 
         pbody->SetUserData(_userdatakey, pinfo);
         _setInitializedBodies.insert(pbody);
@@ -511,7 +513,7 @@ private:
         return _geometrygroup;
     }
 
-    void RemoveUserData(KinBodyPtr pbody)
+    void RemoveUserData(KinBodyConstPtr pbody)
     {
         if( !!pbody ) {
             bool bremoved = pbody->RemoveUserData(_userdatakey);


### PR DESCRIPTION
`ODESpace::KinBodyInfo::vlinks` contains `KinBody::LinkWeakPtr` and it is used in `ODESpace::_Synchronize`. When a kinbody in openrave env is changed (e.g. Remove -> Clone -> Add), a `KinBody::LinkWeakPtr` stored in `ODESpace::KinBodyInfo::vlinks` becomes a null pointer so assertion happens in `ODESpace::_Synchronize`. We need to remove user data in that situation so that `ODESpace::GetCreateInfo` calls `InitKinBody` and update `ODESpace::KinBodyInfo::vlinks`. We do the same thing in fclspace.

## note to self
When we sync environment A to environment B and both environment have a same name kinbody but they have different KinematicsGeometryHash, we remove the kinbody from B and then clone the kinbody in A to the kinbody in B and then add the kinbody to B. So kinbody's user data is not cleared and kept. However `ODESpace::GetCreateInfo` depends user data to judge whether we use cached `ODESpace::KinBodyInfo` or we update `ODESpace::KinBodyInfo`, so we needed to clear user data.