### PR TITLE
Remove unnecessary copy constructor definitions to suppress warning (-Wdeprecated-copy)

### DIFF
--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -74,9 +74,6 @@ class OPENRAVE_API ElectricMotorActuatorInfo : public InfoBase
 public:
     ElectricMotorActuatorInfo() {
     };
-    ElectricMotorActuatorInfo(const ElectricMotorActuatorInfo& other) {
-        *this = other;
-    }
     bool operator==(const ElectricMotorActuatorInfo& other) const {
         return model_type == other.model_type
                && assigned_power_rating == other.assigned_power_rating
@@ -338,9 +335,6 @@ public:
     {
 public:
         GeometryInfo() {
-        }
-        GeometryInfo(const GeometryInfo& other) {
-            *this = other;
         }
         bool operator==(const GeometryInfo& other) const {
             return _t == other._t
@@ -809,9 +803,6 @@ protected:
 public:
         LinkInfo() {
         };
-        LinkInfo(const LinkInfo& other) {
-            *this = other;
-        }
         bool operator==(const LinkInfo& other) const;
         bool operator!=(const LinkInfo& other) const {
             return !operator==(other);
@@ -1309,9 +1300,6 @@ private:
 public:
         MimicInfo() {
         };
-        MimicInfo(const MimicInfo& other) {
-            *this = other;
-        }
 
         void Reset() override;
         void SerializeJSON(rapidjson::Value& value, rapidjson::Document::AllocatorType& allocator, dReal fUnitScale, int options=0) const override;
@@ -1370,9 +1358,6 @@ public:
     {
 public:
         JointInfo() {
-        }
-        JointInfo(const JointInfo& other) {
-            *this = other;
         }
         bool operator==(const JointInfo& other) const;
         bool operator!=(const JointInfo& other) const {
@@ -2042,9 +2027,6 @@ private:
 public:
         GrabbedInfo() {
         }
-        GrabbedInfo(const GrabbedInfo& other) {
-            *this = other;
-        }
         bool operator==(const GrabbedInfo& other) const {
             return _id == other._id
                    && _grabbedname == other._grabbedname
@@ -2179,9 +2161,6 @@ private:
     {
 public:
         KinBodyInfo() {
-        }
-        KinBodyInfo(const KinBodyInfo& other) {
-            *this = other;
         }
         bool operator==(const KinBodyInfo& other) const;
         bool operator!=(const KinBodyInfo& other) const {

--- a/include/openrave/robot.h
+++ b/include/openrave/robot.h
@@ -38,9 +38,6 @@ public:
 public:
         ManipulatorInfo() {
         }
-        ManipulatorInfo(const ManipulatorInfo& other) {
-            *this = other;
-        };
         bool operator==(const ManipulatorInfo& other) const {
             return _name == other._name
                    && _sBaseLinkName == other._sBaseLinkName
@@ -744,9 +741,6 @@ private:
     {
 public:
         ConnectedBodyInfo();
-        ConnectedBodyInfo(const ConnectedBodyInfo& other) {
-            *this = other;
-        };
         bool operator==(const ConnectedBodyInfo& other) const;
         bool operator!=(const ConnectedBodyInfo& other) const {
             return !operator==(other);
@@ -913,9 +907,6 @@ private:
 public:
         RobotBaseInfo() : KinBodyInfo() {
         }
-        RobotBaseInfo(const RobotBaseInfo& other) : KinBodyInfo(other) {
-            *this = other;
-        };
         bool operator==(const RobotBaseInfo& other) const;
         bool operator!=(const RobotBaseInfo& other) const {
             return !operator==(other);


### PR DESCRIPTION
This patch removes unnecessary explicit copy constructor definitions in kinbody.h and robot.h for which compilers emit the following warning:
```
install/include/openrave-0.92/openrave/robot.h: In copy constructor ‘OpenRAVE::RobotBase::RobotBaseInfo::RobotBaseInfo(const OpenRAVE::RobotBase::RobotBaseInfo&)’:
install/include/openrave-0.92/openrave/robot.h:917:21: warning: implicitly-declared ‘OpenRAVE::RobotBase::RobotBaseInfo& OpenRAVE::RobotBase::RobotBaseInfo::operator=(const OpenRAVE::RobotBase::RobotBaseInfo&)’ is deprecated [-Wdeprecated-copy]
  917 |             *this = other;
      |                     ^~~~~
install/include/openrave-0.92/openrave/robot.h:916:9: note: because ‘OpenRAVE::RobotBase::RobotBaseInfo’ has user-provided ‘OpenRAVE::RobotBase::RobotBaseInfo::RobotBaseInfo(const OpenRAVE::RobotBase::RobotBaseInfo&)’
  916 |         RobotBaseInfo(const RobotBaseInfo& other) : KinBodyInfo(other) {
      |         ^~~~~~~~~~~~~
install/include/openrave-0.92/openrave/robot.h: In member function ‘OpenRAVE::RobotBase::RobotBaseInfo& OpenRAVE::RobotBase::RobotBaseInfo::operator=(const OpenRAVE::RobotBase::RobotBaseInfo&)’:
install/include/openrave-0.92/openrave/robot.h:911:24: warning: implicitly-declared ‘OpenRAVE::KinBody::KinBodyInfo& OpenRAVE::KinBody::KinBodyInfo::operator=(const OpenRAVE::KinBody::KinBodyInfo&)’ is deprecated [-Wdeprecated-copy]
  911 |     class OPENRAVE_API RobotBaseInfo : public KinBodyInfo
      |
```

Possible solutions are:
1. Use default copy constructors
2. Add explicit definitions of copy assignment operators in addition to copy constructor definitions

This patch applies the first solution since default copy constructors/operators are good enough in this case and it is simpler.

Reference: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58407
