### PR TITLE
Relax manip info check 20220426

### DIFF
--- a/include/openrave/robot.h
+++ b/include/openrave/robot.h
@@ -38,22 +38,7 @@ public:
 public:
         ManipulatorInfo() {
         }
-        bool operator==(const ManipulatorInfo& other) const {
-            return _name == other._name
-                   && _sBaseLinkName == other._sBaseLinkName
-                   && _sIkChainEndLinkName == other._sIkChainEndLinkName
-                   && _sEffectorLinkName == other._sEffectorLinkName
-                   && _tLocalTool == other._tLocalTool
-                   && _vChuckingDirection == other._vChuckingDirection
-                   && _vdirection == other._vdirection
-                   && _sIkSolverXMLId == other._sIkSolverXMLId
-                   && _vGripperJointNames == other._vGripperJointNames
-                   && _grippername == other._grippername
-                   && _toolChangerConnectedBodyToolName == other._toolChangerConnectedBodyToolName
-                   && _toolChangerLinkName == other._toolChangerLinkName
-                   && _vRestrictGraspSetNames == other._vRestrictGraspSetNames
-                   && _id == other._id;
-        }
+        bool operator==(const ManipulatorInfo& other) const;
         bool operator!=(const ManipulatorInfo& other) const {
             return !operator==(other);
         }

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -71,6 +71,24 @@ void RobotBase::ManipulatorInfo::DeserializeJSON(const rapidjson::Value& value, 
     orjson::LoadJsonValueByKey(value, "restrictGraspSetNames", _vRestrictGraspSetNames);
 }
 
+bool RobotBase::ManipulatorInfo::operator==(const ManipulatorInfo& other) const
+{
+    return _name == other._name
+        && _sBaseLinkName == other._sBaseLinkName
+        && _sIkChainEndLinkName == other._sIkChainEndLinkName
+        && _sEffectorLinkName == other._sEffectorLinkName
+        && _tLocalTool == other._tLocalTool
+        && _vChuckingDirection == other._vChuckingDirection
+        && _vdirection == other._vdirection
+        && _sIkSolverXMLId == other._sIkSolverXMLId
+        && _vGripperJointNames == other._vGripperJointNames
+        && _grippername == other._grippername
+        && _toolChangerConnectedBodyToolName == other._toolChangerConnectedBodyToolName
+        && _toolChangerLinkName == other._toolChangerLinkName
+        && _vRestrictGraspSetNames == other._vRestrictGraspSetNames
+        && _id == other._id;
+}
+
 RobotBase::Manipulator::Manipulator(RobotBasePtr probot, const RobotBase::ManipulatorInfo& info) : _info(info), __probot(probot) {
 }
 RobotBase::Manipulator::~Manipulator() {

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -77,7 +77,7 @@ bool RobotBase::ManipulatorInfo::operator==(const ManipulatorInfo& other) const
         && _sBaseLinkName == other._sBaseLinkName
         && _sIkChainEndLinkName == other._sIkChainEndLinkName
         && _sEffectorLinkName == other._sEffectorLinkName
-        && TransformDistanceFast(_tLocalTool, other._tLocalTool) < g_fEpsilonLinear        
+        && TransformDistanceFast(_tLocalTool, other._tLocalTool) <= g_fEpsilonLinear
         && _vChuckingDirection == other._vChuckingDirection
         && _vdirection == other._vdirection
         && _sIkSolverXMLId == other._sIkSolverXMLId

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -77,7 +77,7 @@ bool RobotBase::ManipulatorInfo::operator==(const ManipulatorInfo& other) const
         && _sBaseLinkName == other._sBaseLinkName
         && _sIkChainEndLinkName == other._sIkChainEndLinkName
         && _sEffectorLinkName == other._sEffectorLinkName
-        && _tLocalTool == other._tLocalTool
+        && TransformDistanceFast(_tLocalTool, other._tLocalTool) < g_fEpsilonLinear        
         && _vChuckingDirection == other._vChuckingDirection
         && _vdirection == other._vdirection
         && _sIkSolverXMLId == other._sIkSolverXMLId


### PR DESCRIPTION
In https://github.com/rdiankov/openrave/pull/1087, ``returnTransformQuaternions`` was removed, and strict check for ``ManipulatorInfo::_tLocalTool`` started to fail on some cases, most likely due to quat<->rotation matrix conversions.
One example is
```
  _tLocalTool = {
    rot = {
      x = 0.99998573648162359,
      y = -0.0053205737414886564,
      z = 0.00034353668270234911,
      w = -0.00031671898242114895
    }
```
against 
```
  _tLocalTool = {
    rot = {
      x = 0.99998573648162359,
      y = -0.0053205737414886555,
      z = 0.00034353668270234905,
      w = -0.00031671898242114889
    },
```
In this MR, check for ``_tLocalTool`` is relaxed to allow epsilon differences using ``TransformDistanceFast``.