### PR TITLE
not using qhull outfile

### DIFF
--- a/plugins/grasper/graspermodule.cpp
+++ b/plugins/grasper/graspermodule.cpp
@@ -1660,7 +1660,7 @@ protected:
         boost::mutex::scoped_lock lock(s_QhullMutex);
 
         if( !outfile ) {
-            outfile = tmpfile();        // stdout from qhull code
+            // outfile = tmpfile();        // stdout from qhull code
         }
         if( !errfile ) {
             errfile = tmpfile();        // stderr, error messages from qhull code


### PR DESCRIPTION
I found deadlock in testplanningcommon.

for detail, see (paste to `base64 -d|mujin_gpg_decrypt.bash`)

```
hQIMA4yIa9T4gk7mARAAhKCfzFK/AlOc/Q3SxXJcvEIfahGXJ436jWib9GD6k9X7gNJWRrDMP501
gUJX0McXDaOdP6jC/gvbjihVPW2u7fFF4mSPx+yCVD35NMKGM8haENNiJ5NMWX8FjTGiS/6nlRt1
LqlXAe+AjSj0JPVfuHEDeRg3w627hevTyfU9laB9Ttz3eyrcPHeGhEwvS20KoXDwdoaA9a2kxa6y
QD2cRox2FeGshxoPosWamsuZaNeHajyukN9BFuKRlqBh7MoFm4+x0774uGFwZuii+1NppBAsRvI5
UPbOgLFzeuQdW1V9EHQbc1ZaMZk9t46WRdDTCwpsy89kByu2I+EAz72+vVBEmEviaezb2IHTaITI
UR31qhk7TL3l92xClg4VtcgxjwVVGQmv15YY2CAnq6sCJ9x8B0l/whQF7fg1fY1YnTT250YygmcK
vMx14SbWklZ0MxhxvMbiJnw0i+2VJAcojk8X7uaKpeA7NK1o3UE4GTshLWUADEZkefy9biofFUNG
c3E6QNyvKo4HMY4Fmq2Hpupt0TrBJN4St1/nXDFQZRXoULUJfayXI9fuJh34sHSoU+Jpn622BtCM
qzTgBKfenYCOzmLa9+kNfVzRpqa25tAqxDfZzERGx7RGTpZ+gabzHl/gPkZihRbTvnI9aoKfcaRU
oR1HWqZtK81EQvwKDdDSewFcW4JhyhwmM49hHn5gNP+ZxmhGxH9QkKjkJZhNacaN3oikPf3xWwYg
DhUz3rG688nGxjdecd7zN5Bf6wqI7dxJhGG5Xed6L3hz7tt3vBCvjyYkr2DX5q7VTI9i8iu23pEf
+f3CN8D20VAUXTwBWISXyiOX27xRT4/y4A==
```