### PR TITLE
Allow arithmetic operations on python `IkReturnAction`

### DIFF
--- a/python/bindings/openravepy_iksolver.cpp
+++ b/python/bindings/openravepy_iksolver.cpp
@@ -312,7 +312,7 @@ void init_openravepy_iksolver()
     ;
 
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
-    enum_<IkReturnAction>(m, "IkReturnAction" DOXY_ENUM(IkReturnAction))
+    enum_<IkReturnAction>(m, "IkReturnAction", py::arithmetic() DOXY_ENUM(IkReturnAction))
 #else
     enum_<IkReturnAction>("IkReturnAction" DOXY_ENUM(IkReturnAction))
 #endif


### PR DESCRIPTION
### Summary

This pull request adds a tag `py::arithmetic()` to `enum_` constructor of `IkReturnAction` to allow arithmetic operations so we can do, for example, `IkReturnAction.RejectCustomFilter | IkReturnAction.RejectJointLimits`.