### PR TITLE
fix: Make OSGLODLabel state set protection more robust

### DIFF
--- a/plugins/qtosgrave/osglodlabel.cpp
+++ b/plugins/qtosgrave/osglodlabel.cpp
@@ -56,8 +56,10 @@ OSGLODLabel::OSGLODLabel(const std::string& label, osg::ref_ptr<osgText::Font> f
     text->setFontResolution(128,128);
 
     // Override the cartoon shader with the default shader for text
-    osg::ref_ptr<osg::Program> program = new osg::Program;
-    text->getOrCreateStateSet()->setAttributeAndModes(program.get(), osg::StateAttribute::PROTECTED | osg::StateAttribute::ON);
+    osg::StateSet::AttributeList attributes = text->getOrCreateStateSet()->getAttributeList();
+    for (osg::StateSet::AttributeList::iterator it=attributes.begin(); it!=attributes.end(); ++it) {
+        text->getOrCreateStateSet()->setAttributeAndModes(it->second.first, it->second.second | osg::StateAttribute::PROTECTED);
+    }
 
     // Ensure that the text is drawn over any shape in the scene
     text->getOrCreateStateSet()->setMode(GL_LIGHTING, osg::StateAttribute::PROTECTED | osg::StateAttribute::OFF );


### PR DESCRIPTION
Possibly due to using newer versions of OpenSceneGraph, it has been observed that the rendering of `OSGLODLabel` breaks and yields black blocks instead of readable text.

This pull request aims to address this issue (and better protect against future `StateSet` intrusions) by refactoring the pre-existing attempt to protect against the cartoon shader's effects in `osglodlabel.cpp` into a more robust approach that protects all of the `OSGLODLabel`'s default `StateSet` attributes from upstream `StateSet`s such as those arising from the cartoon shader.