### PR TITLE
Better C++ conformance with Clang

### DIFF
--- a/include/openrave/collisionchecker.h
+++ b/include/openrave/collisionchecker.h
@@ -75,6 +75,8 @@ public:
         Reset();
     }
 
+    virtual ~CollisionReport() noexcept {}
+
     /// \brief resets the report structure for the next collision call
     ///
     /// depending on nKeepPrevious will keep previous data.

--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -1003,7 +1003,7 @@ protected:
         \param[out] useddofindices a vector of unique DOF indices targetted for the body
         \param[out] usedconfigindices for every used index, returns the first configuration space index it came from
      */
-    void ExtractUsedIndices(const char* pBodyName, int nBodyNameLength, int timederivative, std::vector<int>& useddofindices, std::vector<int>& usedconfigindices) const;
+    void ExtractUsedIndices(const char* pBodyName, size_t nBodyNameLength, int timederivative, std::vector<int>& useddofindices, std::vector<int>& usedconfigindices) const;
 
     /// \brief swaps the data between the two configuration specifications as efficiently as possible
     void Swap(ConfigurationSpecification& spec);

--- a/include/openrave/planner.h
+++ b/include/openrave/planner.h
@@ -528,9 +528,9 @@ protected:
     virtual bool serialize(std::ostream& O, int options=0) const;
 
     //@{ XML parsing functions, parses the default parameters
-    virtual ProcessElement startElement(const std::string& name, const AttributesList& atts);
-    virtual bool endElement(const std::string& name);
-    virtual void characters(const std::string& ch);
+    virtual ProcessElement startElement(const std::string& name, const AttributesList& atts) override;
+    virtual bool endElement(const std::string& name) override;
+    virtual void characters(const std::string& ch) override;
     std::stringstream _ss;         ///< holds the data read by characters
     boost::shared_ptr<std::stringstream> _sslocal;
     /// all the top-level XML parameter tags (lower case) that are handled by this parameter structure, should be registered in the constructor

--- a/include/openrave/robot.h
+++ b/include/openrave/robot.h
@@ -729,7 +729,7 @@ public:
 
         void Reset() override;
         void SerializeJSON(rapidjson::Value &value, rapidjson::Document::AllocatorType& allocator, dReal fUnitScale, int options) const override;
-        void DeserializeJSON(const rapidjson::Value &value, dReal fUnitScale, int options);
+        void DeserializeJSON(const rapidjson::Value &value, dReal fUnitScale, int options) override;
 
         /// \brief Updates the infos depending on the robot at the identity and zero position.
         void InitInfoFromBody(RobotBase& robot);
@@ -924,7 +924,7 @@ public:
         /// \brief release the body state. _pbody will not get restored on destruction
         ///
         /// After this call, it will still be possible to use \ref Restore.
-        virtual void Release();
+        virtual void Release() override;
 
 protected:
         RobotBasePtr _probot;
@@ -953,7 +953,7 @@ private:
         return PT_Robot;
     }
 
-    virtual void Destroy();
+    virtual void Destroy() override;
 
     /// \brief initializes a robot with links, joints, manipulators, and sensors
     ///
@@ -1242,10 +1242,10 @@ private:
     virtual void CalculateActiveAngularVelocityJacobian(int index, std::vector<dReal>& jacobian) const;
     virtual void CalculateActiveAngularVelocityJacobian(int index, boost::multi_array<dReal,2>& jacobian) const;
 
-    virtual const std::vector<int>& GetNonAdjacentLinks(int adjacentoptions=0) const;
+    virtual const std::vector<int>& GetNonAdjacentLinks(int adjacentoptions=0) const override;
 
     /// \brief \ref KinBody::SetNonCollidingConfiguration, also regrabs all bodies
-    virtual void SetNonCollidingConfiguration();
+    virtual void SetNonCollidingConfiguration() override;
 
     //@}
 
@@ -1308,17 +1308,17 @@ private:
 
         Do not call SimulationStep for the attached sensors in this function.
      */
-    virtual void SimulationStep(dReal fElapsedTime);
+    virtual void SimulationStep(dReal fElapsedTime) override;
 
     /// does not clone the grabbed bodies since it requires pointers from other bodies (that might not be initialized yet)
-    virtual void Clone(InterfaceBaseConstPtr preference, int cloningoptions);
+    virtual void Clone(InterfaceBaseConstPtr preference, int cloningoptions) override;
 
     /// \return true if this body is derived from RobotBase
     bool IsRobot() const override {
         return true;
     }
 
-    virtual void serialize(std::ostream& o, int options) const;
+    virtual void serialize(std::ostream& o, int options) const override;
 
     /// A md5 hash unique to the particular robot structure that involves manipulation and sensing components
     /// The serialization for the attached sensors will not involve any sensor specific properties (since they can change through calibration)
@@ -1363,7 +1363,7 @@ protected:
     /// \brief Called to notify the body that certain groups of parameters have been changed.
     ///
     /// This function in calls every registers calledback that is tracking the changes.
-    virtual void _PostprocessChangedParameters(uint32_t parameters);
+    virtual void _PostprocessChangedParameters(uint32_t parameters) override;
 
     virtual void _UpdateAttachedSensors();
 
@@ -1390,7 +1390,7 @@ protected:
     ConfigurationSpecification _activespec;
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_ROBOT_HASH;
     }
     virtual const char* GetKinBodyHash() const {

--- a/include/openrave/sensor.h
+++ b/include/openrave/sensor.h
@@ -213,7 +213,7 @@ public:
         LaserGeomData() : SensorGeometry("Laser"), min_range(0), max_range(0), time_increment(0), time_scan(0) {
             min_angle[0] = min_angle[1] = max_angle[0] = max_angle[1] = resolution[0] = resolution[1] = 0;
         }
-        virtual SensorType GetType() const {
+        virtual SensorType GetType() const override {
             return ST_Laser;
         }
 
@@ -257,7 +257,7 @@ public:
 public:
         CameraGeomData() : SensorGeometry("Camera"), width(0), height(0), measurement_time(1), gain(1), KK(intrinsics) {
         }
-        virtual SensorType GetType() const {
+        virtual SensorType GetType() const override {
             return ST_Camera;
         }
 
@@ -315,7 +315,7 @@ public:
 public:
         JointEncoderGeomData() : SensorGeometry("JointEncoder"), resolution(0) {
         }
-        virtual SensorType GetType() const {
+        virtual SensorType GetType() const override {
             return ST_JointEncoder;
         }
 
@@ -348,7 +348,7 @@ public:
                         0,0,0, 0,1,0,
                         0,0,0, 0,0,1}}) {
         }
-        virtual SensorType GetType() const {
+        virtual SensorType GetType() const override {
             return ST_Force6D;
         }
         bool operator==(const Readable& other) const override {
@@ -384,7 +384,7 @@ public:
 public:
         IMUGeomData() : SensorGeometry("IMU") {
         }
-        virtual SensorType GetType() const {
+        virtual SensorType GetType() const override {
             return ST_IMU;
         }
 
@@ -412,7 +412,7 @@ public:
 public:
         OdometryGeomData() : SensorGeometry("Odometry") {
         }
-        virtual SensorType GetType() const {
+        virtual SensorType GetType() const override {
             return ST_Odometry;
         }
 
@@ -442,7 +442,7 @@ public:
 public:
         TactileGeomData() : SensorGeometry("Tactile") {
         }
-        virtual SensorType GetType() const {
+        virtual SensorType GetType() const override {
             return ST_Tactile;
         }
 
@@ -493,7 +493,7 @@ public:
 public:
         ActuatorGeomData() : SensorGeometry("Actuator") {
         }
-        virtual SensorType GetType() const {
+        virtual SensorType GetType() const override {
             return ST_Actuator;
         }
 

--- a/src/libopenrave/configurationspecification.cpp
+++ b/src/libopenrave/configurationspecification.cpp
@@ -733,7 +733,7 @@ void ConfigurationSpecification::ExtractUsedIndices(KinBodyConstPtr body, std::v
     }
 }
 
-void ConfigurationSpecification::ExtractUsedIndices(const char* pBodyName, int nBodyNameLength, int timederivative, std::vector<int>& useddofindices, std::vector<int>& usedconfigindices) const
+void ConfigurationSpecification::ExtractUsedIndices(const char* pBodyName, size_t nBodyNameLength, int timederivative, std::vector<int>& useddofindices, std::vector<int>& usedconfigindices) const
 {
     // have to look through all groups since groups can contain the same body
     std::stringstream ss;

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -3675,7 +3675,7 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
 
                     // p''(t) = 6*a*t + 2*b. Check |p''(timeelapsed) - a1|.
                     dReal accelerationError = RaveFabs( (2*temp1 + temp2) - ddq1.at(idof) );
-                    OPENRAVE_ASSERT_OP_FORMAT(velocityError, <=, 100*g_fEpsilonCubic, "dof %d final acceleration is not consistent", idof, ORE_InvalidArguments);
+                    OPENRAVE_ASSERT_OP_FORMAT(accelerationError, <=, 100*g_fEpsilonCubic, "dof %d final acceleration is not consistent", idof, ORE_InvalidArguments);
                 }
             }
             break;
@@ -4084,7 +4084,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
             } // end switch maskinterpolation
 
             dReal dqscale = 1.0;  // TODO: write a correct description for this variable later
-            int iScaleIndex = -1; // TODO: write a correct description for this variable later
             dReal fitdiff = 1/(tnext - tprev);
             for( size_t idof = 0; idof < ndof; ++idof ) {
                 if( RaveFabs(dQ[idof]) > vConfigResolution[idof] * 1.01 ) {
@@ -4163,7 +4162,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
                     }
                     if( s < dqscale ) {
                         dqscale = s;
-                        iScaleIndex = (int)idof;
                     }
                 }
                 else {

--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -139,7 +139,7 @@ public:
             return !_bShutdown;
         }
 
-        const string& GetName() const {
+        const std::string& GetName() const {
             return ppluginname;
         }
         bool GetInfo(PLUGININFO& info) {
@@ -257,7 +257,7 @@ public:
         }
 
 
-        bool HasInterface(InterfaceType type, const string& name)
+        bool HasInterface(InterfaceType type, const std::string& name)
         {
             if( name.size() == 0 ) {
                 return false;
@@ -275,7 +275,7 @@ public:
         }
 
         InterfaceBasePtr CreateInterface(InterfaceType type, const std::string& name, const char* interfacehash, EnvironmentBasePtr penv) {
-            pair< InterfaceType, string> p(type,utils::ConvertToLowerCase(name));
+            std::pair<InterfaceType, std::string> p(type,utils::ConvertToLowerCase(name));
             if( _setBadInterfaces.find(p) != _setBadInterfaces.end() ) {
                 return InterfaceBasePtr();
             }

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -1648,7 +1648,6 @@ void RobotBase::Manipulator::serialize(std::ostream& o, int options, IkParameter
             FOREACH(itjoint, vjoints) {
                 tcur = tcur * (*itjoint)->GetInternalHierarchyLeftTransform() * (*itjoint)->GetInternalHierarchyRightTransform();
             }
-            tcur = tcur;
             // if 6D transform IK, then don't inlucde the local tool transform!
             if( !!(options & SO_Kinematics) || iktype != IKP_Transform6D ) {
                 tcur *= _info._tLocalTool;


### PR DESCRIPTION
Some of these warnings were issued when I tried to compile this against Clang, using its default set of warnings:

-Winconsistent-missing-override - Improperly labeled methods that override methods from base class

-Wno-non-virtual-dtor - Not defining a destructor to a derived class with virtual functions is actually undefined behaviour; gcc is lax in this but consulting with the standard shows that Clang is correct in issuing the warning.

-26db3539a: Self assignment

`string` was not prefixed with `std::` in a header file - not sure how this even compiled before, but Clang gives a compile error.

One unused variable was removed and one logging bug was discovered.