### PR TITLE
Static initialization in config specification

### DIFF
--- a/src/libopenrave/configurationspecification.cpp
+++ b/src/libopenrave/configurationspecification.cpp
@@ -22,7 +22,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/bind/bind.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/thread/once.hpp>
 
 using boost::placeholders::_1;
 using boost::placeholders::_2;
@@ -32,23 +31,17 @@ namespace OpenRAVE {
 static boost::array<std::string,5> s_vTimeDerivativeJoints = {{"joint_values", "joint_velocities", "joint_accelerations", "joint_jerks", "joint_snaps"}};
 static boost::array<std::string,5> s_vTimeDerivativeAffine = {{"affine_transform", "affine_velocities", "affine_accelerations", "affine_jerks", "affine_snaps"}};
 
-static std::set<std::string> s_setBodyGroupNames;
-static boost::once_flag _onceSetBodyGroupNames = BOOST_ONCE_INIT;
-
-static void _CreateSetBodyGroupNames()
-{
-    if( s_setBodyGroupNames.size() == 0 ) {
-        s_setBodyGroupNames.insert("joint_values");
-        s_setBodyGroupNames.insert("joint_velocities");
-        s_setBodyGroupNames.insert("joint_accelerations");
-        s_setBodyGroupNames.insert("joint_jerks");
-        s_setBodyGroupNames.insert("joint_torques");
-        s_setBodyGroupNames.insert("affine_transform");
-        s_setBodyGroupNames.insert("affine_velocities");
-        s_setBodyGroupNames.insert("affine_accelerations");
-        s_setBodyGroupNames.insert("affine_jerks");
-    }
-}
+static const std::set<std::string> s_setBodyGroupNames = {
+    "joint_values",
+    "joint_velocities",
+    "joint_accelerations",
+    "joint_jerks",
+    "joint_torques",
+    "affine_transform",
+    "affine_velocities",
+    "affine_accelerations",
+    "affine_jerks",
+};
 
 ConfigurationSpecification RaveGetAffineConfigurationSpecification(int affinedofs,KinBodyConstPtr pbody,const std::string& interpolation)
 {
@@ -719,8 +712,6 @@ void ConfigurationSpecification::ExtractUsedBodies(EnvironmentBasePtr env, std::
 
 void ConfigurationSpecification::ExtractUsedIndices(KinBodyConstPtr body, std::vector<int>& useddofindices, std::vector<int>& usedconfigindices) const
 {
-    boost::call_once(_CreateSetBodyGroupNames,_onceSetBodyGroupNames);
-
     // have to look through all groups since groups can contain the same body
     std::string bodyname = body->GetName();
     std::stringstream ss;
@@ -744,8 +735,6 @@ void ConfigurationSpecification::ExtractUsedIndices(KinBodyConstPtr body, std::v
 
 void ConfigurationSpecification::ExtractUsedIndices(const char* pBodyName, int nBodyNameLength, int timederivative, std::vector<int>& useddofindices, std::vector<int>& usedconfigindices) const
 {
-    boost::call_once(_CreateSetBodyGroupNames,_onceSetBodyGroupNames);
-
     // have to look through all groups since groups can contain the same body
     std::stringstream ss;
     useddofindices.resize(0);


### PR DESCRIPTION
Now that we target C++14, brace init of a set is possible and makes for more concise code.