### PR TITLE
Substitute mutexes, locks, and threads from boost to std

### DIFF
--- a/include/openrave/environment.h
+++ b/include/openrave/environment.h
@@ -24,7 +24,7 @@
 
 namespace OpenRAVE {
 
-typedef boost::recursive_try_mutex EnvironmentMutex;
+typedef std::recursive_mutex EnvironmentMutex;
 typedef EnvironmentMutex::scoped_lock EnvironmentLock;
 
 /// \brief used when adding interfaces to the environment

--- a/include/openrave/environment.h
+++ b/include/openrave/environment.h
@@ -25,7 +25,7 @@
 namespace OpenRAVE {
 
 typedef std::recursive_mutex EnvironmentMutex;
-typedef EnvironmentMutex::scoped_lock EnvironmentLock;
+typedef std::unique_lock<EnvironmentMutex> EnvironmentLock;
 
 /// \brief used when adding interfaces to the environment
 enum InterfaceAddMode

--- a/include/openrave/sensorsystem.h
+++ b/include/openrave/sensorsystem.h
@@ -229,10 +229,10 @@ protected:
 
     std::string _xmlid;
     BODIES _mapbodies;
-    boost::mutex _mutex;
+    std::mutex _mutex;
     uint64_t _expirationtime;     ///< expiration time in us
     bool _bShutdown;
-    boost::thread _threadUpdate;
+    std::thread _threadUpdate;
 };
 
 } // end namespace OpenRAVE

--- a/include/openrave/sensorsystem.h
+++ b/include/openrave/sensorsystem.h
@@ -22,6 +22,8 @@
 #ifndef OPENRAVE_SENSORSYSTEM_H
 #define OPENRAVE_SENSORSYSTEM_H
 
+#include <thread>
+
 namespace OpenRAVE {
 
 /** \brief <b>[interface]</b> Used to manage the creation and destruction of bodies. See \ref arch_sensorsystem.

--- a/plugins/basecontrollers/idealcontroller.cpp
+++ b/plugins/basecontrollers/idealcontroller.cpp
@@ -122,7 +122,7 @@ If SetDesired is called, only joint values will be set at every timestep leaving
         // (there's a race condition we're avoiding where a user calls SetDesired and then state savers revert the robot)
         if( !_bPause ) {
             RobotBasePtr probot = _probot.lock();
-            EnvironmentMutex::scoped_lock lockenv(probot->GetEnv()->GetMutex());
+            EnvironmentLock lockenv(probot->GetEnv()->GetMutex());
             _vecdesired = values;
             if( _nControlTransformation ) {
                 if( !!trans ) {
@@ -144,7 +144,7 @@ If SetDesired is called, only joint values will be set at every timestep leaving
     virtual bool SetPath(TrajectoryBaseConstPtr ptraj)
     {
         OPENRAVE_ASSERT_FORMAT0(!ptraj || GetEnv()==ptraj->GetEnv(), "trajectory needs to come from the same environment as the controller", ORE_InvalidArguments);
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         if( _bPause ) {
             RAVELOG_DEBUG("IdealController cannot start trajectories when paused\n");
             _ptraj.reset();
@@ -259,7 +259,7 @@ If SetDesired is called, only joint values will be set at every timestep leaving
         if( _bPause ) {
             return;
         }
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         TrajectoryBaseConstPtr ptraj = _ptraj; // because of multi-threading setting issues
         if( !!ptraj ) {
             RobotBasePtr probot = _probot.lock();
@@ -562,7 +562,7 @@ private:
     UserDataPtr _cblimits;
     ConfigurationSpecification _samplespec;
     boost::shared_ptr<ConfigurationSpecification::Group> _gjointvalues, _gtransform;
-    boost::mutex _mutex;
+    std::mutex _mutex;
 };
 
 ControllerBasePtr CreateIdealController(EnvironmentBasePtr penv, std::istream& sinput)

--- a/plugins/basecontrollers/idealvelocitycontroller.cpp
+++ b/plugins/basecontrollers/idealvelocitycontroller.cpp
@@ -40,7 +40,7 @@ public:
     virtual void Reset(int options)
     {
 //        if( !!_probot ) {
-//            EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+//            EnvironmentLock lock(GetEnv()->GetMutex());
 //            //_probot->GetDOFVelocities(_vPreviousVelocities,_dofindices);
 //        }
         _bVelocityMode = false;
@@ -55,7 +55,7 @@ public:
 
     virtual bool SetDesired(const std::vector<OpenRAVE::dReal>& values, TransformConstPtr trans) {
         OPENRAVE_ASSERT_OP(values.size(),==,_dofindices.size());
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         _vDesiredVelocities = values;
         std::vector<dReal> vallvelocities;

--- a/plugins/basesensors/basecamera.h
+++ b/plugins/basesensors/basecamera.h
@@ -227,7 +227,7 @@ public:
             return _bRenderData;
         }
         case CC_RenderDataOff: {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             _dataviewer.reset();
             _bRenderData = false;
             return _bRenderData;
@@ -239,7 +239,7 @@ public:
             _RenderGeometry();
             return _bRenderData;
         case CC_RenderGeometryOff: {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             _graphgeometry.reset();
             _bRenderGeometry = false;
             return _bRenderData;
@@ -281,7 +281,7 @@ public:
                     _vimagedata.resize(3*_pgeom->width*_pgeom->height);
                     if( GetEnv()->GetViewer()->GetCameraImage(_vimagedata, _pgeom->width, _pgeom->height, _trans, _pgeom->KK) ) {
                         // copy the data
-                        boost::mutex::scoped_lock lock(_mutexdata);
+                        std::lock_guard<std::mutex> lock(_mutexdata);
                         pdata->vimagedata = _vimagedata;
                         pdata->__stamp = GetEnv()->GetSimulationTime();
                         pdata->__trans = _trans;
@@ -313,7 +313,7 @@ public:
     virtual bool GetSensorData(SensorDataPtr psensordata)
     {
         if( _bPower &&( psensordata->GetType() == ST_Camera) ) {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             if( _pdata->vimagedata.size() > 0 ) {
                 *boost::dynamic_pointer_cast<CameraSensorData>(psensordata) = *_pdata;
                 return true;
@@ -456,7 +456,7 @@ protected:
     ViewerBasePtr _dataviewer;
     string _channelformat;
 
-    mutable boost::mutex _mutexdata;
+    mutable std::mutex _mutexdata;
 
     bool _bRenderGeometry, _bRenderData;
     bool _bPower;     ///< if true, gather data, otherwise don't

--- a/plugins/basesensors/baseflashlidar3d.h
+++ b/plugins/basesensors/baseflashlidar3d.h
@@ -195,7 +195,7 @@ public:
             _bRenderData = true;
             return _bRenderData;
         case CC_RenderDataOff: {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             _listGraphicsHandles.clear();
             _bRenderData = false;
             return _bRenderData;
@@ -207,7 +207,7 @@ public:
             _RenderGeometry();
             return _bRenderData;
         case CC_RenderGeometryOff: {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             _graphgeometry.reset();
             _bRenderGeometry = false;
             return _bRenderData;
@@ -232,7 +232,7 @@ public:
 
             {
                 // Lock the data mutex and fill with the range data (get all in one timestep)
-                boost::mutex::scoped_lock lock(_mutexdata);
+                std::lock_guard<std::mutex> lock(_mutexdata);
                 t = GetTransform();
                 _pdata->__trans = t;
                 _pdata->__stamp = GetEnv()->GetSimulationTime();
@@ -282,7 +282,7 @@ public:
 
                 {
                     // Lock the data mutex and fill the arrays used for rendering
-                    boost::mutex::scoped_lock lock(_mutexdata);
+                    std::lock_guard<std::mutex> lock(_mutexdata);
                     N = (int)_pdata->ranges.size();
                     vpoints.resize(N+1);
                     for(int i = 0; i < N; ++i)
@@ -341,7 +341,7 @@ public:
     virtual bool GetSensorData(SensorDataPtr psensordata)
     {
         if( psensordata->GetType() == ST_Laser ) {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             *boost::dynamic_pointer_cast<LaserSensorData>(psensordata) = *_pdata;
             return true;
         }
@@ -359,7 +359,7 @@ public:
     }
     bool _CollidingBodies(ostream& sout, istream& sinput)
     {
-        boost::mutex::scoped_lock lock(_mutexdata);
+        std::lock_guard<std::mutex> lock(_mutexdata);
         FOREACH(it, _databodyids) {
             sout << *it << " ";
         }
@@ -455,7 +455,7 @@ protected:
     GraphHandlePtr _graphgeometry;
     dReal _fTimeToScan;
 
-    boost::mutex _mutexdata;
+    std::mutex _mutexdata;
     bool _bRenderData, _bRenderGeometry, _bPower;
 
     friend class BaseFlashLidar3DXMLReader;

--- a/plugins/basesensors/baseforce6d.h
+++ b/plugins/basesensors/baseforce6d.h
@@ -165,7 +165,7 @@ public:
     virtual bool GetSensorData(SensorDataPtr psensordata) override
     {
         if( psensordata->GetType() == ST_Force6D ) {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             *boost::dynamic_pointer_cast<Force6DSensorData>(psensordata) = *_pdata;
             return true;
         }
@@ -204,7 +204,7 @@ protected:
 
     Transform _trans;
 
-    mutable boost::mutex _mutexdata;
+    mutable std::mutex _mutexdata;
 
     friend class BaseForce6DXMLReader;
 };

--- a/plugins/basesensors/baselaser.h
+++ b/plugins/basesensors/baselaser.h
@@ -168,7 +168,7 @@ public:
             _bRenderData = true;
             return _bRenderData;
         case CC_RenderDataOff: {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             _listGraphicsHandles.clear();
             _bRenderData = false;
             return _bRenderData;
@@ -180,7 +180,7 @@ public:
             _RenderGeometry();
             return _bRenderData;
         case CC_RenderGeometryOff: {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             _graphgeometry.reset();
             _bRenderGeometry = false;
             return _bRenderData;
@@ -205,7 +205,7 @@ public:
 
             {
                 // Lock the data mutex and fill with the range data (get all in one timestep)
-                boost::mutex::scoped_lock lock(_mutexdata);
+                std::lock_guard<std::mutex> lock(_mutexdata);
                 _pdata->__trans = GetTransform();
                 _pdata->__stamp = GetEnv()->GetSimulationTime();
                 t = GetLaserPlaneTransform();
@@ -247,7 +247,7 @@ public:
 
                 {
                     // Lock the data mutex and fill the arrays used for rendering
-                    boost::mutex::scoped_lock lock(_mutexdata);
+                    std::lock_guard<std::mutex> lock(_mutexdata);
                     N = (int)_pdata->ranges.size();
                     vpoints.resize(N+1);
                     for(int i = 0; i < N; ++i) {
@@ -307,7 +307,7 @@ public:
     virtual bool GetSensorData(SensorDataPtr psensordata)
     {
         if( psensordata->GetType() == ST_Laser ) {
-            boost::mutex::scoped_lock lock(_mutexdata);
+            std::lock_guard<std::mutex> lock(_mutexdata);
             *boost::dynamic_pointer_cast<LaserSensorData>(psensordata) = *_pdata;
             return true;
         }
@@ -325,7 +325,7 @@ public:
     }
     bool _CollidingBodies(ostream& sout, istream& sinput)
     {
-        boost::mutex::scoped_lock lock(_mutexdata);
+        std::lock_guard<std::mutex> lock(_mutexdata);
         FOREACH(it, _databodyids) {
             sout << *it << " ";
         }
@@ -369,7 +369,7 @@ protected:
 
     virtual void _Reset()
     {
-        boost::mutex::scoped_lock lock(_mutexdata);
+        std::lock_guard<std::mutex> lock(_mutexdata);
         int N;
         if( _pgeom->resolution[0] > 0 ) {
             N = (int)( (_pgeom->max_angle[0]-_pgeom->min_angle[0])/_pgeom->resolution[0] + 0.5f)+1;
@@ -441,7 +441,7 @@ protected:
     GraphHandlePtr _graphgeometry;
     dReal _fTimeToScan;
 
-    boost::mutex _mutexdata;
+    std::mutex _mutexdata;
     bool _bRenderData, _bRenderGeometry, _bPower;
 
     friend class BaseLaser2DXMLReader;

--- a/plugins/bulletrave/bulletspace.h
+++ b/plugins/bulletrave/bulletspace.h
@@ -454,7 +454,7 @@ private:
 
     virtual void GeometryChangedCallback(KinBodyWeakPtr _pbody)
     {
-        EnvironmentMutex::scoped_lock lock(_penv->GetMutex());
+        EnvironmentLock lock(_penv->GetMutex());
         KinBodyPtr pbody(_pbody);
         KinBodyInfoPtr pinfo = GetInfo(pbody);
         if( !pinfo ) {

--- a/plugins/configurationcache/configurationcachetree.cpp
+++ b/plugins/configurationcache/configurationcachetree.cpp
@@ -181,7 +181,7 @@ CacheTreeNodePtr CacheTree::_CreateCacheTreeNode(const std::vector<dReal>& cs, C
     // allocate memory for the structure and the internal state vectors
     void* pmemory;
     {
-        //boost::mutex::scoped_lock lock(_mutexpool);
+        //std::lock_guard<std::mutex> lock(_mutexpool);
         pmemory = _poolNodes->malloc();
     }
     //Vector* plinkspheres = (Vector*)((uint8_t*)pmemory + sizeof(CacheTreeNode) + sizeof(dReal)*_statedof);
@@ -198,7 +198,7 @@ CacheTreeNodePtr CacheTree::_CloneCacheTreeNode(CacheTreeNodeConstPtr refnode)
     // allocate memory for the structure and the internal state vectors
     void* pmemory;
     {
-        //boost::mutex::scoped_lock lock(_mutexpool);
+        //std::lock_guard<std::mutex> lock(_mutexpool);
         pmemory = _poolNodes->malloc();
     }
     //Vector* plinkspheres = (Vector*)((uint8_t*)pmemory + sizeof(CacheTreeNode) + sizeof(dReal)*_statedof);
@@ -790,7 +790,7 @@ int CacheTree::RemoveCollisionConfigurations()
 
 int CacheTree::SaveCache(std::string filename)
 {
-    //boost::mutex::scoped_lock lock(_mutexpool);
+    //std::lock_guard<std::mutex> lock(_mutexpool);
     _mapNodeIndices.clear();
     int index=0;
     int knownnodes=0;
@@ -863,7 +863,7 @@ int CacheTree::SaveCache(std::string filename)
 
 int CacheTree::LoadCache(std::string filename, EnvironmentBasePtr penv)
 {
-    //boost::mutex::scoped_lock lock(_mutexpool);
+    //std::lock_guard<std::mutex> lock(_mutexpool);
     _fulldirname = RaveFindDatabaseFile(std::string("selfcache.")+filename,false);
 
     FILE* pfile = fopen(_fulldirname.c_str(),"rb");

--- a/plugins/fclrave/fclcollision.h
+++ b/plugins/fclrave/fclcollision.h
@@ -155,7 +155,7 @@ public:
         DestroyEnvironment();
 
 #ifdef FCLRAVE_COLLISION_OBJECTS_STATISTICS
-        EnvironmentMutex::scoped_lock lock(log_collision_use_mutex);
+        EnvironmentLock lock(log_collision_use_mutex);
 
         FOREACH(itpair, _currentlyused) {
             if(itpair->second > 0) {
@@ -348,7 +348,7 @@ public:
 
     virtual bool InitKinBody(OpenRAVE::KinBodyPtr pbody)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        OpenRAVE::EnvironmentLock lock(GetEnv()->GetMutex());
         FCLSpace::FCLKinBodyInfoPtr pinfo = _fclspace->GetInfo(*pbody);
         if( !pinfo || pinfo->GetBody() != pbody ) {
             pinfo = _fclspace->InitKinBody(pbody);

--- a/plugins/fclrave/fclstatistics.h
+++ b/plugins/fclrave/fclstatistics.h
@@ -54,7 +54,7 @@ public:
     }
 
     void Display() {
-        EnvironmentMutex::scoped_lock lock(log_out_mutex);
+        EnvironmentLock lock(log_out_mutex);
         std::fstream f("fclstatistics.log", std::fstream::out | std::fstream::app);
         FOREACH(ittiming, timings) {
             f << ittiming->first;

--- a/plugins/grasper/graspermodule.cpp
+++ b/plugins/grasper/graspermodule.cpp
@@ -16,8 +16,8 @@
 #include "plugindefs.h"
 
 #include <algorithm>
-#include <boost/thread/condition.hpp>
-#include <boost/thread/mutex.hpp>
+#include <condition_variable>
+#include <mutex>
 #include <cmath>
 
 
@@ -52,7 +52,7 @@ extern "C"
 
 #endif
 
-static boost::mutex s_QhullMutex;
+static std::mutex s_QhullMutex;
 
 #define GTS_M_ICOSAHEDRON_X /* sqrt(sqrt(5)+1)/sqrt(2*sqrt(5)) */   \
     (dReal)0.850650808352039932181540497063011072240401406
@@ -145,7 +145,7 @@ public:
 
     virtual bool _GraspCommand(std::ostream& sout, std::istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         string strsavetraj;
         bool bGetLinkCollisions = false;
@@ -419,7 +419,7 @@ public:
 
     virtual bool _ComputeDistanceMapCommand(std::ostream& sout, std::istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         dReal conewidth = 0.25f*PI;
         int nDistMapSamples = 60000;
@@ -477,7 +477,7 @@ public:
 
     virtual bool _GetStableContactsCommand(std::ostream& sout, std::istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         string cmd;
         dReal mu=0;
@@ -711,7 +711,7 @@ public:
 
     virtual bool _GraspThreadedCommand(std::ostream& sout, std::istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock543(GetEnv()->GetMutex());
+        EnvironmentLock lock543(GetEnv()->GetMutex());
 
         WorkerParametersPtr worker_params(new WorkerParameters());
         int numthreads = 2;
@@ -840,9 +840,9 @@ public:
 
         _bContinueWorker = true;
         // start worker threads
-        vector<boost::shared_ptr<boost::thread> > listthreads(numthreads);
-        FOREACH(itthread,listthreads) {
-            itthread->reset(new boost::thread(boost::bind(&GrasperModule::_WorkerThread,this,worker_params,pcloneenv)));
+        vector<boost::shared_ptr<std::thread> > listthreads(numthreads);
+        for (int threadIdx = 0; threadIdx < numthreads; ++threadIdx) {
+            listthreads[threadIdx] = boost::make_shared<std::thread>(std::bind(&GrasperModule::_WorkerThread, this, worker_params, pcloneenv));
         }
 
         _listGraspResults.clear();
@@ -859,7 +859,7 @@ public:
             size_t iapproachray = (id / (rolls.size() * preshapes.size() * standoffs.size()))%approachrays.size();
             size_t imanipulatordirection = (id / (rolls.size() * preshapes.size() * standoffs.size()*approachrays.size()));
 
-            boost::mutex::scoped_lock lock123(_mutexGrasp);
+            std::unique_lock<std::mutex> lock123(_mutexGrasp);
             if( _listGraspResults.size() >= maxgrasps ) {
                 break;
             }
@@ -915,7 +915,7 @@ public:
         // clone environment
         EnvironmentBasePtr pcloneenv = penv->CloneSelf(Clone_Bodies|Clone_Simulation);
         {
-            EnvironmentMutex::scoped_lock lock765(pcloneenv->GetMutex());
+            EnvironmentLock lock765(pcloneenv->GetMutex());
             boost::shared_ptr<CollisionCheckerMngr> pcheckermngr(new CollisionCheckerMngr(pcloneenv, worker_params->collisionchecker));
             PlannerBasePtr planner = RaveCreatePlanner(pcloneenv,"Grasper");
             RobotBasePtr probot = pcloneenv->GetRobot(_robot->GetName());
@@ -951,7 +951,7 @@ public:
             while(_bContinueWorker) {
                 {
                     // wait for work
-                    boost::mutex::scoped_lock lock653(_mutexGrasp);
+                    std::unique_lock<std::mutex> lock653(_mutexGrasp);
                     if( !_graspParamsWork ) {
                         _condGraspHasWork.wait(lock653);
                         // after signal
@@ -1161,7 +1161,7 @@ public:
 
                 RAVELOG_DEBUG(str(boost::format("grasp %d: success")%grasp_params->id));
 
-                boost::mutex::scoped_lock lock(_mutexGrasp);
+                std::lock_guard<std::mutex> lock(_mutexGrasp);
                 _listGraspResults.push_back(grasp_params);
             }
         }
@@ -1169,10 +1169,10 @@ public:
     }
 
     bool _bContinueWorker;
-    boost::mutex _mutexGrasp;
+    std::mutex _mutexGrasp;
     GraspParametersThreadPtr _graspParamsWork;
     list<GraspParametersThreadPtr> _listGraspResults;
-    boost::condition _condGraspHasWork, _condGraspReceivedWork;
+    std::condition_variable _condGraspHasWork, _condGraspReceivedWork;
 
 protected:
     void _ComputeJointMaxLengths(vector<dReal>& vjointlengths)
@@ -1657,7 +1657,7 @@ protected:
         boolT ismalloc = 0;               // True if qhull should free points in qh_freeqhull() or reallocation
         char flags[]= "qhull Tv FA";     // option flags for qhull, see qh_opt.htm, output volume (FA)
 
-        boost::mutex::scoped_lock lock(s_QhullMutex);
+        std::lock_guard<std::mutex> lock(s_QhullMutex);
 
         if( !outfile ) {
             // outfile = tmpfile();        // stdout from qhull code
@@ -1780,7 +1780,7 @@ protected:
     PlannerBasePtr _planner;
     RobotBasePtr _robot;
     CollisionReportPtr _report;
-    boost::mutex _mutex;
+    std::mutex _mutex;
     FILE *outfile;
     FILE *errfile;
     std::vector<dReal> _vjointmaxlengths;

--- a/plugins/grasper/grasperplanner.cpp
+++ b/plugins/grasper/grasperplanner.cpp
@@ -38,7 +38,7 @@ public:
     }
     bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _robot = pbase;
 
         if( _robot->GetActiveDOF() <= 0 ) {
@@ -69,7 +69,7 @@ public:
         if(!_parameters) {
             return PlannerStatus(PS_Failed);
         }
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBase::RobotStateSaver saver(_robot);
         RobotBase::ManipulatorPtr pmanip = _robot->GetActiveManipulator();
 

--- a/plugins/ikfastsolvers/ikfastmodule.cpp
+++ b/plugins/ikfastsolvers/ikfastmodule.cpp
@@ -408,7 +408,7 @@ public:
 //#endif
 
         // before adding a new library, check for existing
-        boost::mutex::scoped_lock lock(GetLibraryMutex());
+        std::lock_guard<std::mutex> lock(GetLibraryMutex());
         boost::shared_ptr<IkLibrary> lib;
         FOREACH(it, *GetLibraries()) {
             if( libraryname == (*it)->GetLibraryName() ) {
@@ -521,7 +521,7 @@ public:
 
     bool LoadIKFastSolver(ostream& sout, istream& sinput)
     {
-        EnvironmentMutex::scoped_lock envlock(GetEnv()->GetMutex());
+        EnvironmentLock envlock(GetEnv()->GetMutex());
         string robotname;
         string striktype;
         bool bForceIK = false;
@@ -709,7 +709,7 @@ public:
 
     bool PerfTiming(ostream& sout, istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         string cmd, libraryname;
         int num=1000;
         dReal maxtime = 1200;
@@ -807,7 +807,7 @@ public:
 
     bool IKtest(ostream& sout, istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RAVELOG_DEBUG("Starting IKtest...\n");
         vector<dReal> varmjointvals, values;
         bool bInitialized=false;
@@ -930,7 +930,7 @@ public:
     bool DebugIK(ostream& sout, istream& sinput)
     {
         using namespace boost::numeric;
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         int num_itrs = 1000;
         stringstream s;
@@ -1534,9 +1534,9 @@ public:
         return s_vStaticLibraries;
     }
 
-    static boost::mutex& GetLibraryMutex()
+    static std::mutex& GetLibraryMutex()
     {
-        static boost::mutex s_LibraryMutex;
+        static std::mutex s_LibraryMutex;
         return s_LibraryMutex;
     }
 
@@ -1546,7 +1546,7 @@ public:
         string name; name.resize(_name.size());
         std::transform(_name.begin(), _name.end(), name.begin(), ::tolower);
         /// start from the newer libraries
-        boost::mutex::scoped_lock lock(GetLibraryMutex());
+        std::lock_guard<std::mutex> lock(GetLibraryMutex());
         for(list< boost::shared_ptr<IkLibrary> >::reverse_iterator itlib = GetLibraries()->rbegin(); itlib != GetLibraries()->rend(); ++itlib) {
             FOREACHC(itikname,(*itlib)->GetIkNames()) {
                 if( name == *itikname ) {

--- a/plugins/logging/viewerrecorder.cpp
+++ b/plugins/logging/viewerrecorder.cpp
@@ -16,8 +16,9 @@
 #define __STDC_CONSTANT_MACROS
 #include "plugindefs.h"
 
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/condition.hpp>
+#include <condition_variable>
+#include <mutex>
+
 #include <boost/version.hpp>
 
 #include <boost/lexical_cast.hpp>
@@ -96,11 +97,11 @@ class ViewerRecorder : public ModuleBase
         bool _bProcessed;
     };
 
-    boost::mutex _mutex; // for video data passing
-    boost::mutex _mutexlibrary; // for video encoding library resources
-    boost::condition _condnewframe;
+    std::mutex _mutex; // for video data passing
+    std::mutex _mutexlibrary; // for video encoding library resources
+    std::condition_variable _condnewframe;
     bool _bContinueThread, _bStopRecord;
-    boost::shared_ptr<boost::thread> _threadrecord;
+    boost::shared_ptr<std::thread> _threadrecord;
 
     boost::multi_array<uint32_t,2> _vwatermarkimage;
     int _nFrameCount, _nVideoWidth, _nVideoHeight;
@@ -152,7 +153,7 @@ public:
         _picture_size = 0;
         _outbuf_size = 0;
 #endif
-        _threadrecord.reset(new boost::thread(boost::bind(&ViewerRecorder::_RecordThread,this)));
+        _threadrecord = boost::make_shared<std::thread>(std::bind(&ViewerRecorder::_RecordThread, this));
     }
     virtual ~ViewerRecorder()
     {
@@ -160,7 +161,7 @@ public:
         _bContinueThread = false;
         _Reset();
         {
-            boost::mutex::scoped_lock lock(_mutex);
+            std::lock_guard<std::mutex> lock(_mutex);
             _condnewframe.notify_all();
         }
         _threadrecord->join();
@@ -232,7 +233,7 @@ protected:
                     break;
                 }
             }
-            boost::mutex::scoped_lock lock(_mutex);
+            std::lock_guard<std::mutex> lock(_mutex);
             if( !pviewer ) {
                 RAVELOG_WARN("invalid viewer\n");
             }
@@ -270,7 +271,7 @@ protected:
 
     bool _SetWatermarkCommand(ostream& sout, istream& sinput)
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         int W, H;
         sinput >> W >> H;
         _vwatermarkimage.resize(boost::extents[H][W]);
@@ -284,7 +285,7 @@ protected:
 
     void _ViewerImageCallback(const uint8_t* memory, int width, int height, int pixeldepth)
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         if( !GetEnv() || !_callback ) {
             // recorder already destroyed and this thread is just remaining
             return;
@@ -326,7 +327,7 @@ protected:
             // calls the environment lock, which might be taken if the environment is destroying the problem
             // therefore need to take it first
             while(_bContinueThread && !_bStopRecord) {
-                boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = _LockEnvironment(100000);
+                boost::shared_ptr<EnvironmentLock> lockenv = _LockEnvironment(100000);
                 if( !!lockenv ) {
                     GetEnv()->StepSimulation(_fSimulationTimeMultiplier/_framerate);
                     break;
@@ -335,14 +336,10 @@ protected:
         }
     }
 
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> _LockEnvironment(uint64_t timeout)
+    boost::shared_ptr<EnvironmentLock> _LockEnvironment(uint64_t timeout)
     {
         // try to acquire the lock
-#if BOOST_VERSION >= 103500
-        boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetEnv()->GetMutex(),boost::defer_lock_t()));
-#else
-        boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetEnv()->GetMutex(),false));
-#endif
+        boost::shared_ptr<EnvironmentLock> lockenv = boost::make_shared<EnvironmentLock>(GetEnv()->GetMutex(), std::defer_lock_t());
         uint64_t basetime = utils::GetMicroTime();
         while(utils::GetMicroTime()-basetime<timeout ) {
             lockenv->try_lock();
@@ -362,7 +359,7 @@ protected:
             boost::shared_ptr<VideoFrame> frame;
             uint64_t numstores=0;
             {
-                boost::mutex::scoped_lock lock(_mutex);
+                std::unique_lock<std::mutex> lock(_mutex);
                 if( !_bContinueThread ) {
                     return;
                 }
@@ -456,7 +453,7 @@ protected:
         {
             RAVELOG_DEBUG("ViewerRecorder _Reset\n");
             _bStopRecord = true;
-            boost::mutex::scoped_lock lock(_mutex);
+            std::lock_guard<std::mutex> lock(_mutex);
             _nFrameCount = 0;
             _nVideoWidth = _nVideoHeight = 0;
             _framerate = 30000.0f/1001.0f;
@@ -470,7 +467,7 @@ protected:
         }
         {
             RAVELOG_DEBUG("ViewerRecorder _ResetLibrary\n");
-            boost::mutex::scoped_lock lock(_mutexlibrary);
+            std::lock_guard<std::mutex> lock(_mutexlibrary);
             _ResetLibrary();
         }
     }
@@ -623,7 +620,7 @@ protected:
 
     void _AddFrame(void* pdata)
     {
-        boost::mutex::scoped_lock lock(_mutexlibrary);
+        std::lock_guard<std::mutex> lock(_mutexlibrary);
         HRESULT hr = AVIStreamWrite(_psCompressed /*stream pointer*/, _nFrameCount /*time of this frame*/, 1 /*number to write*/, pdata, _biSizeImage /*size of this frame*/, AVIIF_KEYFRAME /*flags....*/, NULL, NULL);
         BOOST_ASSERT(hr == AVIERR_OK);
         _nFrameCount++;
@@ -853,7 +850,7 @@ protected:
 
     void _AddFrame(void* pdata)
     {
-        boost::mutex::scoped_lock lock(_mutexlibrary);
+        std::lock_guard<std::mutex> lock(_mutexlibrary);
         if( !_output ) {
             RAVELOG_DEBUG("video resources destroyed\n");
             return;

--- a/plugins/mobyrave/mobycontroller.h
+++ b/plugins/mobyrave/mobycontroller.h
@@ -260,7 +260,7 @@ public:
         // this will also let it have consistent mechanics as SetPath
         // (there's a race condition we're avoiding where a user calls SetDesired and then state savers revert the robot)
         if( !_bPause ) {
-            EnvironmentMutex::scoped_lock lockenv(_probot->GetEnv()->GetMutex());
+            EnvironmentLock lockenv(_probot->GetEnv()->GetMutex());
             _vecdesired = values;
             if( _nControlTransformation ) {
                 if( !!trans ) {
@@ -282,7 +282,7 @@ public:
     virtual bool SetPath(TrajectoryBaseConstPtr ptraj)
     {
         OPENRAVE_ASSERT_FORMAT0(!ptraj || GetEnv()==ptraj->GetEnv(), "trajectory needs to come from the same environment as the controller", ORE_InvalidArguments);
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         if( _bPause ) {
             RAVELOG_DEBUG("MobyController cannot start trajectories when paused\n");
             _ptraj.reset();
@@ -410,7 +410,7 @@ public:
             return;
         }
   
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         TrajectoryBaseConstPtr ptraj = _ptraj; // because of multi-threading setting issues
         if( !!ptraj ) {
             _bSteadyState = false;
@@ -971,7 +971,7 @@ private:
     UserDataPtr _cblimits;
     ConfigurationSpecification _samplespec;
     boost::shared_ptr<ConfigurationSpecification::Group> _gjointvalues, _gjointvelocities, _gtransform;
-    boost::mutex _mutex;
+    std::mutex _mutex;
 
     vector<dReal> _aggregateErrorP;     //< PI history
     vector<dReal> _aggregateErrorD;     //< DI history

--- a/plugins/mobyrave/mobyreplaycontroller.h
+++ b/plugins/mobyrave/mobyreplaycontroller.h
@@ -409,7 +409,7 @@ public:
         // this will also let it have consistent mechanics as SetPath
         // (there's a race condition we're avoiding where a user calls SetDesired and then state savers revert the robot)
         if( !_bPause ) {
-            EnvironmentMutex::scoped_lock lockenv(_probot->GetEnv()->GetMutex());
+            EnvironmentLock lockenv(_probot->GetEnv()->GetMutex());
             _vecdesired = values;
             if( _nControlTransformation ) {
                 if( !!trans ) {
@@ -431,7 +431,7 @@ public:
     virtual bool SetPath(TrajectoryBaseConstPtr ptraj)
     {
         OPENRAVE_ASSERT_FORMAT0(!ptraj || GetEnv()==ptraj->GetEnv(), "trajectory needs to come from the same environment as the controller", ORE_InvalidArguments);
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         if( _bPause ) {
             RAVELOG_DEBUG("MobyReplayController cannot start trajectories when paused\n");
             _ptraj.reset();
@@ -559,7 +559,7 @@ public:
             return;
         }
  
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         TrajectoryBaseConstPtr ptraj = _ptraj; // because of multi-threading setting issues
         if( !!ptraj ) {
             vector<dReal> sampledata;
@@ -963,7 +963,7 @@ private:
     UserDataPtr _cblimits;
     ConfigurationSpecification _samplespec;
     boost::shared_ptr<ConfigurationSpecification::Group> _gjointvalues, _gjointvelocities, _gtransform;
-    boost::mutex _mutex;
+    std::mutex _mutex;
 
     EnvironmentBasePtr _penv;
 

--- a/plugins/mobyrave/mobyspace.h
+++ b/plugins/mobyrave/mobyspace.h
@@ -606,7 +606,7 @@ private:
 
     virtual void GeometryChangedCallback(KinBodyWeakPtr _pbody)
     {
-        EnvironmentMutex::scoped_lock lock(_penv->GetMutex());
+        EnvironmentLock lock(_penv->GetMutex());
         KinBodyPtr pbody(_pbody);
         KinBodyInfoPtr pinfo = GetInfo(pbody);
         if( !pinfo ) 

--- a/plugins/oderave/odecollision.h
+++ b/plugins/oderave/odecollision.h
@@ -22,7 +22,7 @@
 #include <openrave/utils.h>
 
 #ifndef ODE_USE_MULTITHREAD
-static boost::mutex _mutexode;
+static std::mutex _mutexode;
 static bool _bnotifiedmessage=false;
 #endif
 
@@ -230,7 +230,7 @@ public:
         }
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
         _odespace->Synchronize();
         dSpaceCollide(_odespace->GetSpace(), &cb, KinBodyCollisionCallback);
@@ -255,7 +255,7 @@ public:
         }
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
         _odespace->Synchronize();
 
@@ -289,7 +289,7 @@ public:
         }
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
         _odespace->Synchronize();
         dSpaceCollide(_odespace->GetSpace(), &cb, LinkCollisionCallback);
@@ -343,7 +343,7 @@ public:
         }
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
 
         _odespace->Synchronize();
@@ -462,7 +462,7 @@ public:
         }
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
 
         _odespace->Synchronize();
@@ -519,7 +519,7 @@ public:
             cb.pvlinkexcluded = &vlinkexcluded;
         }
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
 
         _odespace->Synchronize();
@@ -538,7 +538,7 @@ public:
         }
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
 
         _odespace->Synchronize();
@@ -656,7 +656,7 @@ public:
         }
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
 
         _odespace->Synchronize();
@@ -692,7 +692,7 @@ public:
         }
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
         dGeomRaySet(geomray, ray.pos.x, ray.pos.y, ray.pos.z, vnormdir.x, vnormdir.y, vnormdir.z);
 
@@ -734,7 +734,7 @@ public:
         const std::vector<int>& nonadjacent = pbody->GetNonAdjacentLinks(adjacentoptions);
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
         _odespace->Synchronize(); // call after GetNonAdjacentLinks since it can modify the body, even though it is const!
         bool bCollision = false;
@@ -791,7 +791,7 @@ public:
         const std::vector<int>& nonadjacent = pbody->GetNonAdjacentLinks(adjacentoptions);
 
 #ifndef ODE_USE_MULTITHREAD
-        boost::mutex::scoped_lock lock(_mutexode);
+        std::lock_guard<std::mutex> lock(_mutexode);
 #endif
         _odespace->Synchronize(); // call after GetNonAdjacentLinks since it can modify the body, even though it is const!
         bool bCollision = false;

--- a/plugins/oderave/odecontroller.h
+++ b/plugins/oderave/odecontroller.h
@@ -37,7 +37,7 @@ public:
     virtual void Reset(int options)
     {
         if( !!_probot ) {
-            EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+            OpenRAVE::EnvironmentLock lock(GetEnv()->GetMutex());
             ODESpace::KinBodyInfoPtr pinfo = GetODESpace();
             if( !!pinfo ) {
                 boost::shared_ptr<ODESpace> odespace(pinfo->_odespace);
@@ -111,7 +111,7 @@ public:
 protected:
     bool _SetVelocities(const std::vector<OpenRAVE::dReal>& velocities)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        OpenRAVE::EnvironmentLock lock(GetEnv()->GetMutex());
         ODESpace::KinBodyInfoPtr pinfo = GetODESpace();
         if( !pinfo ) {
             RAVELOG_WARN("need to set ode physics engine\n");

--- a/plugins/oderave/odespace.h
+++ b/plugins/oderave/odespace.h
@@ -69,7 +69,7 @@ public:
         dWorldID world;          ///< the dynamics world
         dSpaceID space;          ///< the collision world
         dJointGroupID contactgroup;
-        boost::mutex _mutex;
+        std::mutex _mutex;
     };
 
 public:
@@ -143,7 +143,7 @@ public:
         }
 
         virtual ~KinBodyInfo() {
-            boost::mutex::scoped_lock lock(_ode->_mutex);
+            std::lock_guard<std::mutex> lock(_ode->_mutex);
             Reset();
             dSpaceClean(space);
             dJointGroupEmpty(jointgroup);
@@ -284,10 +284,10 @@ private:
 
     KinBodyInfoPtr InitKinBody(KinBodyConstPtr pbody, KinBodyInfoPtr pinfo = KinBodyInfoPtr(), bool blockode=true)
     {
-        EnvironmentMutex::scoped_lock lock(pbody->GetEnv()->GetMutex());
-        boost::shared_ptr<boost::mutex::scoped_lock> lockode;
+        OpenRAVE::EnvironmentLock lock(pbody->GetEnv()->GetMutex());
+        boost::shared_ptr<std::unique_lock<std::mutex>> lockode;
         if( blockode ) {
-            lockode.reset(new boost::mutex::scoped_lock(_ode->_mutex));
+            lockode = boost::make_shared<std::unique_lock<std::mutex>>(_ode->_mutex);
         }
 #ifdef ODE_HAVE_ALLOCATE_DATA_THREAD
         dAllocateODEDataForThread(dAllocateMaskAll);
@@ -529,7 +529,7 @@ private:
 #ifdef ODE_HAVE_ALLOCATE_DATA_THREAD
         dAllocateODEDataForThread(dAllocateMaskAll);
 #endif
-        boost::mutex::scoped_lock lockode(_ode->_mutex);
+        std::lock_guard<std::mutex> lockode(_ode->_mutex);
         vector<KinBodyPtr> vbodies;
         _penv->GetBodies(vbodies);
         FOREACHC(itbody, vbodies) {
@@ -688,9 +688,9 @@ private:
     void _Synchronize(KinBodyInfoPtr pinfo, bool block=true)
     {
         if( pinfo->nLastStamp != pinfo->GetBody()->GetUpdateStamp() ) {
-            boost::shared_ptr<boost::mutex::scoped_lock> lockode;
+            boost::shared_ptr<std::unique_lock<std::mutex>> lockode;
             if( block ) {
-                lockode.reset(new boost::mutex::scoped_lock(_ode->_mutex));
+                lockode = boost::make_shared<std::unique_lock<std::mutex>>(_ode->_mutex);
             }
             vector<Transform> vtrans;
             KinBodyPtr pbody = pinfo->GetBody();

--- a/plugins/qtcoinrave/item.cpp
+++ b/plugins/qtcoinrave/item.cpp
@@ -393,7 +393,7 @@ bool KinBodyItem::UpdateFromIv()
         ++ittrans;
     }
 
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = _viewer.lock()->LockEnvironment(50000,false);
+    boost::shared_ptr<EnvironmentLock> lockenv = _viewer.lock()->LockEnvironment(50000,false);
     if( !!lockenv ) {
         _pchain->SetLinkTransformations(vtrans,_vdofbranches);
     }
@@ -422,7 +422,7 @@ bool KinBodyItem::UpdateFromModel()
     vector<dReal> vjointvalues;
 
     {
-        boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = _viewer.lock()->LockEnvironment(50000,false);
+        boost::shared_ptr<EnvironmentLock> lockenv = _viewer.lock()->LockEnvironment(50000,false);
         if( !lockenv ) {
             return false;
         }
@@ -443,13 +443,13 @@ bool KinBodyItem::UpdateFromModel()
 
 void KinBodyItem::GetDOFValues(vector<dReal>& vjoints) const
 {
-    boost::mutex::scoped_lock lock(_mutexjoints);
+    std::lock_guard<std::mutex> lock(_mutexjoints);
     vjoints = _vjointvalues;
 }
 
 void KinBodyItem::GetLinkTransformations(vector<Transform>& vtrans, std::vector<dReal>& vdofbranches) const
 {
-    boost::mutex::scoped_lock lock(_mutexjoints);
+    std::lock_guard<std::mutex> lock(_mutexjoints);
     vtrans = _vtrans;
     vdofbranches = _vdofbranches;
 }
@@ -462,7 +462,7 @@ bool KinBodyItem::UpdateFromModel(const vector<dReal>& vjointvalues, const vecto
     }
 
     if( _bReload || _bDrawStateChanged ) {
-        EnvironmentMutex::scoped_try_lock lockenv(_pchain->GetEnv()->GetMutex());
+        EnvironmentLock lockenv(_pchain->GetEnv()->GetMutex());
         if( !!lockenv ) {
             if( _bReload || _bDrawStateChanged ) {
                 Load();
@@ -470,7 +470,7 @@ bool KinBodyItem::UpdateFromModel(const vector<dReal>& vjointvalues, const vecto
         }
     }
 
-    boost::mutex::scoped_lock lock(_mutexjoints);
+    std::lock_guard<std::mutex> lock(_mutexjoints);
     _vjointvalues = vjointvalues;
     _vtrans = vtrans;
 

--- a/plugins/qtcoinrave/item.h
+++ b/plugins/qtcoinrave/item.h
@@ -200,7 +200,7 @@ protected:
     vector<dReal> _vjointvalues;
     vector<Transform> _vtrans;
     std::vector<dReal> _vdofbranches;
-    mutable boost::mutex _mutexjoints;
+    mutable std::mutex _mutexjoints;
     UserDataPtr _geometrycallback, _drawcallback;
 };
 

--- a/plugins/qtcoinrave/ivmodelloader.cpp
+++ b/plugins/qtcoinrave/ivmodelloader.cpp
@@ -58,7 +58,7 @@ public:
         }
         boost::trim(filename);
 
-        boost::mutex::scoped_lock lock(g_mutexsoqt);
+        std::lock_guard<std::mutex> lock(g_mutexsoqt);
         if(!SoDB::isInitialized()) {
             SoDB::init();
         }

--- a/plugins/qtcoinrave/ivselector.cpp
+++ b/plugins/qtcoinrave/ivselector.cpp
@@ -240,7 +240,7 @@ void IvObjectDragger::CheckCollision(bool flag)
         // synchronize the collision model transform
         KinBodyItemPtr pbody = boost::dynamic_pointer_cast<KinBodyItem>(selectedItem);
         if( !!pbody ) {
-            EnvironmentMutex::scoped_try_lock lock(_penv->GetMutex());
+            EnvironmentLock lock(_penv->GetMutex());
             if( !!lock ) {
                 int prevoptions = _penv->GetCollisionChecker()->GetCollisionOptions();
                 _penv->GetCollisionChecker()->SetCollisionOptions(CO_Contacts);
@@ -450,7 +450,7 @@ void IvJointDragger::CheckCollision(bool flag)
         KinBodyItemPtr pbody = boost::dynamic_pointer_cast<KinBodyItem>(selectedItem);
 
         if( !!pbody ) {
-            EnvironmentMutex::scoped_try_lock lock(_penv->GetMutex());
+            EnvironmentLock lock(_penv->GetMutex());
             if( !!lock ) {
                 int prevoptions = _penv->GetCollisionChecker()->GetCollisionOptions();
                 _penv->GetCollisionChecker()->SetCollisionOptions(CO_Contacts);
@@ -488,7 +488,7 @@ void IvJointDragger::UpdateSkeleton()
     RobotItemPtr probotitem = boost::dynamic_pointer_cast<RobotItem>(pbody);
 
     {
-        EnvironmentMutex::scoped_try_lock lock(_penv->GetMutex());
+        EnvironmentLock lock(_penv->GetMutex());
 
         if( !!lock ) {
             KinBody::JointPtr pjoint = pbody->GetBody()->GetJoints()[_iJointIndex];

--- a/plugins/qtcoinrave/qtcameraviewer.h
+++ b/plugins/qtcoinrave/qtcameraviewer.h
@@ -125,7 +125,7 @@ private:
 
     virtual void _CreateImageWindow()
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         if( !_imagewindow ) {
             _imagewindow.reset(new QtImageWindow(_psensor));
             _imagewindow->show();
@@ -138,7 +138,7 @@ private:
 
     SensorBasePtr _psensor;
     boost::shared_ptr<QtImageWindow> _imagewindow;
-    boost::mutex _mutex;
+    std::mutex _mutex;
 };
 
 #endif

--- a/plugins/qtcoinrave/qtcoin.h
+++ b/plugins/qtcoinrave/qtcoin.h
@@ -204,7 +204,7 @@ typedef boost::shared_ptr<QtCoinViewer const> QtCoinViewerConstPtr;
 
 #define CALLBACK_EVENT QEvent::Type(QEvent::User+101)
 
-extern boost::mutex g_mutexsoqt;
+extern std::mutex g_mutexsoqt;
 
 // assumes g_mutexsoqt is locked
 void EnsureSoQtInit();

--- a/plugins/qtcoinrave/qtcoinrave.cpp
+++ b/plugins/qtcoinrave/qtcoinrave.cpp
@@ -25,7 +25,7 @@
 
 ModuleBasePtr CreateIvModelLoader(EnvironmentBasePtr penv);
 
-boost::mutex g_mutexsoqt;
+std::mutex g_mutexsoqt;
 static int s_InitRefCount = 0;
 static int s_SoQtArgc = 0; // has to be static!!
 void EnsureSoQtInit()
@@ -49,7 +49,7 @@ InterfaceBasePtr CreateInterfaceValidated(InterfaceType type, const std::string&
 #endif
         if( interfacename == "qtcoin" ) {
             // have to lock after initialized since call relies on SoDBP::globalmutex
-            boost::mutex::scoped_lock lock(g_mutexsoqt);
+            std::lock_guard<std::mutex> lock(g_mutexsoqt);
             EnsureSoQtInit();
             //SoDBWriteLock dblock;
             return InterfaceBasePtr(new QtCoinViewer(penv, sinput));

--- a/plugins/qtcoinrave/qtcoinviewer.cpp
+++ b/plugins/qtcoinrave/qtcoinviewer.cpp
@@ -66,7 +66,7 @@ public:
     virtual ~ItemSelectionCallbackData() {
         boost::shared_ptr<QtCoinViewer> pviewer = _pweakviewer.lock();
         if( !!pviewer ) {
-            boost::mutex::scoped_lock lock(pviewer->_mutexCallbacks);
+            std::lock_guard<std::mutex> lock(pviewer->_mutexCallbacks);
             pviewer->_listRegisteredItemSelectionCallbacks.erase(_iterator);
         }
     }
@@ -86,7 +86,7 @@ public:
     virtual ~ViewerImageCallbackData() {
         boost::shared_ptr<QtCoinViewer> pviewer = _pweakviewer.lock();
         if( !!pviewer ) {
-            boost::mutex::scoped_lock lock(pviewer->_mutexCallbacks);
+            std::lock_guard<std::mutex> lock(pviewer->_mutexCallbacks);
             pviewer->_listRegisteredViewerImageCallbacks.erase(_iterator);
         }
     }
@@ -106,7 +106,7 @@ public:
     virtual ~ViewerThreadCallbackData() {
         boost::shared_ptr<QtCoinViewer> pviewer = _pweakviewer.lock();
         if( !!pviewer ) {
-            boost::mutex::scoped_lock lock(pviewer->_mutexCallbacks);
+            std::lock_guard<std::mutex> lock(pviewer->_mutexCallbacks);
             pviewer->_listRegisteredViewerThreadCallbacks.erase(_iterator);
         }
     }
@@ -376,7 +376,7 @@ QtCoinViewer::~QtCoinViewer()
     RAVELOG_DEBUG("destroying qtcoinviewer\n");
 
     {
-        boost::mutex::scoped_lock lock(_mutexMessages);
+        std::lock_guard<std::mutex> lock(_mutexMessages);
 
         list<EnvMessagePtr>::iterator itmsg;
         FORIT(itmsg, _listMessages) {
@@ -455,7 +455,7 @@ void QtCoinViewer::_mousemove_cb(SoEventCallback * node)
         }
 
         if (!!pItem) {
-            boost::mutex::scoped_lock lock(_mutexMessages);
+            std::lock_guard<std::mutex> lock(_mutexMessages);
 
             KinBodyItemPtr pKinBody = boost::dynamic_pointer_cast<KinBodyItem>(pItem);
             KinBody::LinkPtr pSelectedLink;
@@ -499,12 +499,12 @@ void QtCoinViewer::_mousemove_cb(SoEventCallback * node)
             _strMouseMove = ss.str();
         }
         else {
-            boost::mutex::scoped_lock lock(_mutexMessages);
+            std::lock_guard<std::mutex> lock(_mutexMessages);
             _strMouseMove.resize(0);
         }
     }
     else {
-        boost::mutex::scoped_lock lock(_mutexMessages);
+        std::lock_guard<std::mutex> lock(_mutexMessages);
         _strMouseMove.resize(0);
     }
 }
@@ -658,7 +658,7 @@ void QtCoinViewer::_StopPlaybackTimer()
     if (_timerSensor->isScheduled()) {
         _timerSensor->unschedule();
     }
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
+    std::lock_guard<std::mutex> lock(_mutexUpdateModels);
     _condUpdateModels.notify_all();
 }
 
@@ -1253,7 +1253,7 @@ void QtCoinViewer::Reset()
 
 boost::shared_ptr<void> QtCoinViewer::LockGUI()
 {
-    boost::shared_ptr<boost::mutex::scoped_lock> lock(new boost::mutex::scoped_lock(_mutexGUI));
+    boost::shared_ptr<std::unique_lock<std::mutex>> lock = boost::make_shared<std::unique_lock<std::mutex>>(_mutexGUI);
     while(!_bInIdleThread) {
         boost::this_thread::sleep(boost::posix_time::milliseconds(1));
     }
@@ -1290,14 +1290,14 @@ void QtCoinViewer::SetBkgndColor(const RaveVector<float>& color)
 
 void QtCoinViewer::SetEnvironmentSync(bool bUpdate)
 {
-    boost::mutex::scoped_lock lockupdating(_mutexUpdating);
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
+    std::lock_guard<std::mutex> lockupdating(_mutexUpdating);
+    std::lock_guard<std::mutex> lock(_mutexUpdateModels);
     _bUpdateEnvironment = bUpdate;
     _condUpdateModels.notify_all();
 
     if( !bUpdate ) {
         // remove all messages in order to release the locks
-        boost::mutex::scoped_lock lockmsg(_mutexMessages);
+        std::lock_guard<std::mutex> lockmsg(_mutexMessages);
         FOREACH(it,_listMessages) {
             (*it)->releasemutex();
         }
@@ -1308,14 +1308,14 @@ void QtCoinViewer::SetEnvironmentSync(bool bUpdate)
 void QtCoinViewer::EnvironmentSync()
 {
     {
-        boost::mutex::scoped_lock lockupdating(_mutexUpdating);
+        std::lock_guard<std::mutex> lockupdating(_mutexUpdating);
         if( !_bUpdateEnvironment ) {
             RAVELOG_WARN("cannot update models from environment sync\n");
             return;
         }
     }
 
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
+    std::unique_lock<std::mutex> lock(_mutexUpdateModels);
     _bModelsUpdated = false;
     _condUpdateModels.wait(lock);
     if( !_bModelsUpdated ) {
@@ -1387,7 +1387,7 @@ void QtCoinViewer::PrintCamera()
 
 RaveTransform<float> QtCoinViewer::GetCameraTransform() const
 {
-    boost::mutex::scoped_lock lock(_mutexMessages);
+    std::lock_guard<std::mutex> lock(_mutexMessages);
     // have to flip Z axis
     RaveTransform<float> trot; trot.rot = quatFromAxisAngle(RaveVector<float>(1,0,0),(float)PI);
     return _Tcamera*trot;
@@ -1395,19 +1395,19 @@ RaveTransform<float> QtCoinViewer::GetCameraTransform() const
 
 float QtCoinViewer::GetCameraDistanceToFocus() const
 {
-    boost::mutex::scoped_lock lock(_mutexMessages);
+    std::lock_guard<std::mutex> lock(_mutexMessages);
     return _focalDistance;
 }
 
 geometry::RaveCameraIntrinsics<float> QtCoinViewer::GetCameraIntrinsics() const
 {
-    boost::mutex::scoped_lock lock(_mutexMessages);
+    std::lock_guard<std::mutex> lock(_mutexMessages);
     return _camintrinsics;
 }
 
 SensorBase::CameraIntrinsics QtCoinViewer::GetCameraIntrinsics2() const
 {
-    boost::mutex::scoped_lock lock(_mutexMessages);
+    std::lock_guard<std::mutex> lock(_mutexMessages);
     SensorBase::CameraIntrinsics intr;
     intr.fx = _camintrinsics.fx;
     intr.fy = _camintrinsics.fy;
@@ -2373,7 +2373,7 @@ bool QtCoinViewer::_TrackLinkCommand(ostream& sout, istream& sinput)
     }
     _ptrackinglink.reset();
     _ptrackingmanip.reset();
-    EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+    EnvironmentLock lockenv(GetEnv()->GetMutex());
     KinBodyPtr pbody = GetEnv()->GetKinBody(bodyname);
     if( !pbody ) {
         return false;
@@ -2406,7 +2406,7 @@ bool QtCoinViewer::_TrackManipulatorCommand(ostream& sout, istream& sinput)
     }
     _ptrackinglink.reset();
     _ptrackingmanip.reset();
-    EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+    EnvironmentLock lockenv(GetEnv()->GetMutex());
     RobotBasePtr probot = GetEnv()->GetRobot(robotname);
     if( !probot ) {
         return false;
@@ -2531,11 +2531,11 @@ bool QtCoinViewer::_HandleSelection(SoPath *path)
 
     // check the callbacks
     if( !!pSelectedLink ) {
-        boost::mutex::scoped_lock lock(_mutexCallbacks);
+        std::lock_guard<std::mutex> lock(_mutexCallbacks);
         FOREACH(it,_listRegisteredItemSelectionCallbacks) {
             bool bSame;
             {
-                boost::mutex::scoped_lock lock(_mutexMessages);
+                std::lock_guard<std::mutex> lock(_mutexMessages);
                 bSame = !_pMouseOverLink.expired() && KinBody::LinkPtr(_pMouseOverLink) == pSelectedLink;
             }
             if( bSame ) {
@@ -2554,7 +2554,7 @@ bool QtCoinViewer::_HandleSelection(SoPath *path)
         return false;
     }
 
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = LockEnvironment(100000);
+    boost::shared_ptr<EnvironmentLock> lockenv = LockEnvironment(100000);
     if( !lockenv ) {
         _ivRoot->deselectAll();
         RAVELOG_WARN("failed to grab environment lock\n");
@@ -2677,14 +2677,10 @@ void QtCoinViewer::_deselect()
     }
 }
 
-boost::shared_ptr<EnvironmentMutex::scoped_try_lock> QtCoinViewer::LockEnvironment(uint64_t timeout,bool bUpdateEnvironment)
+boost::shared_ptr<EnvironmentLock> QtCoinViewer::LockEnvironment(uint64_t timeout,bool bUpdateEnvironment)
 {
     // try to acquire the lock
-#if BOOST_VERSION >= 103500
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetEnv()->GetMutex(),boost::defer_lock_t()));
-#else
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetEnv()->GetMutex(),false));
-#endif
+    boost::shared_ptr<EnvironmentLock> lockenv = boost::make_shared<EnvironmentLock>(GetEnv()->GetMutex(), std::defer_lock_t());
     uint64_t basetime = utils::GetMicroTime();
     while(utils::GetMicroTime()-basetime<timeout ) {
         if( lockenv->try_lock() ) {
@@ -2759,7 +2755,7 @@ void QtCoinViewer::AdvanceFrame(bool bForward)
 
     //    {
     //        _bInIdleThread = true;
-    //        boost::mutex::scoped_lock lock(_mutexGUI);
+    //        std::lock_guard<std::mutex> lock(_mutexGUI);
     //        _bInIdleThread = false;
     //    }
 
@@ -2787,7 +2783,7 @@ void QtCoinViewer::AdvanceFrame(bool bForward)
         }
 
         if( !_pviewer->isViewing() ) {
-            boost::mutex::scoped_lock lock(_mutexMessages);
+            std::lock_guard<std::mutex> lock(_mutexMessages);
             ss << _strMouseMove;
         }
 
@@ -2833,7 +2829,7 @@ void QtCoinViewer::AdvanceFrame(bool bForward)
     {
         std::list<UserDataWeakPtr> listRegisteredViewerThreadCallbacks;
         {
-            boost::mutex::scoped_lock lock(_mutexCallbacks);
+            std::lock_guard<std::mutex> lock(_mutexCallbacks);
             listRegisteredViewerThreadCallbacks = _listRegisteredViewerThreadCallbacks;
         }
         FOREACH(it,listRegisteredViewerThreadCallbacks) {
@@ -2856,13 +2852,13 @@ void QtCoinViewer::AdvanceFrame(bool bForward)
 
 void QtCoinViewer::_UpdateEnvironment(float fTimeElapsed)
 {
-    boost::mutex::scoped_lock lockupd(_mutexUpdating);
+    std::lock_guard<std::mutex> lockupd(_mutexUpdating);
 
     if( _bUpdateEnvironment ) {
         // process all messages
         list<EnvMessagePtr> listmessages;
         {
-            boost::mutex::scoped_lock lockmsg(_mutexMessages);
+            std::lock_guard<std::mutex> lockmsg(_mutexMessages);
             listmessages.swap(_listMessages);
             BOOST_ASSERT( _listMessages.size() == 0 );
         }
@@ -2885,13 +2881,13 @@ void QtCoinViewer::_UpdateEnvironment(float fTimeElapsed)
 bool QtCoinViewer::ForceUpdatePublishedBodies()
 {
     {
-        boost::mutex::scoped_lock lockupdating(_mutexUpdating);
+        std::lock_guard<std::mutex> lockupdating(_mutexUpdating);
         if( !_bUpdateEnvironment )
             return false;
     }
 
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
-    EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+    std::unique_lock<std::mutex> lock(_mutexUpdateModels);
+    EnvironmentLock lockenv(GetEnv()->GetMutex());
     GetEnv()->UpdatePublishedBodies();
 
     _bModelsUpdated = false;
@@ -2911,7 +2907,7 @@ void QtCoinViewer::_VideoFrame()
 {
     std::list<UserDataWeakPtr> listRegisteredViewerImageCallbacks;
     {
-        boost::mutex::scoped_lock lock(_mutexCallbacks);
+        std::lock_guard<std::mutex> lock(_mutexCallbacks);
         if( _listRegisteredViewerImageCallbacks.size() == 0 ) {
             return;
         }
@@ -2940,22 +2936,17 @@ void QtCoinViewer::_VideoFrame()
 void QtCoinViewer::UpdateFromModel()
 {
     {
-        boost::mutex::scoped_lock lock(_mutexItems);
+        std::lock_guard<std::mutex> lock(_mutexItems);
         FOREACH(it,_listRemoveItems) {
             delete *it;
         }
         _listRemoveItems.clear();
     }
 
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
+    std::lock_guard<std::mutex> lock(_mutexUpdateModels);
     vector<KinBody::BodyState> vecbodies;
 
-
-#if BOOST_VERSION >= 103500
-    EnvironmentMutex::scoped_try_lock lockenv(GetEnv()->GetMutex(),boost::defer_lock_t());
-#else
-    EnvironmentMutex::scoped_try_lock lockenv(GetEnv()->GetMutex(),false);
-#endif
+    EnvironmentLock lockenv(GetEnv()->GetMutex(), std::defer_lock_t());
 
     if( _bLockEnvironment && !lockenv ) {
         uint64_t basetime = utils::GetMicroTime();
@@ -3100,7 +3091,7 @@ void QtCoinViewer::_Reset()
     }
 
     {
-        boost::mutex::scoped_lock lock(_mutexItems);
+        std::lock_guard<std::mutex> lock(_mutexItems);
         FOREACH(it,_listRemoveItems) {
             delete *it;
         }
@@ -3110,7 +3101,7 @@ void QtCoinViewer::_Reset()
 
 void QtCoinViewer::_UpdateCameraTransform(float fTimeElapsed)
 {
-    boost::mutex::scoped_lock lock(_mutexMessages);
+    std::lock_guard<std::mutex> lock(_mutexMessages);
 
     SbVec3f pos = GetCamera()->position.getValue();
     _Tcamera.trans = RaveVector<float>(pos[0], pos[1], pos[2]);
@@ -3278,7 +3269,7 @@ void QtCoinViewer::ViewGeometryChanged(QAction* pact)
     _mapbodies.clear();
 
     {
-        boost::mutex::scoped_lock lock(_mutexItems);
+        std::lock_guard<std::mutex> lock(_mutexItems);
         FOREACH(it,_listRemoveItems) {
             delete *it;
         }
@@ -3329,7 +3320,7 @@ void QtCoinViewer::RecordRealtimeVideo(bool on)
 
 void QtCoinViewer::ToggleSimulation(bool on)
 {
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = LockEnvironment(200000);
+    boost::shared_ptr<EnvironmentLock> lockenv = LockEnvironment(200000);
     if( !!lockenv ) {
         if( on ) {
             GetEnv()->StartSimulation(0.01f);
@@ -3697,7 +3688,7 @@ QtCoinViewer::EnvMessage::EnvMessage(QtCoinViewerPtr pviewer, void** ppreturn, b
 {
     // get a mutex
     if( bWaitForMutex ) {
-        _plock.reset(new boost::mutex::scoped_lock(_mutex));
+        _plock = boost::make_shared<std::unique_lock<std::mutex>>(_mutex);
     }
 }
 
@@ -3720,13 +3711,13 @@ void QtCoinViewer::EnvMessage::callerexecute(bool bGuiThread)
         {
             QtCoinViewerPtr pviewer = _pviewer.lock();
             if( !!pviewer ) {
-                boost::mutex::scoped_lock lock(pviewer->_mutexMessages);
+                std::lock_guard<std::mutex> lock(pviewer->_mutexMessages);
                 pviewer->_listMessages.push_back(shared_from_this());
             }
         }
 
         if( bWaitForMutex ) {
-            boost::mutex::scoped_lock lock(_mutex);
+            std::lock_guard<std::mutex> lock(_mutex);
         }
     }
 }
@@ -3802,8 +3793,8 @@ bool QtCoinViewer::_SaveBodyLinkToVRMLCommand(ostream& sout, istream& sinput)
         return false;
     }
 
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
-    boost::mutex::scoped_lock lock2(g_mutexsoqt);
+    std::lock_guard<std::mutex> lock(_mutexUpdateModels);
+    std::lock_guard<std::mutex> lock2(g_mutexsoqt);
 
     if( _mapbodies.find(pbody) == _mapbodies.end() ) {
         RAVELOG_WARN_FORMAT("couldn't find body %s in viewer list", bodyname);

--- a/plugins/qtcoinrave/qtcoinviewer.h
+++ b/plugins/qtcoinrave/qtcoinviewer.h
@@ -188,12 +188,12 @@ public:
     virtual UserDataPtr RegisterViewerThreadCallback(const ViewerThreadCallbackFn& fncallback);
     virtual void _DeleteItemCallback(Item* pItem)
     {
-        boost::mutex::scoped_lock lock(_mutexItems);
+        std::lock_guard<std::mutex> lock(_mutexItems);
         pItem->PrepForDeletion();
         _listRemoveItems.push_back(pItem);
     }
 
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> LockEnvironment(uint64_t timeout=50000,bool bUpdateEnvironment = true);
+    boost::shared_ptr<EnvironmentLock> LockEnvironment(uint64_t timeout=50000,bool bUpdateEnvironment = true);
 
 public slots:
 
@@ -244,8 +244,8 @@ public:
 protected:
         boost::weak_ptr<QtCoinViewer> _pviewer;
         void** _ppreturn;
-        boost::mutex _mutex;
-        boost::shared_ptr<boost::mutex::scoped_lock> _plock;
+        std::mutex _mutex;
+        boost::shared_ptr<std::unique_lock<std::mutex>> _plock;
     };
     typedef boost::shared_ptr<EnvMessage> EnvMessagePtr;
     typedef boost::shared_ptr<EnvMessage const> EnvMessageConstPtr;
@@ -385,8 +385,8 @@ public:
     // Message Queue
     list<EnvMessagePtr> _listMessages;
     list<Item*> _listRemoveItems;
-    boost::mutex _mutexItems, _mutexUpdating, _mutexMouseMove;     ///< mutex protected messages
-    mutable boost::mutex _mutexMessages;
+    std::mutex _mutexItems, _mutexUpdating, _mutexMouseMove;     ///< mutex protected messages
+    mutable std::mutex _mutexMessages;
 
     QVBoxLayout * vlayout;
     QGroupBox * view1;
@@ -446,9 +446,9 @@ public:
     int _available;
 
     bool _bLockEnvironment;
-    boost::mutex _mutexUpdateModels, _mutexCallbacks;
-    boost::condition _condUpdateModels;     ///< signaled everytime environment models are updated
-    boost::mutex _mutexGUI;
+    std::mutex _mutexUpdateModels, _mutexCallbacks;
+    std::condition_variable _condUpdateModels;     ///< signaled everytime environment models are updated
+    std::mutex _mutexGUI;
     bool _bInIdleThread;
 
     // toggle switches

--- a/plugins/qtosgrave/osgrenderitem.cpp
+++ b/plugins/qtosgrave/osgrenderitem.cpp
@@ -712,7 +712,7 @@ bool KinBodyItem::UpdateFromOSG()
         }
     }
 
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = LockEnvironmentWithTimeout(_pbody->GetEnv(), 50000);
+    boost::shared_ptr<EnvironmentLock> lockenv = LockEnvironmentWithTimeout(_pbody->GetEnv(), 50000);
     if( !!lockenv ) {
         _pbody->SetLinkTransformations(vtrans,_vjointvalues);
         _pbody->GetLinkTransformations(_vtrans,_vjointvalues);
@@ -725,13 +725,13 @@ bool KinBodyItem::UpdateFromOSG()
 
 void KinBodyItem::GetDOFValues(vector<dReal>& vjoints) const
 {
-    boost::mutex::scoped_lock lock(_mutexjoints);
+    std::lock_guard<std::mutex> lock(_mutexjoints);
     vjoints = _vjointvalues;
 }
 
 void KinBodyItem::GetLinkTransformations(vector<Transform>& vtrans, std::vector<dReal>& vdofvalues) const
 {
-    boost::mutex::scoped_lock lock(_mutexjoints);
+    std::lock_guard<std::mutex> lock(_mutexjoints);
     vtrans = _vtrans;
     vdofvalues = _vjointvalues;
 }
@@ -745,7 +745,7 @@ bool KinBodyItem::UpdateFromModel()
     vector<dReal> vjointvalues;
 
     {
-        boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv = LockEnvironmentWithTimeout(_pbody->GetEnv(), 50000);
+        boost::shared_ptr<EnvironmentLock> lockenv = LockEnvironmentWithTimeout(_pbody->GetEnv(), 50000);
         if( !lockenv ) {
             return false;
         }
@@ -778,7 +778,7 @@ bool KinBodyItem::UpdateFromModel(const vector<dReal>& vjointvalues, const vecto
     }
 
     if( _bReload || _bDrawStateChanged ) {
-        EnvironmentMutex::scoped_try_lock lockenv(_pbody->GetEnv()->GetMutex());
+        EnvironmentLock lockenv(_pbody->GetEnv()->GetMutex());
         if( !!lockenv ) {
             if( _bReload || _bDrawStateChanged ) {
                 Load();
@@ -786,7 +786,7 @@ bool KinBodyItem::UpdateFromModel(const vector<dReal>& vjointvalues, const vecto
         }
     }
 
-    boost::mutex::scoped_lock lock(_mutexjoints);
+    std::lock_guard<std::mutex> lock(_mutexjoints);
     _vjointvalues = vjointvalues;
     _vtrans = vtrans;
 

--- a/plugins/qtosgrave/osgrenderitem.h
+++ b/plugins/qtosgrave/osgrenderitem.h
@@ -210,7 +210,7 @@ protected:
 
     std::vector<dReal> _vjointvalues;
     vector<Transform> _vtrans;
-    mutable boost::mutex _mutexjoints;
+    mutable std::mutex _mutexjoints;
     UserDataPtr _geometrycallback, _drawcallback;
 
 private:

--- a/plugins/qtosgrave/qtosg.h
+++ b/plugins/qtosgrave/qtosg.h
@@ -220,14 +220,10 @@ protected:
     bool _found;
 };
 
-inline boost::shared_ptr<EnvironmentMutex::scoped_try_lock> LockEnvironmentWithTimeout(EnvironmentBasePtr penv, uint64_t timeout)
+inline boost::shared_ptr<EnvironmentLock> LockEnvironmentWithTimeout(EnvironmentBasePtr penv, uint64_t timeout)
 {
     // try to acquire the lock
-#if BOOST_VERSION >= 103500
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(penv->GetMutex(),boost::defer_lock_t()));
-#else
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(penv->GetMutex(),false));
-#endif
+    boost::shared_ptr<EnvironmentLock> lockenv = boost::make_shared<EnvironmentLock>(penv->GetMutex(), std::defer_lock_t());
     uint64_t basetime = utils::GetMicroTime();
     while(utils::GetMicroTime()-basetime<timeout ) {
         if( lockenv->try_lock() ) {

--- a/plugins/qtosgrave/qtosgviewer.cpp
+++ b/plugins/qtosgrave/qtosgviewer.cpp
@@ -40,7 +40,7 @@ public:
     virtual ~ItemSelectionCallbackData() {
         boost::shared_ptr<QtOSGViewer> pviewer = _pweakviewer.lock();
         if( !!pviewer ) {
-            boost::mutex::scoped_lock lock(pviewer->_mutexCallbacks);
+            std::lock_guard<std::mutex> lock(pviewer->_mutexCallbacks);
             pviewer->_listRegisteredItemSelectionCallbacks.erase(_iterator);
         }
     }
@@ -60,7 +60,7 @@ public:
     virtual ~ViewerThreadCallbackData() {
         boost::shared_ptr<QtOSGViewer> pviewer = _pweakviewer.lock();
         if( !!pviewer ) {
-            boost::mutex::scoped_lock lock(pviewer->_mutexCallbacks);
+            std::lock_guard<std::mutex> lock(pviewer->_mutexCallbacks);
             pviewer->_listRegisteredViewerThreadCallbacks.erase(_iterator);
         }
     }
@@ -346,13 +346,13 @@ void QtOSGViewer::customEvent(QEvent * e)
 bool QtOSGViewer::_ForceUpdatePublishedBodies()
 {
     {
-        boost::mutex::scoped_lock lockupdating(_mutexUpdating);
+        std::lock_guard<std::mutex> lockupdating(_mutexUpdating);
         if( !_bUpdateEnvironment )
             return false;
     }
 
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
-    EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+    std::unique_lock<std::mutex> lock(_mutexUpdateModels);
+    EnvironmentLock lockenv(GetEnv()->GetMutex());
     GetEnv()->UpdatePublishedBodies();
 
     _bModelsUpdated = false;
@@ -477,7 +477,7 @@ void QtOSGViewer::_UpdateViewerCallback()
         {
             std::list<UserDataWeakPtr> listRegisteredViewerThreadCallbacks;
             {
-                boost::mutex::scoped_lock lock(_mutexCallbacks);
+                std::lock_guard<std::mutex> lock(_mutexCallbacks);
                 listRegisteredViewerThreadCallbacks = _listRegisteredViewerThreadCallbacks;
             }
             FOREACH(it,listRegisteredViewerThreadCallbacks) {
@@ -518,7 +518,7 @@ void QtOSGViewer::_Reset()
 
 
     {
-        boost::mutex::scoped_lock lock(_mutexItems);
+        std::lock_guard<std::mutex> lock(_mutexItems);
         FOREACH(it,_listRemoveItems) {
             delete *it;
         }
@@ -572,7 +572,7 @@ void QtOSGViewer::LoadEnvironment()
 
     _Reset();
     try {
-        EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+        EnvironmentLock lockenv(GetEnv()->GetMutex());
         GetEnv()->Reset();
 
         GetEnv()->Load(s.toLatin1().data());
@@ -602,7 +602,7 @@ void QtOSGViewer::ImportEnvironment()
         return;
     }
     try {
-        EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+        EnvironmentLock lockenv(GetEnv()->GetMutex());
         GetEnv()->Load(s.toLatin1().data());
 
         //  Refresh the screen.
@@ -620,7 +620,7 @@ void QtOSGViewer::SaveEnvironment()
         return;
     }
     try {
-        EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+        EnvironmentLock lockenv(GetEnv()->GetMutex());
         GetEnv()->Save(s.toLatin1().data());
     }
     catch(const std::exception& ex) {
@@ -1060,7 +1060,7 @@ void QtOSGViewer::_FillObjectTree(QTreeWidget *treeWidget)
 
 void QtOSGViewer::_UpdateViewport()
 {
-    boost::mutex::scoped_lock lock(_mutexGUIFunctions);
+    std::lock_guard<std::mutex> lock(_mutexGUIFunctions);
 
     int width = centralWidget()->size().width();
     int height = centralWidget()->size().height();
@@ -1146,7 +1146,7 @@ bool QtOSGViewer::_TrackLinkCommand(ostream& sout, istream& sinput)
     if( focalDistance > 0 ) {
         _SetCameraDistanceToFocus(focalDistance);
     }
-    EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+    EnvironmentLock lockenv(GetEnv()->GetMutex());
     KinBodyPtr pbody = GetEnv()->GetKinBody(bodyname);
     if( !pbody ) {
         // restore navigation manipulator
@@ -1182,7 +1182,7 @@ bool QtOSGViewer::_TrackManipulatorCommand(ostream& sout, istream& sinput)
         _SetCameraDistanceToFocus(focalDistance);
     }
 
-    EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex());
+    EnvironmentLock lockenv(GetEnv()->GetMutex());
     RobotBasePtr probot = GetEnv()->GetRobot(robotname);
     RobotBase::ManipulatorPtr requestedManipulator = NULL;
     if( !!probot ) {
@@ -1213,7 +1213,7 @@ void QtOSGViewer::_ProcessApplicationQuit()
     // remove all messages in order to release the locks
     map<ViewerCommandPriority, list<GUIThreadFunctionPtr>> mapGUIFunctionLists;
     {
-        boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
+        std::lock_guard<std::mutex> lockmsg(_mutexGUIFunctions);
         mapGUIFunctionLists.swap(_mapGUIFunctionLists);
     }
 
@@ -1486,7 +1486,7 @@ void QtOSGViewer::_SetCameraDistanceToFocus(float focalDistance)
 
 RaveTransform<float> QtOSGViewer::GetCameraTransform() const
 {
-    boost::mutex::scoped_lock lock(_mutexGUIFunctions);
+    std::lock_guard<std::mutex> lock(_mutexGUIFunctions);
     // have to flip Z axis
     RaveTransform<float> trot; trot.rot = quatFromAxisAngle(RaveVector<float>(1,0,0),(float)PI);
     return GetRaveTransformFromMatrix(_posgWidget->GetCurrentCameraManipulator()->getMatrix()) * trot;
@@ -1494,19 +1494,19 @@ RaveTransform<float> QtOSGViewer::GetCameraTransform() const
 
 float QtOSGViewer::GetCameraDistanceToFocus() const
 {
-    boost::mutex::scoped_lock lock(_mutexGUIFunctions);
+    std::lock_guard<std::mutex> lock(_mutexGUIFunctions);
     return _posgWidget->GetCameraDistanceToFocus();
 }
 
 geometry::RaveCameraIntrinsics<float> QtOSGViewer::GetCameraIntrinsics() const
 {
-    boost::mutex::scoped_lock lock(_mutexGUIFunctions);
+    std::lock_guard<std::mutex> lock(_mutexGUIFunctions);
     return _camintrinsics;
 }
 
 SensorBase::CameraIntrinsics QtOSGViewer::GetCameraIntrinsics2() const
 {
-    boost::mutex::scoped_lock lock(_mutexGUIFunctions);
+    std::lock_guard<std::mutex> lock(_mutexGUIFunctions);
     SensorBase::CameraIntrinsics intr;
     intr.fx = _camintrinsics.fx;
     intr.fy = _camintrinsics.fy;
@@ -2002,21 +2002,17 @@ bool QtOSGViewer::LoadModel(const string& filename)
 void QtOSGViewer::UpdateFromModel()
 {
     {
-        boost::mutex::scoped_lock lock(_mutexItems);
+        std::lock_guard<std::mutex> lock(_mutexItems);
         FOREACH(it,_listRemoveItems) {
             delete *it;
         }
         _listRemoveItems.clear();
     }
 
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
+    std::lock_guard<std::mutex> lock(_mutexUpdateModels);
     vector<KinBody::BodyState> vecbodies;
 
-#if BOOST_VERSION >= 103500
-    EnvironmentMutex::scoped_try_lock lockenv(GetEnv()->GetMutex(),boost::defer_lock_t());
-#else
-    EnvironmentMutex::scoped_try_lock lockenv(GetEnv()->GetMutex(),false);
-#endif
+    EnvironmentLock lockenv(GetEnv()->GetMutex(), std::defer_lock_t());
 
     if( _bLockEnvironment && !lockenv ) {
         uint64_t basetime = utils::GetMicroTime();
@@ -2162,14 +2158,10 @@ void QtOSGViewer::UpdateFromModel()
     }
 }
 
-boost::shared_ptr<EnvironmentMutex::scoped_try_lock> QtOSGViewer::LockEnvironment(uint64_t timeout,bool bUpdateEnvironment)
+boost::shared_ptr<EnvironmentLock> QtOSGViewer::LockEnvironment(uint64_t timeout,bool bUpdateEnvironment)
 {
     // try to acquire the lock
-#if BOOST_VERSION >= 103500
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetEnv()->GetMutex(),boost::defer_lock_t()));
-#else
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetEnv()->GetMutex(),false));
-#endif
+    boost::shared_ptr<EnvironmentLock> lockenv = boost::make_shared<EnvironmentLock>(GetEnv()->GetMutex(), std::defer_lock_t());
     uint64_t basetime = utils::GetMicroTime();
     while(utils::GetMicroTime()-basetime<timeout ) {
         if( lockenv->try_lock() ) {
@@ -2188,13 +2180,13 @@ boost::shared_ptr<EnvironmentMutex::scoped_try_lock> QtOSGViewer::LockEnvironmen
 
 void QtOSGViewer::_UpdateEnvironment()
 {
-    boost::mutex::scoped_lock lockupd(_mutexUpdating);
+    std::lock_guard<std::mutex> lockupd(_mutexUpdating);
 
     if( _bUpdateEnvironment ) {
         // process all messages
         map<ViewerCommandPriority, list<GUIThreadFunctionPtr>> mapGUIFunctionLists;
         {
-            boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
+            std::lock_guard<std::mutex> lockmsg(_mutexGUIFunctions);
             mapGUIFunctionLists.swap(_mapGUIFunctionLists);
         }
 
@@ -2225,7 +2217,7 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, ViewerComm
         return;
     }
 
-    boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
+    std::unique_lock<std::mutex> lockmsg(_mutexGUIFunctions);
     GUIThreadFunctionPtr pfn(new GUIThreadFunction(fn, block));
     // Block non-essential fucntions if viewer is not processing any messages
     if (!_bUpdateEnvironment && priority < ViewerCommandPriority::HIGH) {
@@ -2241,15 +2233,15 @@ void QtOSGViewer::_PostToGUIThread(const boost::function<void()>& fn, ViewerComm
     _mapGUIFunctionLists[priority].push_back(pfn);
     if( block ) {
         while(!pfn->IsFinished()) {
-            _notifyGUIFunctionComplete.wait(_mutexGUIFunctions);
+            _notifyGUIFunctionComplete.wait(lockmsg);
         }
     }
 }
 
 void QtOSGViewer::SetEnvironmentSync(bool bUpdate)
 {
-    boost::mutex::scoped_lock lockupdating(_mutexUpdating);
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
+    std::lock_guard<std::mutex> lockupdating(_mutexUpdating);
+    std::lock_guard<std::mutex> lock(_mutexUpdateModels);
     _bUpdateEnvironment = bUpdate;
     _condUpdateModels.notify_all();
 
@@ -2257,7 +2249,7 @@ void QtOSGViewer::SetEnvironmentSync(bool bUpdate)
         // remove all messages in order to release the locks
         map<ViewerCommandPriority, list<GUIThreadFunctionPtr>> mapGUIFunctionLists;
         {
-            boost::mutex::scoped_lock lockmsg(_mutexGUIFunctions);
+            std::lock_guard<std::mutex> lockmsg(_mutexGUIFunctions);
             mapGUIFunctionLists.swap(_mapGUIFunctionLists);
         }
 
@@ -2283,7 +2275,7 @@ void QtOSGViewer::SetEnvironmentSync(bool bUpdate)
 
 void QtOSGViewer::_DeleteItemCallback(Item* pItem)
 {
-    boost::mutex::scoped_lock lock(_mutexItems);
+    std::lock_guard<std::mutex> lock(_mutexItems);
     pItem->PrepForDeletion();
     _listRemoveItems.push_back(pItem);
 }
@@ -2291,14 +2283,14 @@ void QtOSGViewer::_DeleteItemCallback(Item* pItem)
 void QtOSGViewer::EnvironmentSync()
 {
     {
-        boost::mutex::scoped_lock lockupdating(_mutexUpdating);
+        std::lock_guard<std::mutex> lockupdating(_mutexUpdating);
         if( !_bUpdateEnvironment ) {
             RAVELOG_WARN("cannot update models from environment sync\n");
             return;
         }
     }
 
-    boost::mutex::scoped_lock lock(_mutexUpdateModels);
+    std::unique_lock<std::mutex> lock(_mutexUpdateModels);
     _bModelsUpdated = false;
     _condUpdateModels.wait(lock);
     if( !_bModelsUpdated ) {

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -137,7 +137,7 @@ public:
     virtual UserDataPtr RegisterViewerThreadCallback(const ViewerThreadCallbackFn& fncallback);
 
     /// \brief Locks environment
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> LockEnvironment(uint64_t timeout=50000,bool bUpdateEnvironment = true);
+    boost::shared_ptr<EnvironmentLock> LockEnvironment(uint64_t timeout=50000,bool bUpdateEnvironment = true);
 
 public slots:
 
@@ -415,9 +415,9 @@ public:
     std::map<ViewerCommandPriority, list<GUIThreadFunctionPtr>> _mapGUIFunctionLists; ///< map between priority and sublist for given priority level. protected by _mutexGUIFunctions
     std::map<ViewerCommandPriority, size_t> _mapGUIFunctionListLimits; ///< map between priority and sublist size limit for given priority level
     mutable list<Item*> _listRemoveItems; ///< raw points of items to be deleted in the viewer update thread, triggered from _DeleteItemCallback. proteced by _mutexItems
-    boost::mutex _mutexItems; ///< protects _listRemoveItems
-    mutable boost::mutex _mutexGUIFunctions;
-    mutable boost::condition _notifyGUIFunctionComplete; ///< signaled when a blocking _listGUIFunctions has been completed
+    std::mutex _mutexItems; ///< protects _listRemoveItems
+    mutable std::mutex _mutexGUIFunctions;
+    mutable std::condition_variable _notifyGUIFunctionComplete; ///< signaled when a blocking _listGUIFunctions has been completed
     //@}
 
     //@{ osg rendering primitives
@@ -432,14 +432,14 @@ public:
     geometry::RaveCameraIntrinsics<float> _camintrinsics; ///< intrinsics of the camera representing the current view, updated periodically, read only.
     //@}
 
-    boost::mutex _mutexUpdating; ///< when inside an update function, even if just checking if the viewer should be updated, this will be locked.
-    boost::mutex _mutexUpdateModels; ///< locked when osg environment is being updated from the underlying openrave environment
-    boost::condition _condUpdateModels; ///< signaled everytime environment models are updated
+    std::mutex _mutexUpdating; ///< when inside an update function, even if just checking if the viewer should be updated, this will be locked.
+    std::mutex _mutexUpdateModels; ///< locked when osg environment is being updated from the underlying openrave environment
+    std::condition_variable _condUpdateModels; ///< signaled everytime environment models are updated
 
     ViewGeometry _viewGeometryMode; ///< the visualization mode of the geometries
 
     //@{ callbacks
-    boost::mutex _mutexCallbacks; ///< maintains lock on list of callsbacks viewer has to make like _listRegisteredViewerThreadCallbacks, _listRegisteredItemSelectionCallbacks
+    std::mutex _mutexCallbacks; ///< maintains lock on list of callsbacks viewer has to make like _listRegisteredViewerThreadCallbacks, _listRegisteredItemSelectionCallbacks
     std::list<UserDataWeakPtr> _listRegisteredItemSelectionCallbacks;
     std::list<UserDataWeakPtr> _listRegisteredViewerThreadCallbacks;
     //@}

--- a/plugins/rmanipulation/basemanipulation.cpp
+++ b/plugins/rmanipulation/basemanipulation.cpp
@@ -125,7 +125,7 @@ Method wraps the WorkspaceTrajectoryTracker planner. For more details on paramet
 
     virtual bool SendCommand(std::ostream& sout, std::istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         return ModuleBase::SendCommand(sout,sinput);
     }
 protected:

--- a/plugins/rmanipulation/taskmanipulation.cpp
+++ b/plugins/rmanipulation/taskmanipulation.cpp
@@ -193,7 +193,7 @@ Task-based manipulation planning involving target objects. A lot of the algorith
 
     virtual bool SendCommand(std::ostream& sout, std::istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _robot = GetEnv()->GetRobot(_strRobotName);
         return ModuleBase::SendCommand(sout,sinput);
     }

--- a/plugins/rmanipulation/visualfeedback.cpp
+++ b/plugins/rmanipulation/visualfeedback.cpp
@@ -656,7 +656,7 @@ Visibility computation checks occlusion with other objects using ray sampling in
 
     virtual bool SendCommand(std::ostream& sout, std::istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         return ModuleBase::SendCommand(sout,sinput);
     }
 

--- a/plugins/rplanners/constraintparabolicsmoother.cpp
+++ b/plugins/rplanners/constraintparabolicsmoother.cpp
@@ -107,7 +107,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
         _probot = pbase;
@@ -116,7 +116,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         isParameters >> *_parameters;
         _probot = pbase;

--- a/plugins/rplanners/jerklimitedsmootherbase.h
+++ b/plugins/rplanners/jerklimitedsmootherbase.h
@@ -65,7 +65,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
         return _InitPlan();
@@ -73,7 +73,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& sparams)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         sparams >> *_parameters;
         return _InitPlan();

--- a/plugins/rplanners/linearshortcutadvanced.cpp
+++ b/plugins/rplanners/linearshortcutadvanced.cpp
@@ -33,7 +33,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         _parameters->copy(params);
         _probot = pbase;
@@ -42,7 +42,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         isParameters >> *_parameters;
         _probot = pbase;

--- a/plugins/rplanners/linearsmoother.cpp
+++ b/plugins/rplanners/linearsmoother.cpp
@@ -31,7 +31,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         _parameters->copy(params);
         _probot = pbase;
@@ -40,7 +40,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         isParameters >> *_parameters;
         _probot = pbase;

--- a/plugins/rplanners/parabolicsmoother.cpp
+++ b/plugins/rplanners/parabolicsmoother.cpp
@@ -201,7 +201,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
         return _InitPlan();
@@ -209,7 +209,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         isParameters >> *_parameters;
         return _InitPlan();

--- a/plugins/rplanners/parabolicsmoother2.cpp
+++ b/plugins/rplanners/parabolicsmoother2.cpp
@@ -368,7 +368,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
         return _InitPlan();
@@ -376,7 +376,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         isParameters >> *_parameters;
         return _InitPlan();

--- a/plugins/rplanners/randomized-astar.cpp
+++ b/plugins/rplanners/randomized-astar.cpp
@@ -310,7 +310,7 @@ Rosen Diankov, James Kuffner. \"Randomized Statistical Path Planning. Intl. Conf
     ///< manipulator state is also set
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset();
         Destroy();
         _robot = pbase;

--- a/plugins/rplanners/rrt.h
+++ b/plugins/rplanners/rrt.h
@@ -46,7 +46,7 @@ Uses the Rapidly-Exploring Random Trees Algorithm.\n\
         params->Validate();
         _goalindex = -1;
         _startindex = -1;
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         if( !_uniformsampler ) {
             _uniformsampler = RaveCreateSpaceSampler(GetEnv(),"mt19937");
         }
@@ -296,7 +296,7 @@ Some python code to display data::\n\
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new RRTParameters());
         _parameters->copy(pparams);
         if( !RrtPlanner<SimpleNode>::_InitPlan(pbase,_parameters) ) {
@@ -363,7 +363,7 @@ Some python code to display data::\n\
             return OPENRAVE_PLANNER_STATUS(str(boost::format("env=%s, BirrtPlanner::PlanPath - Error, planner not initialized")%GetEnv()->GetNameId()), PS_Failed);
         }
 
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         uint64_t basetimeus = utils::GetMonotonicTime();
         
         int constraintFilterOptions = 0xffff|CFO_FillCheckedConfiguration;
@@ -693,7 +693,7 @@ public:
 
     bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new BasicRRTParameters());
         _parameters->copy(pparams);
         if( !RrtPlanner<SimpleNode>::_InitPlan(pbase,_parameters) ) {
@@ -750,7 +750,7 @@ public:
             return OPENRAVE_PLANNER_STATUS(description, PS_Failed);
         }
 
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         uint32_t basetime = utils::GetMilliTime();
 
         NodeBasePtr lastnode; // the last node visited by the RRT
@@ -955,7 +955,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr pparams)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ExplorationParameters());
         _parameters->copy(pparams);
         if( !RrtPlanner<SimpleNode>::_InitPlan(pbase,_parameters) ) {
@@ -973,7 +973,7 @@ public:
         if( !_parameters ) {
             return OPENRAVE_PLANNER_STATUS(PS_Failed);
         }
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         vector<dReal> vSampleConfig;
 
         PlannerParameters::StateSaver savestate(_parameters);

--- a/plugins/rplanners/subparabolicsmoother.cpp
+++ b/plugins/rplanners/subparabolicsmoother.cpp
@@ -32,7 +32,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         _parameters->copy(params);
         return _InitPlan();
@@ -40,7 +40,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new TrajectoryTimingParameters());
         isParameters >> *_parameters;
         _numImportantDOF = 7;

--- a/plugins/rplanners/trajectoryretimer.h
+++ b/plugins/rplanners/trajectoryretimer.h
@@ -52,7 +52,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         params->Validate();
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
@@ -64,7 +64,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         isParameters >> *_parameters;
         _parameters->Validate();

--- a/plugins/rplanners/trajectoryretimer2.h
+++ b/plugins/rplanners/trajectoryretimer2.h
@@ -50,7 +50,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         params->Validate();
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
@@ -62,7 +62,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         isParameters >> *_parameters;
         _parameters->Validate();

--- a/plugins/rplanners/trajectoryretimer3.h
+++ b/plugins/rplanners/trajectoryretimer3.h
@@ -59,7 +59,7 @@ public:
     }
 
     virtual bool InitPlan(RobotBasePtr pbase, PlannerParametersConstPtr params) {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         params->Validate();
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         _parameters->copy(params);
@@ -71,7 +71,7 @@ public:
 
     virtual bool InitPlan(RobotBasePtr pbase, std::istream& isParameters)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         _parameters.reset(new ConstraintTrajectoryTimingParameters());
         isParameters >> *_parameters;
         _parameters->Validate();

--- a/plugins/rplanners/workspacetrajectorytracker.cpp
+++ b/plugins/rplanners/workspacetrajectorytracker.cpp
@@ -48,7 +48,7 @@ Planner Parameters\n\
 
     virtual bool InitPlan(RobotBasePtr probot, PlannerParametersConstPtr params)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         boost::shared_ptr<WorkspaceTrajectoryParameters> parameters(new WorkspaceTrajectoryParameters(GetEnv()));
         parameters->copy(params);
@@ -138,7 +138,7 @@ Planner Parameters\n\
             return PlannerStatus(description, PS_Failed);
         }
 
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         uint32_t basetime = utils::GetMilliTime();
         RobotBase::RobotStateSaver savestate(_robot);
         _robot->SetActiveDOFs(_manip->GetArmIndices());     // should be set by user anyway, but this is an extra precaution

--- a/plugins/textserver/textserver.h
+++ b/plugins/textserver/textserver.h
@@ -17,6 +17,8 @@
 #ifndef OPENRAVE_TEXTSERVER
 #define OPENRAVE_TEXTSERVER
 
+#include <condition_variable>
+#include <mutex>
 #include <openrave/planningutils.h>
 #include <cstdlib>
 
@@ -401,8 +403,8 @@ public:
 #endif
 
         RAVELOG_DEBUG("text server listening on port %d\n",_nPort);
-        _servthread.reset(new boost::thread(boost::bind(&SimpleTextServer::_listen_threadcb,this)));
-        _workerthread.reset(new boost::thread(boost::bind(&SimpleTextServer::_worker_threadcb,this)));
+        _servthread = boost::make_shared<std::thread>(std::bind(&SimpleTextServer::_listen_threadcb, this));
+        _workerthread = boost::make_shared<std::thread>(std::bind(&SimpleTextServer::_worker_threadcb, this));
         bInitThread = true;
         return 0;
     }
@@ -412,7 +414,7 @@ public:
         Reset();
 
         {
-            boost::mutex::scoped_lock lock(_mutexWorker);     // need lock to keep multiple threads out of Destroy
+            std::lock_guard<std::mutex> lock(_mutexWorker);     // need lock to keep multiple threads out of Destroy
             if( bDestroying ) {
                 return;
             }
@@ -452,7 +454,7 @@ public:
     virtual void Reset()
     {
         {
-            boost::mutex::scoped_lock lock(_mutexWorker);
+            std::lock_guard<std::mutex> lock(_mutexWorker);
             listWorkers.clear();
             _mapFigureIds.clear();
         }
@@ -481,7 +483,7 @@ private:
     // called from threads other than the main worker to wait until
     void _SyncWithWorkerThread()
     {
-        boost::mutex::scoped_lock lock(_mutexWorker);
+        std::unique_lock<std::mutex> lock(_mutexWorker);
         while((listWorkers.size() > 0 || _bWorking) && !bCloseThread) {
             _condHasWork.notify_all();
             _condWorker.wait(lock);
@@ -490,7 +492,7 @@ private:
 
     void ScheduleWorker(const boost::function<void()>& fn)
     {
-        boost::mutex::scoped_lock lock(_mutexWorker);
+        std::lock_guard<std::mutex> lock(_mutexWorker);
         listWorkers.push_back(fn);
         _condHasWork.notify_all();
     }
@@ -500,7 +502,7 @@ private:
         list<boost::function<void()> > listlocalworkers;
         while(!bCloseThread) {
             {
-                boost::mutex::scoped_lock lock(_mutexWorker);
+                std::unique_lock<std::mutex> lock(_mutexWorker);
                 _condHasWork.wait(lock);
                 if( bCloseThread ) {
                     break;
@@ -546,7 +548,7 @@ private:
             }
 
             // start a new thread
-            _listReadThreads.push_back(boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&SimpleTextServer::_read_threadcb,shared_server(), psocket))));
+            _listReadThreads.emplace_back(boost::make_shared<std::thread>(std::bind(&SimpleTextServer::_read_threadcb, shared_server(), psocket)));
             psocket.reset(new Socket());
         }
 
@@ -643,12 +645,12 @@ private:
 
     int _nPort;     ///< port used for listening to incoming connections
 
-    boost::shared_ptr<boost::thread> _servthread, _workerthread;
-    list<boost::shared_ptr<boost::thread> > _listReadThreads;
+    boost::shared_ptr<std::thread> _servthread, _workerthread;
+    list<boost::shared_ptr<std::thread> > _listReadThreads;
 
-    boost::mutex _mutexWorker;
-    boost::condition _condWorker;
-    boost::condition _condHasWork;
+    std::mutex _mutexWorker;
+    std::condition_variable _condWorker;
+    std::condition_variable _condHasWork;
 
     bool bInitThread;
     bool bCloseThread;
@@ -734,7 +736,7 @@ protected:
         if( cmd == "quit" ) {
             GetEnv()->Reset();
             // call exit in a different thread
-            new boost::thread(_CallExit);
+            new std::thread(_CallExit);
         }
         return true;
     }
@@ -876,7 +878,7 @@ protected:
         if( !is ) {
             return false;
         }
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr robot = RaveCreateRobot(GetEnv(),robottype);
         if( !robot ) {
             return false;
@@ -965,7 +967,7 @@ protected:
         }
 
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr body = GetEnv()->ReadKinBodyURI(KinBodyPtr(),xmlfile,list<pair<string,string> >());
 
         if( !body ) {
@@ -988,7 +990,7 @@ protected:
             return false;
         }
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         KinBodyPtr pbody = GetEnv()->GetKinBody(bodyname);
         if( !pbody ) {
@@ -1003,7 +1005,7 @@ protected:
     bool orEnvGetRobots(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         vector<RobotBasePtr> vrobots;
         GetEnv()->GetRobots(vrobots);
@@ -1018,7 +1020,7 @@ protected:
     bool orEnvGetBodies(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         vector<KinBodyPtr> vbodies;
         GetEnv()->GetBodies(vbodies);
@@ -1070,7 +1072,7 @@ protected:
         }
         // normalize the rotation first
         t.rot.normalize4();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         pbody->SetTransform(t);
 
         if( pbody->IsRobot() ) {
@@ -1115,7 +1117,7 @@ protected:
     bool orBodyGetLinks(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr body = orMacroGetBody(is);
         if( !body ) {
             return false;
@@ -1131,7 +1133,7 @@ protected:
     bool orRobotControllerSend(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot || !probot->GetController() ) {
             return false;
@@ -1146,7 +1148,7 @@ protected:
     bool orRobotSensorSend(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1165,7 +1167,7 @@ protected:
     bool orRobotSensorConfigure(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         string strcmd;
         int sensorindex = 0;
@@ -1212,7 +1214,7 @@ protected:
     bool orRobotSensorData(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1333,7 +1335,7 @@ protected:
     bool orRobotControllerSet(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot )
             return false;
@@ -1468,7 +1470,7 @@ protected:
     bool orRobotSetActiveDOFs(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1513,7 +1515,7 @@ protected:
     bool orRobotSetActiveManipulator(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1530,7 +1532,7 @@ protected:
     bool orRobotCheckSelfCollision(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr probot = orMacroGetBody(is);
         if( !probot ) {
             return false;
@@ -1544,7 +1546,7 @@ protected:
     bool orRobotGetActiveDOF(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1557,7 +1559,7 @@ protected:
     bool orBodyGetAABB(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr pbody = orMacroGetBody(is);
         if( !pbody ) {
             return false;
@@ -1571,7 +1573,7 @@ protected:
     bool orBodyGetAABBs(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr pbody = orMacroGetBody(is);
         if( !pbody ) {
             return false;
@@ -1588,7 +1590,7 @@ protected:
     bool orBodyGetDOF(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr pbody = orMacroGetBody(is);
         if( !pbody ) {
             return false;
@@ -1601,7 +1603,7 @@ protected:
     bool orBodyGetJointValues(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr pbody = orMacroGetBody(is);
         if( !pbody ) {
             return false;
@@ -1634,7 +1636,7 @@ protected:
     bool orRobotGetDOFValues(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1666,7 +1668,7 @@ protected:
     bool orRobotGetDOFLimits(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1687,7 +1689,7 @@ protected:
     bool orRobotGetManipulators(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1736,7 +1738,7 @@ protected:
     bool orRobotGetAttachedSensors(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1768,7 +1770,7 @@ protected:
     bool orBodySetJointValues(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr pbody = orMacroGetBody(is);
         if( !pbody ) {
             return false;
@@ -1841,7 +1843,7 @@ protected:
     bool orBodySetJointTorques(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr pbody = orMacroGetBody(is);
         if( !pbody ) {
             return false;
@@ -1871,7 +1873,7 @@ protected:
     bool orRobotSetDOFValues(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(is);
         if( !probot ) {
             return false;
@@ -1939,7 +1941,7 @@ protected:
     /// - starts a trajectory on the robot with the active degrees of freedom
     bool worRobotStartActiveTrajectory(boost::shared_ptr<istream> is, boost::shared_ptr<void> pdata)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RobotBasePtr probot = orMacroGetRobot(*is);
         if( !probot ) {
             return false;
@@ -2032,7 +2034,7 @@ protected:
     bool orEnvCheckCollision(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr pbody = orMacroGetBody(is);
         if( !pbody ) {
             return false;
@@ -2104,7 +2106,7 @@ protected:
     bool orEnvRayCollision(istream& is, ostream& os, boost::shared_ptr<void>& pdata)
     {
         _SyncWithWorkerThread();
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         KinBodyPtr pbody = orMacroGetBody(is);
 
         int oldoptions = GetEnv()->GetCollisionChecker()->GetCollisionOptions();
@@ -2155,7 +2157,7 @@ protected:
         is >> timestep >> bSync;
         if( bSync ) {
             _SyncWithWorkerThread();
-            EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+            EnvironmentLock lock(GetEnv()->GetMutex());
             GetEnv()->StepSimulation(timestep);
         }
         return true;
@@ -2180,7 +2182,7 @@ protected:
         is >> inclusive;
         vector<int> vobjids = vector<int>((istream_iterator<int>(is)), istream_iterator<int>());
 
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
 
         vector<KinBodyPtr> vbodies;
         GetEnv()->GetBodies(vbodies);
@@ -2215,7 +2217,7 @@ protected:
         dReal ftimeout;
 
         {
-            EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+            EnvironmentLock lock(GetEnv()->GetMutex());
             probot = orMacroGetRobot(is);
             if( !probot ) {
                 os << "1";
@@ -2265,7 +2267,7 @@ protected:
         }
         _SyncWithWorkerThread();
         // do not need lock
-        //EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        //EnvironmentLock lock(GetEnv()->GetMutex());
 
         if( problemid > 0 ) {
             map<int, ModuleBasePtr >::iterator it = _mapModules.find(problemid);

--- a/python/bindings/include/openravepy/openravepy_environmentbase.h
+++ b/python/bindings/include/openravepy/openravepy_environmentbase.h
@@ -25,10 +25,8 @@ using py::object;
 
 class PyEnvironmentBase : public OPENRAVE_ENABLE_SHARED_FROM_THIS<PyEnvironmentBase>
 {
-#if BOOST_VERSION < 103500
-    boost::mutex _envmutex;
-    std::list<OPENRAVE_SHARED_PTR<EnvironmentMutex::scoped_lock> > _listenvlocks, _listfreelocks;
-#endif
+    std::mutex _envmutex;
+    std::list<OPENRAVE_SHARED_PTR<EnvironmentLock> > _listenvlocks, _listfreelocks;
 
 public:
     class PyEnvironmentBaseInfo

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -917,7 +917,7 @@ bool PyRobotBase::PyManipulator::_FindIKSolutions(const IkParameterization& ikpa
 object PyRobotBase::PyManipulator::FindIKSolution(object oparam, int filteroptions, bool ikreturn, bool releasegil) const
 {
     IkParameterization ikparam;
-    EnvironmentMutex::scoped_lock lock(openravepy::GetEnvironment(_pyenv)->GetMutex()); // lock just in case since many users call this without locking...
+    EnvironmentLock lock(openravepy::GetEnvironment(_pyenv)->GetMutex()); // lock just in case since many users call this without locking...
     if( ExtractIkParameterization(oparam,ikparam) ) {
         if( ikreturn ) {
             IkReturn ikreject(IKRA_Reject);
@@ -953,7 +953,7 @@ object PyRobotBase::PyManipulator::FindIKSolution(object oparam, object freepara
 {
     std::vector<dReal> vfreeparams = ExtractArray<dReal>(freeparams);
     IkParameterization ikparam;
-    EnvironmentMutex::scoped_lock lock(openravepy::GetEnvironment(_pyenv)->GetMutex()); // lock just in case since many users call this without locking...
+    EnvironmentLock lock(openravepy::GetEnvironment(_pyenv)->GetMutex()); // lock just in case since many users call this without locking...
     if( ExtractIkParameterization(oparam,ikparam) ) {
         if( ikreturn ) {
             IkReturn ikreject(IKRA_Reject);
@@ -988,7 +988,7 @@ object PyRobotBase::PyManipulator::FindIKSolution(object oparam, object freepara
 object PyRobotBase::PyManipulator::FindIKSolutions(object oparam, int filteroptions, bool ikreturn, bool releasegil) const
 {
     IkParameterization ikparam;
-    EnvironmentMutex::scoped_lock lock(openravepy::GetEnvironment(_pyenv)->GetMutex()); // lock just in case since many users call this without locking...
+    EnvironmentLock lock(openravepy::GetEnvironment(_pyenv)->GetMutex()); // lock just in case since many users call this without locking...
     if( ikreturn ) {
         std::vector<IkReturnPtr> vikreturns;
         if( ExtractIkParameterization(oparam,ikparam) ) {
@@ -1047,7 +1047,7 @@ object PyRobotBase::PyManipulator::FindIKSolutions(object oparam, object freepar
 {
     std::vector<dReal> vfreeparams = ExtractArray<dReal>(freeparams);
     IkParameterization ikparam;
-    EnvironmentMutex::scoped_lock lock(openravepy::GetEnvironment(_pyenv)->GetMutex()); // lock just in case since many users call this without locking...
+    EnvironmentLock lock(openravepy::GetEnvironment(_pyenv)->GetMutex()); // lock just in case since many users call this without locking...
     if( ikreturn ) {
         std::vector<IkReturnPtr> vikreturns;
         if( ExtractIkParameterization(oparam,ikparam) ) {

--- a/src/cppexamples/ikfastloader.cpp
+++ b/src/cppexamples/ikfastloader.cpp
@@ -43,7 +43,7 @@ int main(int argc, char ** argv)
 
     {
         // lock the environment to prevent changes
-        EnvironmentMutex::scoped_lock lock(penv->GetMutex());
+        EnvironmentLock lock(penv->GetMutex());
         // load the scene
         RobotBasePtr probot = penv->ReadRobotXMLFile(robotname);
         if( !probot ) {

--- a/src/cppexamples/opencvsaving.cpp
+++ b/src/cppexamples/opencvsaving.cpp
@@ -85,7 +85,7 @@ public:
                     cvSaveImage(filename.c_str(),vcameras[icamera]->img);
                 }
             }
-            std::this_thread::sleep(boost::posix_time::milliseconds(200));
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
         }
 
     }

--- a/src/cppexamples/opencvsaving.cpp
+++ b/src/cppexamples/opencvsaving.cpp
@@ -85,7 +85,7 @@ public:
                     cvSaveImage(filename.c_str(),vcameras[icamera]->img);
                 }
             }
-            boost::this_thread::sleep(boost::posix_time::milliseconds(200));
+            std::this_thread::sleep(boost::posix_time::milliseconds(200));
         }
 
     }

--- a/src/cppexamples/orcollision.cpp
+++ b/src/cppexamples/orcollision.cpp
@@ -106,7 +106,7 @@ int main(int argc, char ** argv)
     int contactpoints = 0;
     {
         // lock the environment to prevent data from changing
-        EnvironmentMutex::scoped_lock lock(penv->GetMutex());
+        EnvironmentLock lock(penv->GetMutex());
 
         vector<KinBodyPtr> vbodies;
         penv->GetBodies(vbodies);

--- a/src/cppexamples/orconveyormovement.cpp
+++ b/src/cppexamples/orconveyormovement.cpp
@@ -51,7 +51,7 @@ public:
 
     bool RegisterBody(ostream& sout, istream& sinput)
     {
-        EnvironmentMutex::scoped_lock lock(GetEnv()->GetMutex());
+        EnvironmentLock lock(GetEnv()->GetMutex());
         RegisteredBody body;
         sinput >> body.filename >> body.appearanceprobability;
         if( !sinput ) {

--- a/src/cppexamples/orconveyormovement.cpp
+++ b/src/cppexamples/orconveyormovement.cpp
@@ -140,7 +140,7 @@ public:
         sin.str("registerbody data/ketchup.kinbody.xml 0.3");
         p->SendCommand(sout,sin);
         while(IsOk()) {
-            std::this_thread::sleep(boost::posix_time::milliseconds(1));
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
 };

--- a/src/cppexamples/orconveyormovement.cpp
+++ b/src/cppexamples/orconveyormovement.cpp
@@ -140,7 +140,7 @@ public:
         sin.str("registerbody data/ketchup.kinbody.xml 0.3");
         p->SendCommand(sout,sin);
         while(IsOk()) {
-            boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+            std::this_thread::sleep(boost::posix_time::milliseconds(1));
         }
     }
 };

--- a/src/cppexamples/orexample.h
+++ b/src/cppexamples/orexample.h
@@ -61,7 +61,7 @@ public:
 
             // create the main openrave thread
             _bDestroyThread = false;
-            _thopenrave = boost::thread(boost::bind(&OpenRAVEExample::_demothreadwrapper,this,argc,argv));
+            _thopenrave = std::thread(boost::bind(&OpenRAVEExample::_demothreadwrapper,this,argc,argv));
 
             // start the viewer main loop
             _viewer->main(true);
@@ -91,7 +91,7 @@ private:
     OpenRAVE::ViewerBasePtr _viewer;
     std::string _viewername;
     bool _bDestroyThread;
-    boost::thread _thopenrave;
+    std::thread _thopenrave;
 
     void quitviewer(void *) {
         if( !!_viewer ) {

--- a/src/cppexamples/orikfilter.cpp
+++ b/src/cppexamples/orikfilter.cpp
@@ -57,7 +57,7 @@ int main(int argc, char ** argv)
 
     while(1) {
         {
-            EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+            EnvironmentLock lock(penv->GetMutex()); // lock environment
 
             // move robot randomly
             probot->GetActiveDOFLimits(vlower,vupper);

--- a/src/cppexamples/orloadviewer.cpp
+++ b/src/cppexamples/orloadviewer.cpp
@@ -70,7 +70,7 @@ int main(int argc, char ** argv)
     EnvironmentBasePtr penv = RaveCreateEnvironment(); // create the main environment
     RaveSetDebugLevel(Level_Debug);
 
-    boost::thread thviewer(boost::bind(SetViewer,penv,viewername));
+    std::thread thviewer(boost::bind(SetViewer,penv,viewername));
     penv->Load(scenefilename); // load the scene
     thviewer.join(); // wait for the viewer thread to exit
     penv->Destroy(); // destroy

--- a/src/cppexamples/ormulticontrol.cpp
+++ b/src/cppexamples/ormulticontrol.cpp
@@ -41,7 +41,7 @@ public:
         ControllerBasePtr wheelcontroller, armcontroller;
         // create the controllers, make sure to lock environment!
         {
-            EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+            EnvironmentLock lock(penv->GetMutex()); // lock environment
 
             MultiControllerBasePtr multi = RaveCreateMultiController(penv);
             vector<int> dofindices(probot->GetDOF());
@@ -79,7 +79,7 @@ public:
 
         while(IsOk()) {
             {
-                EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+                EnvironmentLock lock(penv->GetMutex()); // lock environment
 
                 if( !!armcontroller ) {
                     // set a trajectory on the arm and velocity on the wheels

--- a/src/cppexamples/ormulticontrol.cpp
+++ b/src/cppexamples/ormulticontrol.cpp
@@ -125,11 +125,11 @@ public:
 
             // unlock the environment and wait for the arm controller to finish (wheel controller will never finish)
             if( !armcontroller ) {
-                std::this_thread::sleep(boost::posix_time::milliseconds(2000));
+                std::this_thread::sleep_for(std::chrono::milliseconds(2000));
             }
             else {
                 while(!armcontroller->IsDone() && IsOk()) {
-                    std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(1));
                 }
             }
         }

--- a/src/cppexamples/ormulticontrol.cpp
+++ b/src/cppexamples/ormulticontrol.cpp
@@ -125,11 +125,11 @@ public:
 
             // unlock the environment and wait for the arm controller to finish (wheel controller will never finish)
             if( !armcontroller ) {
-                boost::this_thread::sleep(boost::posix_time::milliseconds(2000));
+                std::this_thread::sleep(boost::posix_time::milliseconds(2000));
             }
             else {
                 while(!armcontroller->IsDone() && IsOk()) {
-                    boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+                    std::this_thread::sleep(boost::posix_time::milliseconds(1));
                 }
             }
         }

--- a/src/cppexamples/ormultithreadedplanning.cpp
+++ b/src/cppexamples/ormultithreadedplanning.cpp
@@ -101,7 +101,7 @@ public:
         }
 
         while(IsOk()) {
-            std::this_thread::sleep(boost::posix_time::milliseconds(1));
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
 
         RAVELOG_INFO("wait for threads to finish\n");

--- a/src/cppexamples/ormultithreadedplanning.cpp
+++ b/src/cppexamples/ormultithreadedplanning.cpp
@@ -95,13 +95,13 @@ public:
         int numthreads = 2;
 
         // start worker threads
-        vector<boost::shared_ptr<boost::thread> > vthreads(numthreads);
+        vector<boost::shared_ptr<std::thread> > vthreads(numthreads);
         for(size_t i = 0; i < vthreads.size(); ++i) {
-            vthreads[i].reset(new boost::thread(boost::bind(&MultithreadedPlanningExample::_PlanningThread,this,probot->GetName())));
+            vthreads[i].reset(new std::thread(boost::bind(&MultithreadedPlanningExample::_PlanningThread,this,probot->GetName())));
         }
 
         while(IsOk()) {
-            boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+            std::this_thread::sleep(boost::posix_time::milliseconds(1));
         }
 
         RAVELOG_INFO("wait for threads to finish\n");

--- a/src/cppexamples/ormultithreadedplanning.cpp
+++ b/src/cppexamples/ormultithreadedplanning.cpp
@@ -97,7 +97,7 @@ public:
         // start worker threads
         vector<boost::shared_ptr<std::thread> > vthreads(numthreads);
         for(size_t i = 0; i < vthreads.size(); ++i) {
-            vthreads[i].reset(new std::thread(boost::bind(&MultithreadedPlanningExample::_PlanningThread,this,probot->GetName())));
+            vthreads[i] = boost::make_shared<std::thread>(std::bind(&MultithreadedPlanningExample::_PlanningThread, this, probot->GetName()));
         }
 
         while(IsOk()) {

--- a/src/cppexamples/ormultithreadedplanning.cpp
+++ b/src/cppexamples/ormultithreadedplanning.cpp
@@ -40,7 +40,7 @@ public:
 
 
         while(IsOk()) {
-            EnvironmentMutex::scoped_lock lock(pclondedenv->GetMutex()); // lock environment
+            EnvironmentLock lock(pclondedenv->GetMutex()); // lock environment
 
             // find a new manipulator position and feed that into the planner. If valid, robot will move to it safely.
             Transform t = pmanip->GetTransform();

--- a/src/cppexamples/orplanning_door.cpp
+++ b/src/cppexamples/orplanning_door.cpp
@@ -261,7 +261,7 @@ public:
         PlannerBase::PlannerParametersPtr params(new PlannerBase::PlannerParameters());
         Transform trobotorig;
         {
-            EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+            EnvironmentLock lock(penv->GetMutex()); // lock environment
 
             probot->SetActiveDOFs(pmanip->GetGripperIndices());
             probot->SetActiveDOFValues(vpreshape);
@@ -280,7 +280,7 @@ public:
             iter += 1;
             GraphHandlePtr pgraph;
             {
-                EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+                EnvironmentLock lock(penv->GetMutex()); // lock environment
 
                 if( (iter%5) == 0 ) {
                     RAVELOG_INFO("find a new position for the robot\n");

--- a/src/cppexamples/orplanning_door.cpp
+++ b/src/cppexamples/orplanning_door.cpp
@@ -356,7 +356,7 @@ public:
 
             // wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep(boost::posix_time::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_door.cpp
+++ b/src/cppexamples/orplanning_door.cpp
@@ -356,7 +356,7 @@ public:
 
             // wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_ik.cpp
+++ b/src/cppexamples/orplanning_ik.cpp
@@ -75,7 +75,7 @@ public:
 
             // unlock the environment and wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep(boost::posix_time::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_ik.cpp
+++ b/src/cppexamples/orplanning_ik.cpp
@@ -75,7 +75,7 @@ public:
 
             // unlock the environment and wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_ik.cpp
+++ b/src/cppexamples/orplanning_ik.cpp
@@ -57,7 +57,7 @@ public:
 
         while(IsOk()) {
             {
-                EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+                EnvironmentLock lock(penv->GetMutex()); // lock environment
 
                 // find a new manipulator position and feed that into the planner. If valid, robot will move to it safely.
                 Transform t = pmanip->GetTransform();

--- a/src/cppexamples/orplanning_module.cpp
+++ b/src/cppexamples/orplanning_module.cpp
@@ -43,7 +43,7 @@ public:
 
         while(IsOk()) {
             {
-                EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+                EnvironmentLock lock(penv->GetMutex()); // lock environment
 
                 // find a set of free joint values for the robot
                 {

--- a/src/cppexamples/orplanning_module.cpp
+++ b/src/cppexamples/orplanning_module.cpp
@@ -75,7 +75,7 @@ public:
 
             // unlock the environment and wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep(boost::posix_time::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_module.cpp
+++ b/src/cppexamples/orplanning_module.cpp
@@ -75,7 +75,7 @@ public:
 
             // unlock the environment and wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_multirobot.cpp
+++ b/src/cppexamples/orplanning_multirobot.cpp
@@ -49,7 +49,7 @@ public:
         while(IsOk()) {
             list<GraphHandlePtr> listgraphs;
             {
-                EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+                EnvironmentLock lock(penv->GetMutex()); // lock environment
 
                 params->_getstatefn(params->vinitialconfig);
                 params->vgoalconfig.resize(params->GetDOF());

--- a/src/cppexamples/orplanning_multirobot.cpp
+++ b/src/cppexamples/orplanning_multirobot.cpp
@@ -106,7 +106,7 @@ public:
                 if( probot1->GetController()->IsDone() || probot2->GetController()->IsDone() ) {
                     break;
                 }
-                boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep(boost::posix_time::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_multirobot.cpp
+++ b/src/cppexamples/orplanning_multirobot.cpp
@@ -106,7 +106,7 @@ public:
                 if( probot1->GetController()->IsDone() || probot2->GetController()->IsDone() ) {
                     break;
                 }
-                std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_planner.cpp
+++ b/src/cppexamples/orplanning_planner.cpp
@@ -54,7 +54,7 @@ public:
         while(IsOk()) {
             GraphHandlePtr pgraph;
             {
-                EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+                EnvironmentLock lock(penv->GetMutex()); // lock environment
 
                 probot->SetActiveDOFs(pmanip->GetArmIndices());
 

--- a/src/cppexamples/orplanning_planner.cpp
+++ b/src/cppexamples/orplanning_planner.cpp
@@ -113,7 +113,7 @@ public:
 
             // unlock the environment and wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep(boost::posix_time::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orplanning_planner.cpp
+++ b/src/cppexamples/orplanning_planner.cpp
@@ -113,7 +113,7 @@ public:
 
             // unlock the environment and wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/orpr2turnlever.cpp
+++ b/src/cppexamples/orpr2turnlever.cpp
@@ -79,7 +79,7 @@ public:
         penv->Add(taskmodule,true,probot->GetName());
 
         {
-            EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+            EnvironmentLock lock(penv->GetMutex()); // lock environment
             stringstream ssin, ssout; ssin << "ReleaseFingers";
             taskmodule->SendCommand(ssout,ssin);
         }
@@ -88,7 +88,7 @@ public:
         TrajectoryBasePtr workspacetraj;
         Transform Tgrasp0;
         {
-            EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+            EnvironmentLock lock(penv->GetMutex()); // lock environment
             Transform Toffset;
             Toffset.trans = Vector(0,0.2,0);
             Transform Ttarget0 = target->GetTransform();
@@ -132,7 +132,7 @@ public:
 
         list<TrajectoryBasePtr> listtrajectories;
         {
-            EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+            EnvironmentLock lock(penv->GetMutex()); // lock environment
             probot->SetActiveDOFs(pmanip->GetArmIndices());
             probot->Grab(target);
             PlannerBasePtr planner = RaveCreatePlanner(penv,"workspacetrajectorytracker");

--- a/src/cppexamples/orpr2turnlever.cpp
+++ b/src/cppexamples/orpr2turnlever.cpp
@@ -32,7 +32,7 @@ public:
     virtual void WaitRobot(RobotBasePtr probot) {
         // unlock the environment and wait for the robot to finish
         while(!probot->GetController()->IsDone() && IsOk()) {
-            std::this_thread::sleep(boost::posix_time::milliseconds(1));
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
 

--- a/src/cppexamples/orpr2turnlever.cpp
+++ b/src/cppexamples/orpr2turnlever.cpp
@@ -32,7 +32,7 @@ public:
     virtual void WaitRobot(RobotBasePtr probot) {
         // unlock the environment and wait for the robot to finish
         while(!probot->GetController()->IsDone() && IsOk()) {
-            boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+            std::this_thread::sleep(boost::posix_time::milliseconds(1));
         }
     }
 

--- a/src/cppexamples/orqtcoinviewercustom.cpp
+++ b/src/cppexamples/orqtcoinviewercustom.cpp
@@ -74,7 +74,7 @@ int main(int argc, char ** argv)
     EnvironmentBasePtr penv = RaveCreateEnvironment(); // create the main environment
     RaveSetDebugLevel(Level_Debug);
 
-    boost::thread thviewer(boost::bind(SetViewer,penv,viewername));
+    std::thread thviewer(boost::bind(SetViewer,penv,viewername));
     penv->Load(scenefilename); // load the scene
 
 
@@ -83,7 +83,7 @@ int main(int argc, char ** argv)
         if( !pregistration && !!penv->GetViewer() ) {
             pregistration = penv->GetViewer()->RegisterViewerThreadCallback(boost::bind(ViewerCallback,penv->GetViewer()));
         }
-        boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+        std::this_thread::sleep(boost::posix_time::milliseconds(1));
     }
 
     thviewer.join(); // wait for the viewer thread to exit

--- a/src/cppexamples/orqtcoinviewercustom.cpp
+++ b/src/cppexamples/orqtcoinviewercustom.cpp
@@ -83,7 +83,7 @@ int main(int argc, char ** argv)
         if( !pregistration && !!penv->GetViewer() ) {
             pregistration = penv->GetViewer()->RegisterViewerThreadCallback(boost::bind(ViewerCallback,penv->GetViewer()));
         }
-        std::this_thread::sleep(boost::posix_time::milliseconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     thviewer.join(); // wait for the viewer thread to exit

--- a/src/cppexamples/orshowsensors.cpp
+++ b/src/cppexamples/orshowsensors.cpp
@@ -36,7 +36,7 @@ public:
                 sensors[isensor]->Configure(isensor == ienablesensor ? SensorBase::CC_RenderDataOn : SensorBase::CC_RenderDataOff);
             }
             ienablesensor = (ienablesensor+1)%sensors.size();
-            std::this_thread::sleep(boost::posix_time::seconds(5));
+            std::this_thread::sleep_for(std::chrono::seconds(5));
         }
     }
 };

--- a/src/cppexamples/orshowsensors.cpp
+++ b/src/cppexamples/orshowsensors.cpp
@@ -36,7 +36,7 @@ public:
                 sensors[isensor]->Configure(isensor == ienablesensor ? SensorBase::CC_RenderDataOn : SensorBase::CC_RenderDataOff);
             }
             ienablesensor = (ienablesensor+1)%sensors.size();
-            boost::this_thread::sleep(boost::posix_time::seconds(5));
+            std::this_thread::sleep(boost::posix_time::seconds(5));
         }
     }
 };

--- a/src/cppexamples/ortrajectory.cpp
+++ b/src/cppexamples/ortrajectory.cpp
@@ -61,7 +61,7 @@ public:
 
         while(IsOk()) {
             {
-                EnvironmentMutex::scoped_lock lock(penv->GetMutex()); // lock environment
+                EnvironmentLock lock(penv->GetMutex()); // lock environment
 
                 TrajectoryBasePtr traj = RaveCreateTrajectory(penv,"");
                 traj->Init(probot->GetActiveConfigurationSpecification());

--- a/src/cppexamples/ortrajectory.cpp
+++ b/src/cppexamples/ortrajectory.cpp
@@ -85,7 +85,7 @@ public:
             }
             // unlock the environment and wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                boost::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep(boost::posix_time::milliseconds(1));
             }
         }
     }

--- a/src/cppexamples/ortrajectory.cpp
+++ b/src/cppexamples/ortrajectory.cpp
@@ -85,7 +85,7 @@ public:
             }
             // unlock the environment and wait for the robot to finish
             while(!probot->GetController()->IsDone() && IsOk()) {
-                std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
     }

--- a/src/libopenrave-core/colladaparser/colladacommon.cpp
+++ b/src/libopenrave-core/colladaparser/colladacommon.cpp
@@ -35,7 +35,7 @@ void SetGlobalDAE(boost::shared_ptr<DAE> newdae)
 void ResetGlobalDAEWithLock()
 {
     RAVELOG_VERBOSE("resetting global collada DAE\n");
-    std::scoped_lock lock(s_daemutex);
+    std::lock_guard<std::mutex> lock(s_daemutex);
     s_dae.reset();
 }
 

--- a/src/libopenrave-core/colladaparser/colladacommon.cpp
+++ b/src/libopenrave-core/colladaparser/colladacommon.cpp
@@ -22,7 +22,7 @@
 namespace OpenRAVE
 {
 static boost::shared_ptr<DAE> s_dae;
-static boost::mutex s_daemutex;
+static std::mutex s_daemutex;
 static bool s_daedestroycallback=false; // true if we already registered with RaveAddCallbackForDestroy
 
 /// \brief should have s_daemutex locked before calling
@@ -35,7 +35,7 @@ void SetGlobalDAE(boost::shared_ptr<DAE> newdae)
 void ResetGlobalDAEWithLock()
 {
     RAVELOG_VERBOSE("resetting global collada DAE\n");
-    boost::mutex::scoped_lock lock(s_daemutex);
+    std::scoped_lock lock(s_daemutex);
     s_dae.reset();
 }
 
@@ -62,7 +62,7 @@ boost::shared_ptr<DAE> GetGlobalDAE(bool resetdefaults)
     return s_dae;
 }
 
-boost::mutex& GetGlobalDAEMutex()
+std::mutex& GetGlobalDAEMutex()
 {
     return s_daemutex;
 }

--- a/src/libopenrave-core/colladaparser/colladacommon.h
+++ b/src/libopenrave-core/colladaparser/colladacommon.h
@@ -160,7 +160,7 @@ typedef boost::shared_ptr<ColladaXMLReadable> ColladaXMLReadablePtr;
 boost::shared_ptr<DAE> GetGlobalDAE(bool resetdefaults=true);
 /// \brief reset the global DAE
 void SetGlobalDAE(boost::shared_ptr<DAE>);
-boost::mutex& GetGlobalDAEMutex();
+std::mutex& GetGlobalDAEMutex();
 
 
 // register for typeof (MSVC only)

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -5909,7 +5909,7 @@ private:
 
 bool RaveParseColladaURI(EnvironmentBasePtr penv, const std::string& uri,const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if( !reader.InitFromURI(uri,atts) ) {
         return false;
@@ -5919,7 +5919,7 @@ bool RaveParseColladaURI(EnvironmentBasePtr penv, const std::string& uri,const A
 
 bool RaveParseColladaURI(EnvironmentBasePtr penv, KinBodyPtr& pbody, const string& uri, const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromURI(uri,atts)) {
         return false;
@@ -5932,7 +5932,7 @@ bool RaveParseColladaURI(EnvironmentBasePtr penv, KinBodyPtr& pbody, const strin
 
 bool RaveParseColladaURI(EnvironmentBasePtr penv, RobotBasePtr& probot, const string& uri, const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromURI(uri,atts)) {
         return false;
@@ -5945,7 +5945,7 @@ bool RaveParseColladaURI(EnvironmentBasePtr penv, RobotBasePtr& probot, const st
 
 bool RaveParseColladaFile(EnvironmentBasePtr penv, const string& filename, const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     string filedata = RaveFindLocalFile(filename);
     if (filedata.size() == 0 || !reader.InitFromFile(filedata,atts)) {
@@ -5956,7 +5956,7 @@ bool RaveParseColladaFile(EnvironmentBasePtr penv, const string& filename, const
 
 bool RaveParseColladaFile(EnvironmentBasePtr penv, KinBodyPtr& pbody, const string& filename,const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     string filedata = RaveFindLocalFile(filename);
     if (filedata.size() == 0 || !reader.InitFromFile(filedata,atts)) {
@@ -5967,7 +5967,7 @@ bool RaveParseColladaFile(EnvironmentBasePtr penv, KinBodyPtr& pbody, const stri
 
 bool RaveParseColladaFile(EnvironmentBasePtr penv, RobotBasePtr& probot, const string& filename,const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     string filedata = RaveFindLocalFile(filename);
     if (filedata.size() == 0 || !reader.InitFromFile(filedata,atts)) {
@@ -5978,7 +5978,7 @@ bool RaveParseColladaFile(EnvironmentBasePtr penv, RobotBasePtr& probot, const s
 
 bool RaveParseColladaData(EnvironmentBasePtr penv, const string& pdata,const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromData(pdata,atts)) {
         return false;
@@ -5988,7 +5988,7 @@ bool RaveParseColladaData(EnvironmentBasePtr penv, const string& pdata,const Att
 
 bool RaveParseColladaData(EnvironmentBasePtr penv, KinBodyPtr& pbody, const string& pdata,const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromData(pdata,atts)) {
         return false;
@@ -6006,7 +6006,7 @@ bool RaveParseColladaData(EnvironmentBasePtr penv, KinBodyPtr& pbody, const stri
 
 bool RaveParseColladaData(EnvironmentBasePtr penv, RobotBasePtr& probot, const string& pdata,const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromData(pdata,atts)) {
         return false;

--- a/src/libopenrave-core/colladaparser/colladareader.cpp
+++ b/src/libopenrave-core/colladaparser/colladareader.cpp
@@ -5909,7 +5909,7 @@ private:
 
 bool RaveParseColladaURI(EnvironmentBasePtr penv, const std::string& uri,const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if( !reader.InitFromURI(uri,atts) ) {
         return false;
@@ -5919,7 +5919,7 @@ bool RaveParseColladaURI(EnvironmentBasePtr penv, const std::string& uri,const A
 
 bool RaveParseColladaURI(EnvironmentBasePtr penv, KinBodyPtr& pbody, const string& uri, const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromURI(uri,atts)) {
         return false;
@@ -5932,7 +5932,7 @@ bool RaveParseColladaURI(EnvironmentBasePtr penv, KinBodyPtr& pbody, const strin
 
 bool RaveParseColladaURI(EnvironmentBasePtr penv, RobotBasePtr& probot, const string& uri, const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromURI(uri,atts)) {
         return false;
@@ -5945,7 +5945,7 @@ bool RaveParseColladaURI(EnvironmentBasePtr penv, RobotBasePtr& probot, const st
 
 bool RaveParseColladaFile(EnvironmentBasePtr penv, const string& filename, const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     string filedata = RaveFindLocalFile(filename);
     if (filedata.size() == 0 || !reader.InitFromFile(filedata,atts)) {
@@ -5956,7 +5956,7 @@ bool RaveParseColladaFile(EnvironmentBasePtr penv, const string& filename, const
 
 bool RaveParseColladaFile(EnvironmentBasePtr penv, KinBodyPtr& pbody, const string& filename,const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     string filedata = RaveFindLocalFile(filename);
     if (filedata.size() == 0 || !reader.InitFromFile(filedata,atts)) {
@@ -5967,7 +5967,7 @@ bool RaveParseColladaFile(EnvironmentBasePtr penv, KinBodyPtr& pbody, const stri
 
 bool RaveParseColladaFile(EnvironmentBasePtr penv, RobotBasePtr& probot, const string& filename,const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     string filedata = RaveFindLocalFile(filename);
     if (filedata.size() == 0 || !reader.InitFromFile(filedata,atts)) {
@@ -5978,7 +5978,7 @@ bool RaveParseColladaFile(EnvironmentBasePtr penv, RobotBasePtr& probot, const s
 
 bool RaveParseColladaData(EnvironmentBasePtr penv, const string& pdata,const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromData(pdata,atts)) {
         return false;
@@ -5988,7 +5988,7 @@ bool RaveParseColladaData(EnvironmentBasePtr penv, const string& pdata,const Att
 
 bool RaveParseColladaData(EnvironmentBasePtr penv, KinBodyPtr& pbody, const string& pdata,const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromData(pdata,atts)) {
         return false;
@@ -6006,7 +6006,7 @@ bool RaveParseColladaData(EnvironmentBasePtr penv, KinBodyPtr& pbody, const stri
 
 bool RaveParseColladaData(EnvironmentBasePtr penv, RobotBasePtr& probot, const string& pdata,const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaReader reader(penv);
     if (!reader.InitFromData(pdata,atts)) {
         return false;

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -3205,7 +3205,7 @@ BOOST_TYPEOF_REGISTER_TYPE(ColladaWriter::articulated_system_output)
 
 void RaveWriteColladaFile(EnvironmentBasePtr penv, const string& filename, const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaWriter writer(penv, atts);
     std::string scenename, keywords, subject, author;
     FOREACHC(itatt,atts) {
@@ -3265,7 +3265,7 @@ void RaveWriteColladaFile(EnvironmentBasePtr penv, const string& filename, const
 
 void RaveWriteColladaFile(KinBodyPtr pbody, const string& filename, const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaWriter writer(pbody->GetEnv(),atts);
     std::string keywords, subject, author;
     FOREACHC(itatt,atts) {
@@ -3289,7 +3289,7 @@ void RaveWriteColladaFile(KinBodyPtr pbody, const string& filename, const Attrib
 
 void RaveWriteColladaFile(const std::list<KinBodyPtr>& listbodies, const std::string& filename,const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     if( listbodies.size() > 0 ) {
         EnvironmentBasePtr penv = listbodies.front()->GetEnv();
         ColladaWriter writer(penv,atts);
@@ -3353,7 +3353,7 @@ void RaveWriteColladaFile(const std::list<KinBodyPtr>& listbodies, const std::st
 
 void RaveWriteColladaMemory(EnvironmentBasePtr penv, std::vector<char>& output, const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaWriter writer(penv, atts);
     std::string scenename, keywords, subject, author;
     FOREACHC(itatt,atts) {
@@ -3400,7 +3400,7 @@ void RaveWriteColladaMemory(EnvironmentBasePtr penv, std::vector<char>& output, 
 
 void RaveWriteColladaMemory(KinBodyPtr pbody, std::vector<char>& output, const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     ColladaWriter writer(pbody->GetEnv(),atts);
     std::string keywords, subject, author;
     FOREACHC(itatt,atts) {
@@ -3424,7 +3424,7 @@ void RaveWriteColladaMemory(KinBodyPtr pbody, std::vector<char>& output, const A
 
 void RaveWriteColladaMemory(const std::list<KinBodyPtr>& listbodies, std::vector<char>& output,  const AttributesList& atts)
 {
-    boost::mutex::scoped_lock lock(GetGlobalDAEMutex());
+    std::scoped_lock lock(GetGlobalDAEMutex());
     output.clear();
     if( listbodies.size() > 0 ) {
         EnvironmentBasePtr penv = listbodies.front()->GetEnv();

--- a/src/libopenrave-core/colladaparser/colladawriter.cpp
+++ b/src/libopenrave-core/colladaparser/colladawriter.cpp
@@ -512,7 +512,7 @@ private:
     /// \brief Write down environment
     virtual bool Write(const std::string& scenename=std::string())
     {
-        EnvironmentMutex::scoped_lock lockenv(_penv->GetMutex());
+        EnvironmentLock lockenv(_penv->GetMutex());
         vector<KinBodyPtr> vbodies;
         _penv->GetBodies(vbodies);
         std::list<KinBodyPtr> listbodies(vbodies.begin(),vbodies.end());
@@ -595,7 +595,7 @@ private:
     /// \brief Write one robot as a file
     virtual bool Write(RobotBasePtr probot)
     {
-        EnvironmentMutex::scoped_lock lockenv(_penv->GetMutex());
+        EnvironmentLock lockenv(_penv->GetMutex());
         _CreateScene(probot->GetName());
         _mapBodyIds[probot->GetEnvironmentBodyIndex()] = 0;
         _AssignLinkSids(probot);
@@ -621,7 +621,7 @@ private:
         if( pbody->IsRobot() ) {
             return Write(RaveInterfaceCast<RobotBase>(pbody));
         }
-        EnvironmentMutex::scoped_lock lockenv(_penv->GetMutex());
+        EnvironmentLock lockenv(_penv->GetMutex());
         _CreateScene(pbody->GetName());
         _mapBodyIds[pbody->GetEnvironmentBodyIndex()] = 0;
         _AssignLinkSids(pbody);
@@ -1234,7 +1234,7 @@ private:
     /// \brief Write common kinematic body in a given scene, called by _WriteKinBody
     virtual boost::shared_ptr<instance_kinematics_model_output> _WriteInstance_kinematics_model(KinBodyPtr pbody, daeElementRef parent, const string& sidscope)
     {
-        EnvironmentMutex::scoped_lock lockenv(_penv->GetMutex());
+        EnvironmentLock lockenv(_penv->GetMutex());
         RAVELOG_VERBOSE(str(boost::format("writing instance_kinematics_model (%d) %s\n")%_mapBodyIds[pbody->GetEnvironmentBodyIndex()]%pbody->GetName()));
         boost::shared_ptr<kinematics_model_output> kmout = WriteKinematics_model(pbody);
 
@@ -1348,7 +1348,7 @@ private:
 
     virtual boost::shared_ptr<kinematics_model_output> WriteKinematics_model(KinBodyPtr pbody)
     {
-        EnvironmentMutex::scoped_lock lockenv(_penv->GetMutex());
+        EnvironmentLock lockenv(_penv->GetMutex());
         boost::shared_ptr<kinematics_model_output> kmout;
         if( _bReuseSimilar ) {
             kmout = _GetKinematics_model(pbody);
@@ -3205,7 +3205,7 @@ BOOST_TYPEOF_REGISTER_TYPE(ColladaWriter::articulated_system_output)
 
 void RaveWriteColladaFile(EnvironmentBasePtr penv, const string& filename, const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaWriter writer(penv, atts);
     std::string scenename, keywords, subject, author;
     FOREACHC(itatt,atts) {
@@ -3265,7 +3265,7 @@ void RaveWriteColladaFile(EnvironmentBasePtr penv, const string& filename, const
 
 void RaveWriteColladaFile(KinBodyPtr pbody, const string& filename, const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaWriter writer(pbody->GetEnv(),atts);
     std::string keywords, subject, author;
     FOREACHC(itatt,atts) {
@@ -3289,7 +3289,7 @@ void RaveWriteColladaFile(KinBodyPtr pbody, const string& filename, const Attrib
 
 void RaveWriteColladaFile(const std::list<KinBodyPtr>& listbodies, const std::string& filename,const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     if( listbodies.size() > 0 ) {
         EnvironmentBasePtr penv = listbodies.front()->GetEnv();
         ColladaWriter writer(penv,atts);
@@ -3353,7 +3353,7 @@ void RaveWriteColladaFile(const std::list<KinBodyPtr>& listbodies, const std::st
 
 void RaveWriteColladaMemory(EnvironmentBasePtr penv, std::vector<char>& output, const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaWriter writer(penv, atts);
     std::string scenename, keywords, subject, author;
     FOREACHC(itatt,atts) {
@@ -3400,7 +3400,7 @@ void RaveWriteColladaMemory(EnvironmentBasePtr penv, std::vector<char>& output, 
 
 void RaveWriteColladaMemory(KinBodyPtr pbody, std::vector<char>& output, const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     ColladaWriter writer(pbody->GetEnv(),atts);
     std::string keywords, subject, author;
     FOREACHC(itatt,atts) {
@@ -3424,7 +3424,7 @@ void RaveWriteColladaMemory(KinBodyPtr pbody, std::vector<char>& output, const A
 
 void RaveWriteColladaMemory(const std::list<KinBodyPtr>& listbodies, std::vector<char>& output,  const AttributesList& atts)
 {
-    std::scoped_lock lock(GetGlobalDAEMutex());
+    std::lock_guard<std::mutex> lock(GetGlobalDAEMutex());
     output.clear();
     if( listbodies.size() > 0 ) {
         EnvironmentBasePtr penv = listbodies.front()->GetEnv();

--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -3915,7 +3915,7 @@ protected:
     {
         if( !_threadSimulation ) {
             _bShutdownSimulation = false;
-            _threadSimulation.reset(new std::thread(boost::bind(&Environment::_SimulationThread, this)));
+            _threadSimulation = boost::make_shared<std::thread>(std::bind(&Environment::_SimulationThread, this));
         }
     }
 

--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -25,9 +25,11 @@
 #include <boost/filesystem/operations.hpp>
 #endif
 
-#include <unordered_map>
+#include <chrono>
 #include <mutex>
 #include <shared_mutex>
+#include <thread>
+#include <unordered_map>
 
 #include <pcrecpp.h>
 
@@ -3957,7 +3959,7 @@ protected:
                             lockenv.reset();
                             // sleep for less time since sleep isn't accurate at all and we have a 7ms buffer
                             int actual_sleep=max((int)sleeptime*6/8,1000);
-                            std::this_thread::sleep (boost::posix_time::microseconds(actual_sleep));
+                            std::this_thread::sleep_for(std::chrono::microseconds(actual_sleep));
                             //RAVELOG_INFO("sleeptime ideal %d, actually slept: %d\n",(int)sleeptime,(int)actual_sleep);
                             nLastSleptTime = utils::GetMicroTime();
                             //Since already slept this cycle, wait till next time to sleep.
@@ -3979,7 +3981,7 @@ protected:
 
             if( utils::GetMicroTime()-nLastSleptTime > 20000 ) {     // 100000 freezes the environment
                 lockenv.reset();
-                std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
                 bNeedSleep = false;
                 nLastSleptTime = utils::GetMicroTime();
             }
@@ -4003,7 +4005,7 @@ protected:
             //TODO: Verify if this always has to happen even if thread slept in RT if statement above
             lockenv.reset(); // always release at the end of loop to give other threads time
             if( bNeedSleep ) {
-                std::this_thread::sleep(boost::posix_time::milliseconds(1));
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }
     }

--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -249,7 +249,7 @@ public:
 
     virtual void Init(bool bStartSimulationThread=true)
     {
-        std::scoped_lock lockinit(_mutexInit);
+        std::lock_guard<std::mutex> lockinit(_mutexInit);
         if( _bInit ) {
             RAVELOG_WARN("environment is already initialized, ignoring\n");
             return;
@@ -326,7 +326,7 @@ public:
 
     virtual void Destroy()
     {
-        std::scoped_lock lockdestroy(_mutexInit);
+        std::lock_guard<std::mutex> lockdestroy(_mutexInit);
         if( !_bInit ) {
             RAVELOG_VERBOSE_FORMAT("env=%s is already destroyed", GetNameId());
             return;
@@ -366,7 +366,7 @@ public:
 
         // lock the environment
         {
-            EnvironmentMutex::scoped_lock lockenv(GetMutex());
+            EnvironmentLock lockenv(GetMutex());
             _bEnableSimulation = false;
             if( !!_pPhysicsEngine ) {
                 _pPhysicsEngine->DestroyEnvironment();
@@ -428,7 +428,7 @@ public:
             }
         }
 
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
 
         if( !!_pPhysicsEngine ) {
             _pPhysicsEngine->DestroyEnvironment();
@@ -507,21 +507,21 @@ public:
     virtual void OwnInterface(InterfaceBasePtr pinterface)
     {
         CHECK_INTERFACE(pinterface);
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         ExclusiveLock lock473(_mutexInterfaces);
         _listOwnedInterfaces.push_back(pinterface);
     }
     virtual void DisownInterface(InterfaceBasePtr pinterface)
     {
         CHECK_INTERFACE(pinterface);
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         ExclusiveLock lock277(_mutexInterfaces);
         _listOwnedInterfaces.remove(pinterface);
     }
 
     EnvironmentBasePtr CloneSelf(int options) override
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         boost::shared_ptr<Environment> penv(new Environment());
         penv->_Clone(boost::static_pointer_cast<Environment const>(shared_from_this()),options,false);
         return penv;
@@ -529,7 +529,7 @@ public:
 
     EnvironmentBasePtr CloneSelf(const std::string& clonedEnvName, int options) override
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         boost::shared_ptr<Environment> penv(new Environment(clonedEnvName));
         penv->_Clone(boost::static_pointer_cast<Environment const>(shared_from_this()),options,false);
         return penv;
@@ -537,13 +537,13 @@ public:
 
     void Clone(EnvironmentBaseConstPtr preference, int cloningoptions) override
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         _Clone(boost::static_pointer_cast<Environment const>(preference),cloningoptions,true);
     }
 
     void Clone(EnvironmentBaseConstPtr preference, const std::string& clonedEnvName, int cloningoptions) override
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         _Clone(boost::static_pointer_cast<Environment const>(preference), cloningoptions,true);
         _name = clonedEnvName;
         if (_name.empty()) {
@@ -562,7 +562,7 @@ public:
             RAVELOG_WARN_FORMAT("Error %d with executing module %s", ret%module->GetXMLId());
         }
         else {
-            EnvironmentMutex::scoped_lock lockenv(GetMutex());
+            EnvironmentLock lockenv(GetMutex());
             ExclusiveLock lock668(_mutexInterfaces);
             _listModules.emplace_back(module,  cmdargs);
         }
@@ -603,7 +603,7 @@ public:
 
     virtual bool Load(const std::string& filename, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         OpenRAVEXMLParser::GetXMLErrorCount() = 0;
         if( _IsColladaURI(filename) ) {
             if( RaveParseColladaURI(shared_from_this(), filename, atts) ) {
@@ -660,7 +660,7 @@ public:
 
     virtual bool LoadData(const std::string& data, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         if( _IsColladaData(data) ) {
             return RaveParseColladaData(shared_from_this(), data, atts);
         }
@@ -677,13 +677,13 @@ public:
 
     bool LoadJSON(const rapidjson::Value& rEnvInfo, UpdateFromInfoMode updateMode, std::vector<KinBodyPtr>& vCreatedBodies, std::vector<KinBodyPtr>& vModifiedBodies, std::vector<KinBodyPtr>& vRemovedBodies, const AttributesList& atts) override
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         return RaveParseJSON(shared_from_this(), rEnvInfo, updateMode, vCreatedBodies, vModifiedBodies, vRemovedBodies, atts, *_prLoadEnvAlloc);
     }
 
     virtual void Save(const std::string& filename, SelectionOptions options, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         std::list<KinBodyPtr> listbodies;
         switch(options) {
         case SO_Everything:
@@ -777,7 +777,7 @@ public:
 
     virtual void SerializeJSON(rapidjson::Value& rEnvironment, rapidjson::Document::AllocatorType& allocator, SelectionOptions options, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         std::list<KinBodyPtr> listbodies;
         switch(options) {
         case SO_Everything:
@@ -843,7 +843,7 @@ public:
             throw OPENRAVE_EXCEPTION_FORMAT("got invalid filetype %s, only support collada and json", filetype, ORE_InvalidArguments);
         }
 
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         std::list<KinBodyPtr> listbodies;
         switch(options) {
         case SO_Everything:
@@ -953,7 +953,7 @@ public:
 
     virtual void _AddKinBody(KinBodyPtr pbody, InterfaceAddMode addMode)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_INTERFACE(pbody);
         if( !utils::IsValidName(pbody->GetName()) ) {
             if( addMode & IAM_StrictNameChecking ) {
@@ -990,7 +990,7 @@ public:
 
     virtual void _AddRobot(RobotBasePtr robot, InterfaceAddMode addMode)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_INTERFACE(robot);
         if( !robot->IsRobot() ) {
             throw openrave_exception(str(boost::format(_("kinbody \"%s\" is not a robot"))%robot->GetName()));
@@ -1030,7 +1030,7 @@ public:
 
     virtual void _AddSensor(SensorBasePtr psensor, InterfaceAddMode addMode)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_INTERFACE(psensor);
         if( !utils::IsValidName(psensor->GetName()) ) {
             if( addMode & IAM_StrictNameChecking ) {
@@ -1054,7 +1054,7 @@ public:
 
     virtual bool Remove(InterfaceBasePtr pinterface)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_INTERFACE(pinterface);
         switch(pinterface->GetInterfaceType()) {
         case PT_KinBody:
@@ -1112,7 +1112,7 @@ public:
 
     virtual bool RemoveKinBodyByName(const std::string& name)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         KinBodyPtr pbody;
         {
             ExclusiveLock lock101(_mutexInterfaces);
@@ -1281,7 +1281,7 @@ public:
 
     virtual bool SetPhysicsEngine(PhysicsEngineBasePtr pengine)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         if( !!_pPhysicsEngine ) {
             _pPhysicsEngine->DestroyEnvironment();
         }
@@ -1327,7 +1327,7 @@ public:
 
     virtual bool SetCollisionChecker(CollisionCheckerBasePtr pchecker)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         if( _pCurrentChecker == pchecker ) {
             return true;
         }
@@ -1358,14 +1358,14 @@ public:
 
     virtual bool CheckCollision(KinBodyConstPtr pbody1, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(pbody1);
         return _pCurrentChecker->CheckCollision(pbody1,report);
     }
 
     virtual bool CheckCollision(KinBodyConstPtr pbody1, KinBodyConstPtr pbody2, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(pbody1);
         CHECK_COLLISION_BODY(pbody2);
         return _pCurrentChecker->CheckCollision(pbody1,pbody2,report);
@@ -1373,14 +1373,14 @@ public:
 
     virtual bool CheckCollision(KinBody::LinkConstPtr plink, CollisionReportPtr report )
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(plink->GetParent());
         return _pCurrentChecker->CheckCollision(plink,report);
     }
 
     virtual bool CheckCollision(KinBody::LinkConstPtr plink1, KinBody::LinkConstPtr plink2, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(plink1->GetParent());
         CHECK_COLLISION_BODY(plink2->GetParent());
         return _pCurrentChecker->CheckCollision(plink1,plink2,report);
@@ -1388,7 +1388,7 @@ public:
 
     virtual bool CheckCollision(KinBody::LinkConstPtr plink, KinBodyConstPtr pbody, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(plink->GetParent());
         CHECK_COLLISION_BODY(pbody);
         return _pCurrentChecker->CheckCollision(plink,pbody,report);
@@ -1396,27 +1396,27 @@ public:
 
     virtual bool CheckCollision(KinBody::LinkConstPtr plink, const std::vector<KinBodyConstPtr>& vbodyexcluded, const std::vector<KinBody::LinkConstPtr>& vlinkexcluded, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(plink->GetParent());
         return _pCurrentChecker->CheckCollision(plink,vbodyexcluded,vlinkexcluded,report);
     }
 
     virtual bool CheckCollision(KinBodyConstPtr pbody, const std::vector<KinBodyConstPtr>& vbodyexcluded, const std::vector<KinBody::LinkConstPtr>& vlinkexcluded, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(pbody);
         return _pCurrentChecker->CheckCollision(pbody,vbodyexcluded,vlinkexcluded,report);
     }
 
     virtual bool CheckCollision(const RAY& ray, KinBody::LinkConstPtr plink, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(plink->GetParent());
         return _pCurrentChecker->CheckCollision(ray,plink,report);
     }
     virtual bool CheckCollision(const RAY& ray, KinBodyConstPtr pbody, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(pbody);
         return _pCurrentChecker->CheckCollision(ray,pbody,report);
     }
@@ -1427,21 +1427,21 @@ public:
 
     virtual bool CheckCollision(const TriMesh& trimesh, KinBodyConstPtr pbody, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(pbody);
         return _pCurrentChecker->CheckCollision(trimesh,pbody,report);
     }
 
     virtual bool CheckStandaloneSelfCollision(KinBodyConstPtr pbody, CollisionReportPtr report)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         CHECK_COLLISION_BODY(pbody);
         return _pCurrentChecker->CheckStandaloneSelfCollision(pbody,report);
     }
 
     virtual void StepSimulation(dReal fTimeStep)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
 
         uint64_t step = (uint64_t)ceil(1000000.0 * (double)fTimeStep);
         fTimeStep = (dReal)((double)step * 0.000001);
@@ -1556,7 +1556,7 @@ public:
 
     virtual void Triangulate(TriMesh& trimesh, const KinBody &body)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());     // reading collision data, so don't want anyone modifying it
+        EnvironmentLock lockenv(GetMutex());     // reading collision data, so don't want anyone modifying it
         FOREACHC(it, body.GetLinks()) {
             trimesh.Append((*it)->GetCollisionData(), (*it)->GetTransform());
         }
@@ -1564,7 +1564,7 @@ public:
 
     virtual void TriangulateScene(TriMesh& trimesh, SelectionOptions options,const std::string& selectname)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         ExclusiveLock lock830(_mutexInterfaces);
         for (KinBodyPtr& pbody : _vecbodies) {
             if (!pbody) {
@@ -1615,7 +1615,7 @@ public:
 
     virtual RobotBasePtr ReadRobotURI(RobotBasePtr robot, const std::string& filename, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
 
         if( !!robot ) {
             SharedLock lock617(_mutexInterfaces);
@@ -1736,7 +1736,7 @@ public:
 
     virtual RobotBasePtr ReadRobotData(RobotBasePtr robot, const std::string& data, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
 
         if( !!robot ) {
             SharedLock lock681(_mutexInterfaces);
@@ -1807,7 +1807,7 @@ public:
 
     virtual KinBodyPtr ReadKinBodyURI(KinBodyPtr body, const std::string& filename, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
 
         if( !!body ) {
             SharedLock lock285(_mutexInterfaces);
@@ -1927,7 +1927,7 @@ public:
 
     virtual KinBodyPtr ReadKinBodyData(KinBodyPtr body, const std::string& data, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
 
         if( !!body ) {
             SharedLock lock937(_mutexInterfaces);
@@ -1997,7 +1997,7 @@ public:
     virtual InterfaceBasePtr ReadInterfaceURI(const std::string& filename, const AttributesList& atts)
     {
         try {
-            EnvironmentMutex::scoped_lock lockenv(GetMutex());
+            EnvironmentLock lockenv(GetMutex());
             BaseXMLReaderPtr preader = OpenRAVEXMLParser::CreateInterfaceReader(shared_from_this(),atts,false);
             if( !preader ) {
                 return InterfaceBasePtr();
@@ -2019,7 +2019,7 @@ public:
 
     virtual InterfaceBasePtr ReadInterfaceURI(InterfaceBasePtr pinterface, InterfaceType type, const std::string& filename, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         bool bIsColladaURI = false;
         bool bIsColladaFile = false;
         bool bIsJSONURI = false;
@@ -2166,7 +2166,7 @@ public:
 
     virtual InterfaceBasePtr ReadInterfaceData(InterfaceBasePtr pinterface, InterfaceType type, const std::string& data, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
 
         // check for collada?
         BaseXMLReaderPtr preader = OpenRAVEXMLParser::CreateInterfaceReader(shared_from_this(), type, pinterface, RaveGetInterfaceName(type), atts);
@@ -2190,7 +2190,7 @@ public:
 
     virtual boost::shared_ptr<TriMesh> _ReadTrimeshURI(boost::shared_ptr<TriMesh> ptrimesh, const std::string& filename, RaveVector<float>& diffuseColor, RaveVector<float>& ambientColor, const AttributesList& atts)
     {
-        //EnvironmentMutex::scoped_lock lockenv(GetMutex()); // don't lock!
+        //EnvironmentLock lockenv(GetMutex()); // don't lock!
         string filedata = RaveFindLocalFile(filename);
         if( filedata.size() == 0 ) {
             return boost::shared_ptr<TriMesh>();
@@ -2252,7 +2252,7 @@ public:
     /// \param[in] listGeometries geometry list to be filled
     virtual std::string _ReadGeometriesFile(std::list<KinBody::GeometryInfo>& listGeometries, const std::string& filename, const AttributesList& atts)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         string filedata = RaveFindLocalFile(filename);
         if( filedata.size() == 0 ) {
             return std::string();
@@ -2277,7 +2277,7 @@ public:
     virtual void _AddViewer(ViewerBasePtr pnewviewer)
     {
         CHECK_INTERFACE(pnewviewer);
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         ExclusiveLock lock212(_mutexInterfaces);
         BOOST_ASSERT(find(_listViewers.begin(),_listViewers.end(),pnewviewer) == _listViewers.end() );
         _CheckUniqueName(ViewerBaseConstPtr(pnewviewer),true);
@@ -2490,7 +2490,7 @@ public:
     virtual void StartSimulation(dReal fDeltaTime, bool bRealTime)
     {
         {
-            EnvironmentMutex::scoped_lock lockenv(GetMutex());
+            EnvironmentLock lockenv(GetMutex());
             _bEnableSimulation = true;
             _fDeltaSimTime = fDeltaTime;
             _bRealTime = bRealTime;
@@ -2507,7 +2507,7 @@ public:
     virtual void StopSimulation(int shutdownthread=1)
     {
         {
-            EnvironmentMutex::scoped_lock lockenv(GetMutex());
+            EnvironmentLock lockenv(GetMutex());
             _bEnableSimulation = false;
             _fDeltaSimTime = 1.0f;
         }
@@ -2588,7 +2588,7 @@ public:
 
     virtual void UpdatePublishedBodies(uint64_t timeout=0)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         TimedExclusiveLock lock152(_mutexInterfaces, timeout);
         if (!lock152) {
             throw OPENRAVE_EXCEPTION_FORMAT(_("timeout of %f s failed"),(1e-6*static_cast<double>(timeout)),ORE_Timeout);
@@ -2657,7 +2657,7 @@ public:
     /// \brief similar to GetInfo, but creates a copy of an up-to-date info, safe for caller to manipulate
     virtual void ExtractInfo(EnvironmentBaseInfo& info) override
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         std::vector<KinBodyPtr> vBodies;
         int numBodies = 0;
         {
@@ -2700,7 +2700,7 @@ public:
         vModifiedBodies.clear();
         vRemovedBodies.clear();
 
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         std::vector<dReal> vDOFValues;
 
         if( updateMode != UFIM_OnlySpecifiedBodiesExact ) {
@@ -3076,43 +3076,43 @@ public:
     }
 
     int GetRevision() const override {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         return _revision;
     }
 
     void SetDescription(const std::string& sceneDescription) override {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         _description = sceneDescription;
     }
 
     std::string GetDescription() const override {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         return _description;
     }
 
     void SetKeywords(const std::vector<std::string>& sceneKeywords) override {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         _keywords = sceneKeywords;
     }
 
     std::vector<std::string> GetKeywords() const override {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         return _keywords;
     }
 
     void SetUInt64Parameter(const std::string& parameterName, uint64_t value) override {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         _mapUInt64Parameters[parameterName] = value;
     }
 
     bool RemoveUInt64Parameter(const std::string& parameterName) override
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         return _mapUInt64Parameters.erase(parameterName) > 0;
     }
 
     uint64_t GetUInt64Parameter(const std::string& parameterName, uint64_t defaultValue) const override {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         std::map<std::string, uint64_t>::const_iterator it = _mapUInt64Parameters.find(parameterName);
         if( it != _mapUInt64Parameters.end() ) {
             return it->second;
@@ -3266,13 +3266,13 @@ protected:
 
     virtual bool _ParseXMLFile(BaseXMLReaderPtr preader, const std::string& filename)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         return OpenRAVEXMLParser::ParseXMLFile(preader, filename);
     }
 
     virtual bool _ParseXMLData(BaseXMLReaderPtr preader, const std::string& pdata)
     {
-        EnvironmentMutex::scoped_lock lockenv(GetMutex());
+        EnvironmentLock lockenv(GetMutex());
         return OpenRAVEXMLParser::ParseXMLData(preader, pdata);
     }
 
@@ -3282,7 +3282,7 @@ protected:
             Destroy();
         }
 
-        std::scoped_lock lockinit(_mutexInit);
+        std::lock_guard<std::mutex> lockinit(_mutexInit);
         if( !bCheckSharedResources ) {
             SetCollisionChecker(CollisionCheckerBasePtr());
             SetPhysicsEngine(PhysicsEngineBasePtr());
@@ -3352,7 +3352,7 @@ protected:
             listModules.clear();
         }
 
-        EnvironmentMutex::scoped_lock lock(GetMutex());
+        EnvironmentLock lock(GetMutex());
 
         bool bCollisionCheckerChanged = false;
         if( !!r->GetCollisionChecker() ) {
@@ -3937,7 +3937,7 @@ protected:
         RAVELOG_VERBOSE_FORMAT("starting simulation thread envid=%d", environmentid);
         while( _bInit && !_bShutdownSimulation ) {
             bool bNeedSleep = true;
-            boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv;
+            boost::shared_ptr<EnvironmentLock> lockenv;
             if( _bEnableSimulation ) {
                 bNeedSleep = false;
                 lockenv = _LockEnvironmentWithTimeout(100000);
@@ -4026,14 +4026,10 @@ protected:
         }
     }
 
-    boost::shared_ptr<EnvironmentMutex::scoped_try_lock> _LockEnvironmentWithTimeout(uint64_t timeout)
+    boost::shared_ptr<EnvironmentLock> _LockEnvironmentWithTimeout(uint64_t timeout)
     {
         // try to acquire the lock
-#if BOOST_VERSION >= 103500
-        boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetMutex(),boost::defer_lock_t()));
-#else
-        boost::shared_ptr<EnvironmentMutex::scoped_try_lock> lockenv(new EnvironmentMutex::scoped_try_lock(GetMutex(),false));
-#endif
+        boost::shared_ptr<EnvironmentLock> lockenv = boost::make_shared<EnvironmentLock>(GetMutex(), std::defer_lock_t());
         uint64_t basetime = utils::GetMicroTime();
         while(utils::GetMicroTime()-basetime<timeout ) {
             lockenv->try_lock();

--- a/src/libopenrave-core/multicontroller.cpp
+++ b/src/libopenrave-core/multicontroller.cpp
@@ -28,7 +28,7 @@ public:
 
     virtual bool Init(RobotBasePtr robot, const std::vector<int>& dofindices, int nControlTransformation)
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         _probot=robot;
         if( !_probot ) {
             return false;
@@ -62,7 +62,7 @@ public:
 
     virtual bool AttachController(ControllerBasePtr controller, const std::vector<int>& dofindices, int nControlTransformation)
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         if( nControlTransformation && !!_ptransformcontroller ) {
             throw openrave_exception(_("controller already attached for transformation"),ORE_InvalidArguments);
         }
@@ -86,7 +86,7 @@ public:
 
     virtual void RemoveController(ControllerBasePtr controller)
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         _listcontrollers.remove(controller);
         if( _ptransformcontroller == controller ) {
             _ptransformcontroller.reset();
@@ -100,7 +100,7 @@ public:
 
     virtual ControllerBasePtr GetController(int dof) const
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         if( dof < 0 ) {
             return _ptransformcontroller;
         }
@@ -116,7 +116,7 @@ public:
 
     virtual void Reset(int options=0)
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         FOREACH(itcontroller,_listcontrollers) {
             (*itcontroller)->Reset(options);
         }
@@ -124,7 +124,7 @@ public:
 
     virtual bool SetDesired(const std::vector<dReal>& values, TransformConstPtr trans=TransformConstPtr())
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         vector<dReal> v;
         bool bsuccess = true;
         FOREACH(itcontroller,_listcontrollers) {
@@ -139,7 +139,7 @@ public:
 
     virtual bool SetPath(TrajectoryBaseConstPtr ptraj)
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         bool bsuccess = true;
         FOREACH(itcontroller,_listcontrollers) {
             bsuccess &= (*itcontroller)->SetPath(ptraj);
@@ -148,7 +148,7 @@ public:
     }
 
     virtual void SimulationStep(dReal fTimeElapsed) {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         FOREACH(it,_listcontrollers) {
             (*it)->SimulationStep(fTimeElapsed);
         }
@@ -156,7 +156,7 @@ public:
 
     virtual bool IsDone()
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         bool bdone=true;
         FOREACH(it,_listcontrollers) {
             bdone &= (*it)->IsDone();
@@ -166,7 +166,7 @@ public:
 
     virtual dReal GetTime() const
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         dReal t = 0;
         FOREACHC(it,_listcontrollers) {
             if( it == _listcontrollers.begin() ) {
@@ -185,7 +185,7 @@ public:
 
     virtual void GetVelocity(std::vector<dReal>& vel) const
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         vel.resize(_dofindices.size());
         FOREACH(it,vel) {
             *it = 0;
@@ -205,7 +205,7 @@ public:
     /// The feedforward and friction terms should be subtracted out already
     virtual void GetTorque(std::vector<dReal>& torque) const
     {
-        boost::mutex::scoped_lock lock(_mutex);
+        std::scoped_lock lock(_mutex);
         torque.resize(_dofindices.size());
         FOREACH(it,torque) {
             *it = 0;
@@ -228,7 +228,7 @@ protected:
     std::vector<ControllerBasePtr> _vcontrollersbydofs;
     ControllerBasePtr _ptransformcontroller;
     TrajectoryBasePtr _ptraj;
-    mutable boost::mutex _mutex;
+    mutable std::mutex _mutex;
 };
 
 MultiControllerBasePtr CreateMultiController(EnvironmentBasePtr penv, std::istream& sinput)

--- a/src/libopenrave-core/multicontroller.cpp
+++ b/src/libopenrave-core/multicontroller.cpp
@@ -28,7 +28,7 @@ public:
 
     virtual bool Init(RobotBasePtr robot, const std::vector<int>& dofindices, int nControlTransformation)
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         _probot=robot;
         if( !_probot ) {
             return false;
@@ -62,7 +62,7 @@ public:
 
     virtual bool AttachController(ControllerBasePtr controller, const std::vector<int>& dofindices, int nControlTransformation)
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         if( nControlTransformation && !!_ptransformcontroller ) {
             throw openrave_exception(_("controller already attached for transformation"),ORE_InvalidArguments);
         }
@@ -86,7 +86,7 @@ public:
 
     virtual void RemoveController(ControllerBasePtr controller)
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         _listcontrollers.remove(controller);
         if( _ptransformcontroller == controller ) {
             _ptransformcontroller.reset();
@@ -100,7 +100,7 @@ public:
 
     virtual ControllerBasePtr GetController(int dof) const
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         if( dof < 0 ) {
             return _ptransformcontroller;
         }
@@ -116,7 +116,7 @@ public:
 
     virtual void Reset(int options=0)
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         FOREACH(itcontroller,_listcontrollers) {
             (*itcontroller)->Reset(options);
         }
@@ -124,7 +124,7 @@ public:
 
     virtual bool SetDesired(const std::vector<dReal>& values, TransformConstPtr trans=TransformConstPtr())
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         vector<dReal> v;
         bool bsuccess = true;
         FOREACH(itcontroller,_listcontrollers) {
@@ -139,7 +139,7 @@ public:
 
     virtual bool SetPath(TrajectoryBaseConstPtr ptraj)
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         bool bsuccess = true;
         FOREACH(itcontroller,_listcontrollers) {
             bsuccess &= (*itcontroller)->SetPath(ptraj);
@@ -148,7 +148,7 @@ public:
     }
 
     virtual void SimulationStep(dReal fTimeElapsed) {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         FOREACH(it,_listcontrollers) {
             (*it)->SimulationStep(fTimeElapsed);
         }
@@ -156,7 +156,7 @@ public:
 
     virtual bool IsDone()
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         bool bdone=true;
         FOREACH(it,_listcontrollers) {
             bdone &= (*it)->IsDone();
@@ -166,7 +166,7 @@ public:
 
     virtual dReal GetTime() const
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         dReal t = 0;
         FOREACHC(it,_listcontrollers) {
             if( it == _listcontrollers.begin() ) {
@@ -185,7 +185,7 @@ public:
 
     virtual void GetVelocity(std::vector<dReal>& vel) const
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         vel.resize(_dofindices.size());
         FOREACH(it,vel) {
             *it = 0;
@@ -205,7 +205,7 @@ public:
     /// The feedforward and friction terms should be subtracted out already
     virtual void GetTorque(std::vector<dReal>& torque) const
     {
-        std::scoped_lock lock(_mutex);
+        std::lock_guard<std::mutex> lock(_mutex);
         torque.resize(_dofindices.size());
         FOREACH(it,torque) {
             *it = 0;

--- a/src/libopenrave-core/xmlreaders-core.cpp
+++ b/src/libopenrave-core/xmlreaders-core.cpp
@@ -686,7 +686,7 @@ bool ParseXMLFile(BaseXMLReaderPtr preader, const string& filename)
     if( filedata.size() == 0 ) {
         return false;
     }
-    EnvironmentMutex::scoped_lock lock(*GetXMLMutex());
+    EnvironmentLock lock(*GetXMLMutex());
 
 #ifdef HAVE_BOOST_FILESYSTEM
     SetParseDirectoryScope scope(boost::filesystem::path(filedata).parent_path().string());
@@ -721,7 +721,7 @@ bool ParseXMLData(BaseXMLReaderPtr preader, const std::string& pdata)
     if( pdata.size() == 0 ) {
         return false;
     }
-    EnvironmentMutex::scoped_lock lock(*GetXMLMutex());
+    EnvironmentLock lock(*GetXMLMutex());
     return raveXmlSAXUserParseMemory(GetSAXHandler(), preader, pdata.c_str(), pdata.size())==0;
 }
 

--- a/src/libopenrave/interface.cpp
+++ b/src/libopenrave/interface.cpp
@@ -30,7 +30,7 @@ InterfaceBase::InterfaceBase(InterfaceType type, EnvironmentBasePtr penv) : __ty
 
 InterfaceBase::~InterfaceBase()
 {
-    boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     __mapCommands.clear();
     __mapUserData.clear();
     __mapReadableInterfaces.clear();
@@ -42,7 +42,7 @@ void InterfaceBase::SetUserData(const std::string& key, UserDataPtr data) const
 {
     UserDataPtr olduserdata;
     {
-        boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+        std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
         std::map<std::string, UserDataPtr>::iterator it = __mapUserData.find(key);
         if( it == __mapUserData.end() ) {
             __mapUserData[key] = data;
@@ -70,7 +70,7 @@ bool InterfaceBase::RemoveUserData(const std::string& key) const
     // have to destroy the userdata pointer outside the lock, otherwise can get into a deadlock
     UserDataPtr olduserdata;
     {
-        boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+        std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
         std::map<std::string, UserDataPtr>::iterator it = __mapUserData.find(key);
         if( it == __mapUserData.end() ) {
             return false;
@@ -134,7 +134,7 @@ void InterfaceBase::Serialize(BaseXMLWriterPtr writer, int options) const
 
 void InterfaceBase::RegisterCommand(const std::string& cmdname, InterfaceBase::InterfaceCommandFn fncmd, const std::string& strhelp)
 {
-    boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     if((cmdname.size() == 0)|| !utils::IsValidName(cmdname) ||(_stricmp(cmdname.c_str(),"commands") == 0)) {
         throw openrave_exception(str(boost::format(_("command '%s' invalid"))%cmdname),ORE_InvalidArguments);
     }
@@ -146,7 +146,7 @@ void InterfaceBase::RegisterCommand(const std::string& cmdname, InterfaceBase::I
 
 void InterfaceBase::UnregisterCommand(const std::string& cmdname)
 {
-    boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     CMDMAP::iterator it = __mapCommands.find(cmdname);
     if( it != __mapCommands.end() ) {
         __mapCommands.erase(it);
@@ -217,7 +217,7 @@ bool InterfaceBase::SupportsJSONCommand(const std::string& cmd)
 
 void InterfaceBase::RegisterJSONCommand(const std::string& cmdname, InterfaceBase::InterfaceJSONCommandFn fncmd, const std::string& strhelp)
 {
-    boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     if((cmdname.size() == 0)|| !utils::IsValidName(cmdname)) {
         throw openrave_exception(str(boost::format(_("command '%s' invalid"))%cmdname),ORE_InvalidArguments);
     }
@@ -229,7 +229,7 @@ void InterfaceBase::RegisterJSONCommand(const std::string& cmdname, InterfaceBas
 
 void InterfaceBase::UnregisterJSONCommand(const std::string& cmdname)
 {
-    boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     JSONCMDMAP::iterator it = __mapJSONCommands.find(cmdname);
     if( it != __mapJSONCommands.end() ) {
         __mapJSONCommands.erase(it);
@@ -268,7 +268,7 @@ ReadablePtr InterfaceBase::GetReadableInterface(const std::string& id) const
 
 ReadablePtr InterfaceBase::SetReadableInterface(const std::string& id, ReadablePtr readable)
 {
-    boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     READERSMAP::iterator it = __mapReadableInterfaces.find(id);
     if( it == __mapReadableInterfaces.end() ) {
         if( !!readable ) {
@@ -288,7 +288,7 @@ ReadablePtr InterfaceBase::SetReadableInterface(const std::string& id, ReadableP
 
 void InterfaceBase::SetReadableInterfaces(const InterfaceBase::READERSMAP& mapReadables, bool bClearAllExisting)
 {
-    boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     if( bClearAllExisting ) {
         __mapReadableInterfaces = mapReadables;
     }
@@ -299,17 +299,17 @@ void InterfaceBase::SetReadableInterfaces(const InterfaceBase::READERSMAP& mapRe
 
 void InterfaceBase::ClearReadableInterfaces()
 {
-    boost::unique_lock< boost::shared_mutex > lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     __mapReadableInterfaces.clear();
 }
 
 void InterfaceBase::ClearReadableInterface(const std::string& id) {
-    boost::unique_lock<boost::shared_mutex> lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     __mapReadableInterfaces.erase(id);
 }
 
 bool InterfaceBase::UpdateReadableInterfaces(const std::map<std::string, ReadablePtr>& newReadableInterfaces) {
-    boost::unique_lock<boost::shared_mutex> lock(_mutexInterface);
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     bool bChanged = false;
     bool bNewAllFound = true;
     FOREACH(it, newReadableInterfaces) {

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -72,7 +72,7 @@ public:
     virtual ~ChangeCallbackData() {
         KinBodyConstPtr pbody = _pweakbody.lock();
         if( !!pbody ) {
-            boost::unique_lock< boost::shared_mutex > lock(pbody->GetInterfaceMutex());
+            std::unique_lock<boost::shared_mutex> lock(pbody->GetInterfaceMutex());
             FOREACH(itinfo, _iterators) {
                 pbody->_vlistRegisteredCallbacks.at(itinfo->first).erase(itinfo->second);
             }
@@ -5801,7 +5801,7 @@ ConfigurationSpecification KinBody::GetConfigurationSpecificationIndices(const s
 UserDataPtr KinBody::RegisterChangeCallback(uint32_t properties, const boost::function<void()>&callback) const
 {
     ChangeCallbackDataPtr pdata(new ChangeCallbackData(properties,callback,shared_kinbody_const()));
-    boost::unique_lock< boost::shared_mutex > lock(GetInterfaceMutex());
+    std::unique_lock<boost::shared_mutex> lock(GetInterfaceMutex());
 
     uint32_t index = 0;
     while(properties) {

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -500,7 +500,7 @@ public:
         // environments have to be destroyed carefully since their destructors can be called, which will attempt to unregister the environment
         std::map<int, EnvironmentBase*> mapenvironments;
         {
-            boost::mutex::scoped_lock lock(_mutexinternal);
+            std::scoped_lock lock(_mutexinternal);
             mapenvironments = _mapenvironments;
         }
         FOREACH(itenv,mapenvironments) {
@@ -517,7 +517,7 @@ public:
         // process the callbacks
         std::list<boost::function<void()> > listDestroyCallbacks;
         {
-            boost::mutex::scoped_lock lock(_mutexinternal);
+            std::scoped_lock lock(_mutexinternal);
             listDestroyCallbacks.swap(_listDestroyCallbacks);
         }
         FOREACH(itcallback, listDestroyCallbacks) {
@@ -548,7 +548,7 @@ public:
 
     void AddCallbackForDestroy(const boost::function<void()>& fn)
     {
-        boost::mutex::scoped_lock lock(_mutexinternal);
+        std::scoped_lock lock(_mutexinternal);
         _listDestroyCallbacks.push_back(fn);
     }
 
@@ -637,7 +637,7 @@ public:
 public:
         XMLReaderFunctionData(InterfaceType type, const std::string& xmltag, const CreateXMLReaderFn& fn, boost::shared_ptr<RaveGlobal> global) : _global(global), _type(type), _xmltag(xmltag)
         {
-            boost::mutex::scoped_lock lock(global->_mutexinternal);
+            std::scoped_lock lock(global->_mutexinternal);
             _oldfn = global->_mapxmlreaders[_type][_xmltag];
             global->_mapxmlreaders[_type][_xmltag] = fn;
         }
@@ -645,7 +645,7 @@ public:
         {
             boost::shared_ptr<RaveGlobal> global = _global.lock();
             if( !!global ) {
-                boost::mutex::scoped_lock lock(global->_mutexinternal);
+                std::scoped_lock lock(global->_mutexinternal);
                 global->_mapxmlreaders[_type][_xmltag] = _oldfn;
             }
         }
@@ -676,7 +676,7 @@ protected:
 public:
         JSONReaderFunctionData(InterfaceType type, const std::string& id, const CreateJSONReaderFn& fn, boost::shared_ptr<RaveGlobal> global) : _global(global), _type(type), _id(id)
         {
-            boost::mutex::scoped_lock lock(global->_mutexinternal);
+            std::scoped_lock lock(global->_mutexinternal);
             _oldfn = global->_mapjsonreaders[_type][_id];
             global->_mapjsonreaders[_type][_id] = fn;
         }
@@ -684,7 +684,7 @@ public:
         {
             boost::shared_ptr<RaveGlobal> global = _global.lock();
             if( !!global ) {
-                boost::mutex::scoped_lock lock(global->_mutexinternal);
+                std::scoped_lock lock(global->_mutexinternal);
                 global->_mapjsonreaders[_type][_id] = _oldfn;
             }
         }
@@ -736,14 +736,14 @@ protected:
     int RegisterEnvironment(EnvironmentBase* penv)
     {
         BOOST_ASSERT(!!_pdatabase);
-        boost::mutex::scoped_lock lock(_mutexinternal);
+        std::scoped_lock lock(_mutexinternal);
         _mapenvironments[++_nGlobalEnvironmentId] = penv;
         return _nGlobalEnvironmentId;
     }
 
     void UnregisterEnvironment(EnvironmentBase* penv)
     {
-        boost::mutex::scoped_lock lock(_mutexinternal);
+        std::scoped_lock lock(_mutexinternal);
         FOREACH(it, _mapenvironments) {
             if( it->second == penv ) {
                 _mapenvironments.erase(it);
@@ -755,7 +755,7 @@ protected:
     int GetEnvironmentId(EnvironmentBaseConstPtr penv)
     {
         return !!penv ? penv->GetId() : 0;
-//        boost::mutex::scoped_lock lock(_mutexinternal);
+//        std::scoped_lock lock(_mutexinternal);
 //        FOREACH(it,_mapenvironments) {
 //            if( it->second == penv.get() ) {
 //                return it->first;
@@ -766,7 +766,7 @@ protected:
 
     EnvironmentBasePtr GetEnvironment(int id)
     {
-        boost::mutex::scoped_lock lock(_mutexinternal);
+        std::scoped_lock lock(_mutexinternal);
         std::map<int, EnvironmentBase*>::iterator it = _mapenvironments.find(id);
         if( it == _mapenvironments.end() ) {
             return EnvironmentBasePtr();
@@ -777,7 +777,7 @@ protected:
     void GetEnvironments(std::list<EnvironmentBasePtr>& listenvironments)
     {
         listenvironments.clear();
-        boost::mutex::scoped_lock lock(_mutexinternal);
+        std::scoped_lock lock(_mutexinternal);
         FOREACH(it,_mapenvironments) {
             EnvironmentBasePtr penv = it->second->shared_from_this();
             if( !!penv ) {
@@ -789,7 +789,7 @@ protected:
     SpaceSamplerBasePtr GetDefaultSampler()
     {
         if( !_pdefaultsampler ) {
-            boost::mutex::scoped_lock lock(_mutexinternal);
+            std::scoped_lock lock(_mutexinternal);
             BOOST_ASSERT( _mapenvironments.size() > 0 );
             _pdefaultsampler = GetDatabase()->CreateSpaceSampler(_mapenvironments.begin()->second->shared_from_this(),"MT19937");
         }
@@ -805,7 +805,7 @@ protected:
             return std::string();
         }
 
-        boost::mutex::scoped_lock lock(_mutexinternal);
+        std::scoped_lock lock(_mutexinternal);
         boost::filesystem::path fullfilename;
         boost::filesystem::path filename(_filename);
 
@@ -870,11 +870,11 @@ protected:
     }
 
     void SetDataAccess(int options) {
-        boost::mutex::scoped_lock lock(_mutexinternal);
+        std::scoped_lock lock(_mutexinternal);
         _nDataAccessOptions = options;
     }
     int GetDataAccess() {
-        boost::mutex::scoped_lock lock(_mutexinternal);
+        std::scoped_lock lock(_mutexinternal);
         return _nDataAccessOptions;
     }
     std::string GetDefaultViewerType() {
@@ -906,7 +906,7 @@ protected:
         return std::string();
     }
 
-    boost::mutex& GetInitializationMutex() {
+    std::mutex& GetInitializationMutex() {
         return _mutexInitialization;
     }
 
@@ -1089,8 +1089,8 @@ private:
     // state that is initialized/destroyed
     boost::shared_ptr<RaveDatabase> _pdatabase;
     int _nDebugLevel;
-    boost::mutex _mutexInitialization; ///< external mutex for initialization only
-    boost::mutex _mutexinternal;
+    std::mutex _mutexInitialization; ///< external mutex for initialization only
+    std::mutex _mutexinternal;
     std::map<InterfaceType, XMLREADERSMAP > _mapxmlreaders;
     std::map<InterfaceType, JSONREADERSMAP > _mapjsonreaders;
     std::map<InterfaceType,string> _mapinterfacenames;
@@ -1180,9 +1180,9 @@ std::string RaveFindDatabaseFile(const std::string& filename, bool bRead)
 int RaveInitialize(bool bLoadAllPlugins, int level)
 {
     boost::shared_ptr<RaveGlobal>& state = RaveGlobal::instance();
-    boost::mutex::scoped_lock lock(state->GetInitializationMutex());
+    std::scoped_lock lock(state->GetInitializationMutex());
     if( state->_IsInitialized() ) {
-        RAVELOG_WARN_FORMAT("[th:%s] OpenRAVE already initialized, so not initializing again", boost::this_thread::get_id());
+        RAVELOG_WARN_FORMAT("[th:%s] OpenRAVE already initialized, so not initializing again", std::this_thread::get_id());
         return 0;
     }
     else {
@@ -1205,7 +1205,7 @@ UserDataPtr RaveGlobalState()
         }
         else {
             // make sure another thread is not initializing the state!
-            boost::mutex::scoped_lock lock(state->GetInitializationMutex());
+            std::scoped_lock lock(state->GetInitializationMutex());
             if( state->_IsInitialized() ) {
                 return state;
             }
@@ -2333,10 +2333,10 @@ void DummyXMLReader::characters(const std::string& ch)
 void EnvironmentBase::_InitializeInternal()
 {
     if( !RaveGlobalState() ) {
-        RAVELOG_WARN_FORMAT("[th:%s] OpenRAVE global state is not initialized! Need to call RaveInitialize before any OpenRAVE services can be used. For now, initializing with default parameters.", boost::this_thread::get_id());
+        RAVELOG_WARN_FORMAT("[th:%s] OpenRAVE global state is not initialized! Need to call RaveInitialize before any OpenRAVE services can be used. For now, initializing with default parameters.", std::this_thread::get_id());
         uint64_t starttime = utils::GetMicroTime();
         RaveInitialize(true);
-        RAVELOG_WARN_FORMAT("[th:%s] OpenRAVE global state finished initializing in %u[us].", boost::this_thread::get_id()%(utils::GetMicroTime()-starttime));
+        RAVELOG_WARN_FORMAT("[th:%s] OpenRAVE global state finished initializing in %u[us].", std::this_thread::get_id()%(utils::GetMicroTime()-starttime));
     }
     __nUniqueId = RaveGlobal::instance()->RegisterEnvironment(this);
 }

--- a/src/libopenrave/libopenrave_c.cpp
+++ b/src/libopenrave/libopenrave_c.cpp
@@ -264,7 +264,7 @@ int ORCEnvironmentSetViewer(void* env, const char* viewername)
 
     if( !!viewername && strlen(viewername) > 0 ) {
         std::unique_lock<std::mutex> lock(s_mutexViewer);
-        boost::shared_ptr<std::thread> threadviewer(new std::thread(boost::bind(CViewerThread, penv, std::string(viewername), true)));
+        boost::shared_ptr<std::thread> threadviewer = boost::make_shared<std::thread>(std::bind(CViewerThread, penv, std::string(viewername), true));
         s_mapEnvironmentThreadViewers[penv] = threadviewer;
         s_conditionViewer.wait(lock);
     }

--- a/src/libopenrave/libopenrave_c.cpp
+++ b/src/libopenrave/libopenrave_c.cpp
@@ -17,7 +17,7 @@
 #include "openrave_c/openrave_c.h"
 #include "libopenrave.h"
 
-#include <boost/thread/condition.hpp>
+#include <condition_variable>
 
 namespace OpenRAVE {
 
@@ -232,7 +232,7 @@ void CViewerThread(EnvironmentBasePtr penv, const string &strviewer, int bShowVi
 {
     ViewerBasePtr pviewer;
     {
-        std::scoped_lock lock(s_mutexViewer);
+        std::lock_guard<std::mutex> lock(s_mutexViewer);
         pviewer = RaveCreateViewer(penv, strviewer);
         if( !!pviewer ) {
             penv->Add(pviewer, IAM_AllowRenaming);
@@ -263,7 +263,7 @@ int ORCEnvironmentSetViewer(void* env, const char* viewername)
     }
 
     if( !!viewername && strlen(viewername) > 0 ) {
-        std::scoped_lock lock(s_mutexViewer);
+        std::unique_lock<std::mutex> lock(s_mutexViewer);
         boost::shared_ptr<std::thread> threadviewer(new std::thread(boost::bind(CViewerThread, penv, std::string(viewername), true)));
         s_mapEnvironmentThreadViewers[penv] = threadviewer;
         s_conditionViewer.wait(lock);

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -601,7 +601,7 @@ PlannerStatus _PlanActiveDOFTrajectory(TrajectoryBasePtr traj, RobotBasePtr prob
     }
 
     EnvironmentBasePtr env = traj->GetEnv();
-    EnvironmentMutex::scoped_lock lockenv(env->GetMutex());
+    EnvironmentLock lockenv(env->GetMutex());
     CollisionOptionsStateSaver optionstate(env->GetCollisionChecker(),env->GetCollisionChecker()->GetCollisionOptions()|CO_ActiveDOFs,false);
     PlannerBasePtr planner = RaveCreatePlanner(env,plannername.size() > 0 ? plannername : string("parabolicsmoother"));
     TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
@@ -639,7 +639,7 @@ ActiveDOFTrajectorySmoother::ActiveDOFTrajectorySmoother(RobotBasePtr robot, con
 {
     std::string plannername = _plannername.size() > 0 ? _plannername : "parabolicsmoother";
     _robot = robot;
-    EnvironmentMutex::scoped_lock lockenv(robot->GetEnv()->GetMutex());
+    EnvironmentLock lockenv(robot->GetEnv()->GetMutex());
     _vRobotActiveIndices = _robot->GetActiveDOFIndices();
     _nRobotAffineDOF = _robot->GetAffineDOF();
     _vRobotRotationAxis = _robot->GetAffineRotationAxis();
@@ -700,7 +700,7 @@ ActiveDOFTrajectoryRetimer::ActiveDOFTrajectoryRetimer(RobotBasePtr robot, const
 {
     std::string plannername = _plannername.size() > 0 ? _plannername : "parabolicretimer";
     _robot = robot;
-    EnvironmentMutex::scoped_lock lockenv(robot->GetEnv()->GetMutex());
+    EnvironmentLock lockenv(robot->GetEnv()->GetMutex());
     _vRobotActiveIndices = _robot->GetActiveDOFIndices();
     _nRobotAffineDOF = _robot->GetAffineDOF();
     _vRobotRotationAxis = _robot->GetAffineRotationAxis();
@@ -773,7 +773,7 @@ PlannerStatus _PlanTrajectory(TrajectoryBasePtr traj, bool hastimestamps, dReal 
         return PlannerStatus(PS_HasSolution);
     }
 
-    EnvironmentMutex::scoped_lock lockenv(traj->GetEnv()->GetMutex());
+    EnvironmentLock lockenv(traj->GetEnv()->GetMutex());
     PlannerBasePtr planner = RaveCreatePlanner(traj->GetEnv(),plannername.size() > 0 ? plannername : string("parabolicsmoother"));
     TrajectoryTimingParametersPtr params(new TrajectoryTimingParameters());
     params->SetConfigurationSpecification(traj->GetEnv(),traj->GetConfigurationSpecification().GetTimeDerivativeSpecification(0));
@@ -901,7 +901,7 @@ static PlannerStatus _PlanAffineTrajectory(TrajectoryBasePtr traj, const std::ve
         return PlannerStatus(PS_HasSolution);
     }
 
-    EnvironmentMutex::scoped_lock lockenv(traj->GetEnv()->GetMutex());
+    EnvironmentLock lockenv(traj->GetEnv()->GetMutex());
     ConfigurationSpecification newspec = traj->GetConfigurationSpecification().GetTimeDerivativeSpecification(0);
     if( newspec.GetDOF() != (int)maxvelocities.size() || newspec.GetDOF() != (int)maxaccelerations.size() ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("traj values (%d) do not match maxvelocity size (%d) or maxaccelerations size (%d)"),newspec.GetDOF()%maxvelocities.size()%maxaccelerations.size(), ORE_InvalidArguments);
@@ -1052,7 +1052,7 @@ PlannerStatus AffineTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, const st
     }
 
     EnvironmentBasePtr env = traj->GetEnv();
-    EnvironmentMutex::scoped_lock lockenv(env->GetMutex());
+    EnvironmentLock lockenv(env->GetMutex());
     ConfigurationSpecification trajspec = traj->GetConfigurationSpecification().GetTimeDerivativeSpecification(0);
     if( trajspec.GetDOF() != (int)maxvelocities.size() || trajspec.GetDOF() != (int)maxaccelerations.size() ) {
         throw OPENRAVE_EXCEPTION_FORMAT(_("traj values (%d) do not match maxvelocity size (%d) or maxaccelerations size (%d)"),trajspec.GetDOF()%maxvelocities.size()%maxaccelerations.size(), ORE_InvalidArguments);
@@ -1168,7 +1168,7 @@ PlannerStatus AffineTrajectoryRetimer::PlanPath(TrajectoryBasePtr traj, const st
     }
 
     EnvironmentBasePtr env = traj->GetEnv();
-    EnvironmentMutex::scoped_lock lockenv(env->GetMutex());
+    EnvironmentLock lockenv(env->GetMutex());
     ConfigurationSpecification trajspec = traj->GetConfigurationSpecification().GetTimeDerivativeSpecification(0);
     int trajdof = trajspec.GetDOF();
     if( trajdof != (int)maxvelocities.size() ||
@@ -1640,7 +1640,7 @@ size_t InsertWaypointWithSmoothing(int index, const std::vector<dReal>& dofvalue
     PlannerBase::PlannerParametersConstPtr params = planner->GetParameters();
     ConfigurationSpecification specpos = traj->GetConfigurationSpecification().GetTimeDerivativeSpecification(0);
 
-    EnvironmentMutex::scoped_lock lockenv(traj->GetEnv()->GetMutex());
+    EnvironmentLock lockenv(traj->GetEnv()->GetMutex());
 
     dReal fSamplingTime = 0.01; // for collision checking
     dReal fTimeBuffer = 0.01; // if new trajectory increases within this time limit, then it will be accepted
@@ -2148,7 +2148,7 @@ TrajectoryBasePtr MergeTrajectories(const std::list<TrajectoryBaseConstPtr>& lis
 
 void GetDHParameters(std::vector<DHParameter>& vparameters, KinBodyConstPtr pbody)
 {
-    EnvironmentMutex::scoped_lock lockenv(pbody->GetEnv()->GetMutex());
+    EnvironmentLock lockenv(pbody->GetEnv()->GetMutex());
     Transform tbaseinv = pbody->GetTransform().inverse();
     vparameters.resize(pbody->GetDependencyOrderedJoints().size());
     std::vector<DHParameter>::iterator itdh = vparameters.begin();

--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -17,6 +17,7 @@
 #ifndef RAVE_PLUGIN_DATABASE_H
 #define RAVE_PLUGIN_DATABASE_H
 
+#include <condition_variable>
 #include <errno.h>
 
 #ifdef HAVE_BOOST_FILESYSTEM

--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -431,7 +431,7 @@ protected:
 
     virtual bool Init(bool bLoadAllPlugins)
     {
-        _threadPluginLoader.reset(new std::thread(boost::bind(&RaveDatabase::_PluginLoaderThread, this)));
+        _threadPluginLoader = boost::make_shared<std::thread>(std::bind(&RaveDatabase::_PluginLoaderThread, this));
         std::vector<std::string> vplugindirs;
 #ifdef _WIN32
         const char* delim = ";";

--- a/src/libopenrave/sensorsystem.cpp
+++ b/src/libopenrave/sensorsystem.cpp
@@ -118,7 +118,7 @@ SimpleSensorSystem::~SimpleSensorSystem()
 
 void SimpleSensorSystem::Reset()
 {
-    boost::mutex::scoped_lock lock(_mutex);
+    std::scoped_lock lock(_mutex);
     _mapbodies.clear();
 }
 
@@ -148,7 +148,7 @@ KinBody::ManageDataPtr SimpleSensorSystem::AddKinBody(KinBodyPtr pbody, Readable
         }
     }
 
-    boost::mutex::scoped_lock lock(_mutex);
+    std::scoped_lock lock(_mutex);
     if( _mapbodies.find(pbody->GetEnvironmentBodyIndex()) != _mapbodies.end() ) {
         RAVELOG_WARN(str(boost::format("body %s already added\n")%pbody->GetName()));
         return KinBody::ManageDataPtr();
@@ -164,7 +164,7 @@ KinBody::ManageDataPtr SimpleSensorSystem::AddKinBody(KinBodyPtr pbody, Readable
 
 bool SimpleSensorSystem::RemoveKinBody(KinBodyPtr pbody)
 {
-    boost::mutex::scoped_lock lock(_mutex);
+    std::scoped_lock lock(_mutex);
     bool bSuccess = _mapbodies.erase(pbody->GetEnvironmentBodyIndex())>0;
     RAVELOG_VERBOSE(str(boost::format("system removing body %s %s\n")%pbody->GetName()%(bSuccess ? "succeeded" : "failed")));
     return bSuccess;
@@ -172,13 +172,13 @@ bool SimpleSensorSystem::RemoveKinBody(KinBodyPtr pbody)
 
 bool SimpleSensorSystem::IsBodyPresent(KinBodyPtr pbody)
 {
-    boost::mutex::scoped_lock lock(_mutex);
+    std::scoped_lock lock(_mutex);
     return _mapbodies.find(pbody->GetEnvironmentBodyIndex()) != _mapbodies.end();
 }
 
 bool SimpleSensorSystem::EnableBody(KinBodyPtr pbody, bool bEnable)
 {
-    boost::mutex::scoped_lock lock(_mutex);
+    std::scoped_lock lock(_mutex);
     BODIES::iterator it = _mapbodies.find(pbody->GetEnvironmentBodyIndex());
     if( it == _mapbodies.end() ) {
         RAVELOG_WARN("trying to %s body %s that is not in system\n", bEnable ? "enable" : "disable", pbody->GetName().c_str());
@@ -191,7 +191,7 @@ bool SimpleSensorSystem::EnableBody(KinBodyPtr pbody, bool bEnable)
 
 bool SimpleSensorSystem::SwitchBody(KinBodyPtr pbody1, KinBodyPtr pbody2)
 {
-    //boost::mutex::scoped_lock lock(_mutex);
+    //std::scoped_lock lock(_mutex);
     BODIES::iterator it = _mapbodies.find(pbody1->GetEnvironmentBodyIndex());
     boost::shared_ptr<BodyData> pb1,pb2;
     if( it != _mapbodies.end() ) {
@@ -250,7 +250,7 @@ void SimpleSensorSystem::_UpdateBodies(list<SimpleSensorSystem::SNAPSHOT>& listb
         }
     }
 
-    boost::mutex::scoped_lock lock(_mutex);
+    std::scoped_lock lock(_mutex);
     BODIES::iterator itbody = _mapbodies.begin();
     while(itbody != _mapbodies.end()) {
         KinBody::LinkPtr plink = itbody->second->GetOffsetLink();

--- a/src/libopenrave/sensorsystem.cpp
+++ b/src/libopenrave/sensorsystem.cpp
@@ -118,7 +118,7 @@ SimpleSensorSystem::~SimpleSensorSystem()
 
 void SimpleSensorSystem::Reset()
 {
-    std::scoped_lock lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     _mapbodies.clear();
 }
 
@@ -148,7 +148,7 @@ KinBody::ManageDataPtr SimpleSensorSystem::AddKinBody(KinBodyPtr pbody, Readable
         }
     }
 
-    std::scoped_lock lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     if( _mapbodies.find(pbody->GetEnvironmentBodyIndex()) != _mapbodies.end() ) {
         RAVELOG_WARN(str(boost::format("body %s already added\n")%pbody->GetName()));
         return KinBody::ManageDataPtr();
@@ -164,7 +164,7 @@ KinBody::ManageDataPtr SimpleSensorSystem::AddKinBody(KinBodyPtr pbody, Readable
 
 bool SimpleSensorSystem::RemoveKinBody(KinBodyPtr pbody)
 {
-    std::scoped_lock lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     bool bSuccess = _mapbodies.erase(pbody->GetEnvironmentBodyIndex())>0;
     RAVELOG_VERBOSE(str(boost::format("system removing body %s %s\n")%pbody->GetName()%(bSuccess ? "succeeded" : "failed")));
     return bSuccess;
@@ -172,13 +172,13 @@ bool SimpleSensorSystem::RemoveKinBody(KinBodyPtr pbody)
 
 bool SimpleSensorSystem::IsBodyPresent(KinBodyPtr pbody)
 {
-    std::scoped_lock lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     return _mapbodies.find(pbody->GetEnvironmentBodyIndex()) != _mapbodies.end();
 }
 
 bool SimpleSensorSystem::EnableBody(KinBodyPtr pbody, bool bEnable)
 {
-    std::scoped_lock lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     BODIES::iterator it = _mapbodies.find(pbody->GetEnvironmentBodyIndex());
     if( it == _mapbodies.end() ) {
         RAVELOG_WARN("trying to %s body %s that is not in system\n", bEnable ? "enable" : "disable", pbody->GetName().c_str());
@@ -191,7 +191,7 @@ bool SimpleSensorSystem::EnableBody(KinBodyPtr pbody, bool bEnable)
 
 bool SimpleSensorSystem::SwitchBody(KinBodyPtr pbody1, KinBodyPtr pbody2)
 {
-    //std::scoped_lock lock(_mutex);
+    //std::lock_guard<std::mutex> lock(_mutex);
     BODIES::iterator it = _mapbodies.find(pbody1->GetEnvironmentBodyIndex());
     boost::shared_ptr<BodyData> pb1,pb2;
     if( it != _mapbodies.end() ) {
@@ -222,7 +222,7 @@ boost::shared_ptr<SimpleSensorSystem::BodyData> SimpleSensorSystem::CreateBodyDa
 
 void SimpleSensorSystem::_UpdateBodies(list<SimpleSensorSystem::SNAPSHOT>& listbodies)
 {
-    EnvironmentMutex::scoped_lock lockenv(GetEnv()->GetMutex()); // always lock environment to preserve mutex order
+    EnvironmentLock lockenv(GetEnv()->GetMutex()); // always lock environment to preserve mutex order
     uint64_t curtime = utils::GetMicroTime();
     if( listbodies.size() > 0 ) {
 
@@ -250,7 +250,7 @@ void SimpleSensorSystem::_UpdateBodies(list<SimpleSensorSystem::SNAPSHOT>& listb
         }
     }
 
-    std::scoped_lock lock(_mutex);
+    std::lock_guard<std::mutex> lock(_mutex);
     BODIES::iterator itbody = _mapbodies.begin();
     while(itbody != _mapbodies.end()) {
         KinBody::LinkPtr plink = itbody->second->GetOffsetLink();

--- a/src/openrave.cpp
+++ b/src/openrave.cpp
@@ -274,7 +274,7 @@ int main(int argc, char ** argv)
 
     // mac osx requires the main thread to be the gui thread...
     //s_bThreadDestroyed = false;
-    //s_mainThread.reset(new std::thread(boost::bind(MainOpenRAVEThread)));
+    //s_mainThread = boost::make_shared<std::thread>(std::bind(MainOpenRAVEThread));
     //s_mainThread->join();
     MainOpenRAVEThread();
     {

--- a/src/openrave.cpp
+++ b/src/openrave.cpp
@@ -51,7 +51,7 @@ static bool bDisplayGUI = true, bShowGUI = true;
 static EnvironmentBasePtr s_penv;
 static ViewerBasePtr s_pviewer; ///< static viewer created by the main thread. need to quit from its main loop
 
-//static boost::shared_ptr<boost::thread> s_mainThread;
+//static boost::shared_ptr<std::thread> s_mainThread;
 static string s_sceneFile;
 static string s_saveScene; // if not NULL, saves the scene and exits
 static boost::shared_ptr<string> s_viewerName;
@@ -274,7 +274,7 @@ int main(int argc, char ** argv)
 
     // mac osx requires the main thread to be the gui thread...
     //s_bThreadDestroyed = false;
-    //s_mainThread.reset(new boost::thread(boost::bind(MainOpenRAVEThread)));
+    //s_mainThread.reset(new std::thread(boost::bind(MainOpenRAVEThread)));
     //s_mainThread->join();
     MainOpenRAVEThread();
     {

--- a/src/openrave.cpp
+++ b/src/openrave.cpp
@@ -331,7 +331,7 @@ void MainOpenRAVEThread()
     }
 
     {
-        EnvironmentMutex::scoped_lock lock(penv->GetMutex());
+        EnvironmentLock lock(penv->GetMutex());
 
         if( s_sceneFile.size() > 0 ) {
             if( !penv->Load(s_sceneFile) ) {


### PR DESCRIPTION
Note that this pull request does NOT merge into production or master; it merges into a "master dev branch" I call openrave-static. I'm doing it like this so that I can make small merge requests that are easy to manage and comprehend, topic by topic, without affecting production branch immediately.

This merge request is for the conversion of mutexes, locks, condition_variables, and threads from `boost` namespace to `std`. This is done in preparation for supporting platforms that have different implementations of threads and mutexes that are not necessarily fully posix compatible, but provide a C++ standard library.

Note that `call_once` has not been converted yet. I'm still testing those, because the syntax change to `std` is not as straightforward as I thought. That will be a separate merge request.