### PR TITLE
Split plugin database into header and cpp file

### DIFF
--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -2892,12 +2892,6 @@ typedef void (*PluginExportFn_OnRaveInitialized)();
 /// \ingroup plugin_exports
 typedef void (*PluginExportFn_OnRavePreDestroy)();
 
-/// \deprecated (12/01/01)
-typedef InterfaceBasePtr (*PluginExportFn_CreateInterface)(InterfaceType type, const std::string& name, const char* pluginhash, EnvironmentBasePtr env) RAVE_DEPRECATED;
-
-/// \deprecated (12/01/01)
-typedef bool (*PluginExportFn_GetPluginAttributes)(PLUGININFO* pinfo, int size) RAVE_DEPRECATED;
-
 // define inline functions
 const std::string& IkParameterization::GetName() const
 {

--- a/src/libopenrave/CMakeLists.txt
+++ b/src/libopenrave/CMakeLists.txt
@@ -21,6 +21,7 @@ set(openrave_lib_SOURCES
   plannerparameters.cpp
   planningutils.cpp
   plugindatabase.h
+  plugindatabase.cpp
   robot.cpp
   robotconnectedbody.cpp
   robotmanipulator.cpp

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -1272,22 +1272,22 @@ InterfaceBasePtr RaveCreateInterface(EnvironmentBasePtr penv, InterfaceType type
 
 RobotBasePtr RaveCreateRobot(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<RobotBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Robot, name));
+    return boost::static_pointer_cast<RobotBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Robot, name));
 }
 
 PlannerBasePtr RaveCreatePlanner(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<PlannerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Planner, name));
+    return boost::static_pointer_cast<PlannerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Planner, name));
 }
 
 SensorSystemBasePtr RaveCreateSensorSystem(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<SensorSystemBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_SensorSystem, name));
+    return boost::static_pointer_cast<SensorSystemBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_SensorSystem, name));
 }
 
 ControllerBasePtr RaveCreateController(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<ControllerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Controller, name));
+    return boost::static_pointer_cast<ControllerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Controller, name));
 }
 
 MultiControllerBasePtr RaveCreateMultiController(EnvironmentBasePtr env, const std::string& rawname)
@@ -1301,7 +1301,7 @@ MultiControllerBasePtr RaveCreateMultiController(EnvironmentBasePtr env, const s
         std::transform(name.begin(), name.end(), name.begin(), ::tolower);
     }
     // TODO remove hack once MultiController is a registered interface
-    ControllerBasePtr pcontroller = RaveInterfaceCast<ControllerBase>(RaveGlobal::instance()->GetDatabase()->Create(env, PT_Controller, name));
+    ControllerBasePtr pcontroller = boost::static_pointer_cast<ControllerBase>(RaveGlobal::instance()->GetDatabase()->Create(env, PT_Controller, name));
     if( name == "genericmulticontroller" ) {
         return boost::static_pointer_cast<MultiControllerBase>(pcontroller);
     }
@@ -1311,62 +1311,62 @@ MultiControllerBasePtr RaveCreateMultiController(EnvironmentBasePtr env, const s
 
 ModuleBasePtr RaveCreateModule(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
+    return boost::static_pointer_cast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
 }
 
 ModuleBasePtr RaveCreateProblem(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
+    return boost::static_pointer_cast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
 }
 
 ModuleBasePtr RaveCreateProblemInstance(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
+    return boost::static_pointer_cast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
 }
 
 IkSolverBasePtr RaveCreateIkSolver(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<IkSolverBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_IkSolver, name));
+    return boost::static_pointer_cast<IkSolverBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_IkSolver, name));
 }
 
 PhysicsEngineBasePtr RaveCreatePhysicsEngine(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<PhysicsEngineBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_PhysicsEngine, name));
+    return boost::static_pointer_cast<PhysicsEngineBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_PhysicsEngine, name));
 }
 
 SensorBasePtr RaveCreateSensor(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<SensorBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Sensor, name));
+    return boost::static_pointer_cast<SensorBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Sensor, name));
 }
 
 CollisionCheckerBasePtr RaveCreateCollisionChecker(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<CollisionCheckerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_CollisionChecker, name));
+    return boost::static_pointer_cast<CollisionCheckerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_CollisionChecker, name));
 }
 
 ViewerBasePtr RaveCreateViewer(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<ViewerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Viewer, name));
+    return boost::static_pointer_cast<ViewerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Viewer, name));
 }
 
 KinBodyPtr RaveCreateKinBody(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<KinBody>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_KinBody, name));
+    return boost::static_pointer_cast<KinBody>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_KinBody, name));
 }
 
 TrajectoryBasePtr RaveCreateTrajectory(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<TrajectoryBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Trajectory, name));
+    return boost::static_pointer_cast<TrajectoryBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Trajectory, name));
 }
 
 TrajectoryBasePtr RaveCreateTrajectory(EnvironmentBasePtr penv, int dof)
 {
-    return RaveInterfaceCast<TrajectoryBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Trajectory, ""));
+    return boost::static_pointer_cast<TrajectoryBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Trajectory, ""));
 }
 
 SpaceSamplerBasePtr RaveCreateSpaceSampler(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveInterfaceCast<SpaceSamplerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_SpaceSampler, name));
+    return boost::static_pointer_cast<SpaceSamplerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_SpaceSampler, name));
 }
 
 UserDataPtr RaveRegisterInterface(InterfaceType type, const std::string& name, const char* interfacehash, const char* envhash, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn)

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -791,7 +791,8 @@ protected:
         if( !_pdefaultsampler ) {
             std::lock_guard<std::mutex> lock(_mutexinternal);
             BOOST_ASSERT( _mapenvironments.size() > 0 );
-            _pdefaultsampler = GetDatabase()->CreateSpaceSampler(_mapenvironments.begin()->second->shared_from_this(),"MT19937");
+            InterfaceBasePtr ifBasePtr = GetDatabase()->Create(_mapenvironments.begin()->second->shared_from_this(), PT_SpaceSampler, "MT19937");
+            _pdefaultsampler = RaveInterfaceCast<SpaceSamplerBase>(ifBasePtr);
         }
         return _pdefaultsampler;
     }
@@ -1271,22 +1272,22 @@ InterfaceBasePtr RaveCreateInterface(EnvironmentBasePtr penv, InterfaceType type
 
 RobotBasePtr RaveCreateRobot(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateRobot(penv,name);
+    return RaveInterfaceCast<RobotBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Robot, name));
 }
 
 PlannerBasePtr RaveCreatePlanner(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreatePlanner(penv, name);
+    return RaveInterfaceCast<PlannerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Planner, name));
 }
 
 SensorSystemBasePtr RaveCreateSensorSystem(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateSensorSystem(penv, name);
+    return RaveInterfaceCast<SensorSystemBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_SensorSystem, name));
 }
 
 ControllerBasePtr RaveCreateController(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateController(penv, name);
+    return RaveInterfaceCast<ControllerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Controller, name));
 }
 
 MultiControllerBasePtr RaveCreateMultiController(EnvironmentBasePtr env, const std::string& rawname)
@@ -1300,7 +1301,7 @@ MultiControllerBasePtr RaveCreateMultiController(EnvironmentBasePtr env, const s
         std::transform(name.begin(), name.end(), name.begin(), ::tolower);
     }
     // TODO remove hack once MultiController is a registered interface
-    ControllerBasePtr pcontroller = RaveGlobal::instance()->GetDatabase()->CreateController(env, name);
+    ControllerBasePtr pcontroller = RaveInterfaceCast<ControllerBase>(RaveGlobal::instance()->GetDatabase()->Create(env, PT_Controller, name));
     if( name == "genericmulticontroller" ) {
         return boost::static_pointer_cast<MultiControllerBase>(pcontroller);
     }
@@ -1310,62 +1311,62 @@ MultiControllerBasePtr RaveCreateMultiController(EnvironmentBasePtr env, const s
 
 ModuleBasePtr RaveCreateModule(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateModule(penv, name);
+    return RaveInterfaceCast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
 }
 
 ModuleBasePtr RaveCreateProblem(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateModule(penv, name);
+    return RaveInterfaceCast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
 }
 
 ModuleBasePtr RaveCreateProblemInstance(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateModule(penv, name);
+    return RaveInterfaceCast<ModuleBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Module, name));
 }
 
 IkSolverBasePtr RaveCreateIkSolver(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateIkSolver(penv, name);
+    return RaveInterfaceCast<IkSolverBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_IkSolver, name));
 }
 
 PhysicsEngineBasePtr RaveCreatePhysicsEngine(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreatePhysicsEngine(penv, name);
+    return RaveInterfaceCast<PhysicsEngineBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_PhysicsEngine, name));
 }
 
 SensorBasePtr RaveCreateSensor(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateSensor(penv, name);
+    return RaveInterfaceCast<SensorBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Sensor, name));
 }
 
 CollisionCheckerBasePtr RaveCreateCollisionChecker(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateCollisionChecker(penv, name);
+    return RaveInterfaceCast<CollisionCheckerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_CollisionChecker, name));
 }
 
 ViewerBasePtr RaveCreateViewer(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateViewer(penv, name);
+    return RaveInterfaceCast<ViewerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Viewer, name));
 }
 
 KinBodyPtr RaveCreateKinBody(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateKinBody(penv, name);
+    return RaveInterfaceCast<KinBody>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_KinBody, name));
 }
 
 TrajectoryBasePtr RaveCreateTrajectory(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateTrajectory(penv, name);
+    return RaveInterfaceCast<TrajectoryBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Trajectory, name));
 }
 
 TrajectoryBasePtr RaveCreateTrajectory(EnvironmentBasePtr penv, int dof)
 {
-    return RaveCreateTrajectory(penv,"");
+    return RaveInterfaceCast<TrajectoryBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_Trajectory, ""));
 }
 
 SpaceSamplerBasePtr RaveCreateSpaceSampler(EnvironmentBasePtr penv, const std::string& name)
 {
-    return RaveGlobal::instance()->GetDatabase()->CreateSpaceSampler(penv, name);
+    return RaveInterfaceCast<SpaceSamplerBase>(RaveGlobal::instance()->GetDatabase()->Create(penv, PT_SpaceSampler, name));
 }
 
 UserDataPtr RaveRegisterInterface(InterfaceType type, const std::string& name, const char* interfacehash, const char* envhash, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn)

--- a/src/libopenrave/plugindatabase.cpp
+++ b/src/libopenrave/plugindatabase.cpp
@@ -668,6 +668,17 @@ InterfaceBasePtr RaveDatabase::Create(EnvironmentBasePtr penv, InterfaceType typ
     }
     if( !pointer ) {
         RAVELOG_WARN_FORMAT("env=%d failed to create name %s, interface %s\n", penv->GetId()%name%RaveGetInterfaceNamesMap().find(type)->second);
+        return pointer;
+    }
+
+    if (pointer->GetInterfaceType() == type) {
+        // No-op, this is correct
+    } else if ((pointer->GetInterfaceType() == PT_Robot) && (type == PT_KinBody)) {
+        // Special case: Robots are also KinBodies.
+        // No-op, this is correct
+    } else {
+        // Return an empty pointer; behaviour inherited from `RaveInterfaceCast`
+        pointer.reset();
     }
     return pointer;
 }

--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -126,46 +126,6 @@ public:
     RaveDatabase();
     virtual ~RaveDatabase();
 
-    RobotBasePtr CreateRobot(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<RobotBase>(Create(penv, PT_Robot, name));
-    }
-    KinBodyPtr CreateKinBody(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<KinBody>(Create(penv, PT_KinBody, name));
-    }
-    PlannerBasePtr CreatePlanner(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<PlannerBase>(Create(penv, PT_Planner, name));
-    }
-    SensorSystemBasePtr CreateSensorSystem(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<SensorSystemBase>(Create(penv, PT_SensorSystem, name));
-    }
-    ControllerBasePtr CreateController(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<ControllerBase>(Create(penv, PT_Controller, name));
-    }
-    ModuleBasePtr CreateModule(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<ModuleBase>(Create(penv, PT_Module, name));
-    }
-    IkSolverBasePtr CreateIkSolver(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<IkSolverBase>(Create(penv, PT_IkSolver, name));
-    }
-    PhysicsEngineBasePtr CreatePhysicsEngine(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<PhysicsEngineBase>(Create(penv, PT_PhysicsEngine, name));
-    }
-    SensorBasePtr CreateSensor(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<SensorBase>(Create(penv, PT_Sensor, name));
-    }
-    CollisionCheckerBasePtr CreateCollisionChecker(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<CollisionCheckerBase>(Create(penv, PT_CollisionChecker, name));
-    }
-    ViewerBasePtr CreateViewer(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<ViewerBase>(Create(penv, PT_Viewer, name));
-    }
-    TrajectoryBasePtr CreateTrajectory(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<TrajectoryBase>(Create(penv, PT_Trajectory, name));
-    }
-    SpaceSamplerBasePtr CreateSpaceSampler(EnvironmentBasePtr penv, const std::string& name) {
-        return RaveInterfaceCast<SpaceSamplerBase>(Create(penv, PT_SpaceSampler, name));
-    }
-
     virtual bool Init(bool bLoadAllPlugins);
 
     /// Destroy all plugins and directories

--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -17,47 +17,12 @@
 #ifndef RAVE_PLUGIN_DATABASE_H
 #define RAVE_PLUGIN_DATABASE_H
 
-#include <condition_variable>
-#include <errno.h>
+#include "openrave/openrave.h"
+#include "openrave/plugininfo.h"
 
-#ifdef HAVE_BOOST_FILESYSTEM
-#include <boost/filesystem.hpp>
-#endif
-#include <boost/version.hpp>
-
-#ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#define PLUGIN_EXT ".dll"
-#define OPENRAVE_LAZY_LOADING false
-#else
-#define OPENRAVE_LAZY_LOADING true
-#include <dlfcn.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <dirent.h>
-
-#ifdef __APPLE_CC__
-#define PLUGIN_EXT ".dylib"
-#else
-#define PLUGIN_EXT ".so"
-#endif
-
-#endif
-
-//#define INTERFACE_PREDELETER boost::bind(&RaveDatabase::_InterfaceDestroyCallbackShared,shared_from_this(),_1)
-
-#define INTERFACE_PREDELETER boost::function<void(void const*)>()
-#define INTERFACE_POSTDELETER(name, plugin) boost::bind(&RaveDatabase::_InterfaceDestroyCallbackSharedPost,shared_from_this(),name, plugin)
-
+#include <boost/shared_ptr.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
-
-#ifdef _WIN32
-const char s_filesep = '\\';
-#else
-const char s_filesep = '/';
-#endif
 
 namespace OpenRAVE {
 
@@ -66,21 +31,14 @@ class RaveDatabase : public boost::enable_shared_from_this<RaveDatabase>
 {
     struct RegisteredInterface : public UserData
     {
-        RegisteredInterface(InterfaceType type, const std::string& name, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn, boost::shared_ptr<RaveDatabase> database) : _type(type), _name(name), _createfn(createfn), _database(database) {
-        }
-        virtual ~RegisteredInterface() {
-            boost::shared_ptr<RaveDatabase> database = _database.lock();
-            if( !!database ) {
-                std::lock_guard<std::mutex> lock(database->_mutex);
-                database->_listRegisteredInterfaces.erase(_iterator);
-            }
-        }
+        RegisteredInterface(InterfaceType type, const std::string& name, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn, boost::shared_ptr<RaveDatabase> database);
+        virtual ~RegisteredInterface();
 
         InterfaceType _type;
         std::string _name;
         boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)> _createfn;
         std::list< boost::weak_ptr<RegisteredInterface> >::iterator _iterator;
-protected:
+    protected:
         boost::weak_ptr<RaveDatabase> _database;
     };
     typedef boost::shared_ptr<RegisteredInterface> RegisteredInterfacePtr;
@@ -88,279 +46,44 @@ protected:
 public:
     class Plugin : public UserData, public boost::enable_shared_from_this<Plugin>
     {
-public:
-        Plugin(boost::shared_ptr<RaveDatabase> pdatabase) : _pdatabase(pdatabase), plibrary(NULL), pfnCreate(NULL), pfnCreateNew(NULL), pfnGetPluginAttributes(NULL), pfnGetPluginAttributesNew(NULL), pfnDestroyPlugin(NULL), pfnOnRaveInitialized(NULL), pfnOnRavePreDestroy(NULL), _bShutdown(false), _bInitializing(true), _bHasCalledOnRaveInitialized(false) {
-        }
-        virtual ~Plugin() {
-            Destroy();
-        }
+    public:
+        Plugin(boost::shared_ptr<RaveDatabase> pdatabase);
+        virtual ~Plugin();
 
-        virtual void Destroy() {
-            if( _bInitializing ) {
-                if( plibrary ) {
-                    if( OPENRAVE_LAZY_LOADING ) {
-                        // NOTE: for some reason, closing the lazy loaded library can make the system crash, so instead keep the memory around, and create a new one with RTLD_NOW if necessary
-                    }
-                    else {
-                        RaveDatabase::_SysCloseLibrary(plibrary);
-                    }
-                    plibrary = NULL;
-                }
-            }
-            else {
-                if( plibrary ) {
-                    Load_DestroyPlugin();
-                }
-                std::lock_guard<std::mutex> lock(_mutex);
-                // do some more checking here, there still might be instances of robots, planners, and sensors out there
-                if (plibrary) {
-                    RAVELOG_DEBUG("RaveDatabase: closing plugin %s\n", ppluginname.c_str());        // Sleep(10);
-                    if( pfnDestroyPlugin != NULL ) {
-                        pfnDestroyPlugin();
-                    }
-                    boost::shared_ptr<RaveDatabase> pdatabase = _pdatabase.lock();
-                    if( !!pdatabase ) {
-                        pdatabase->_QueueLibraryDestruction(plibrary);
-                    }
-                    plibrary = NULL;
-                }
-            }
-            pfnCreate = NULL;
-            pfnCreateNew = NULL;
-            pfnDestroyPlugin = NULL;
-            pfnOnRaveInitialized = NULL;
-            pfnOnRavePreDestroy = NULL;
-            pfnGetPluginAttributes = NULL;
-            pfnGetPluginAttributesNew = NULL;
-            _bShutdown = true;
-        }
+        virtual void Destroy();
 
-        virtual bool IsValid() {
-            return !_bShutdown;
-        }
+        virtual bool IsValid();
 
-        const string& GetName() const {
-            return ppluginname;
-        }
-        bool GetInfo(PLUGININFO& info) {
-            info = _infocached;
-            return true;
-        }
+        const std::string& GetName() const;
 
-        virtual bool Load_CreateInterfaceGlobal()
-        {
-            _confirmLibrary();
-            if(( pfnCreateNew == NULL) &&( pfnCreate == NULL) ) {
-                if( pfnCreateNew == NULL ) {
-                    pfnCreateNew = (PluginExportFn_OpenRAVECreateInterface)_SysLoadSym(plibrary, "OpenRAVECreateInterface");
-                }
+        bool GetInfo(PLUGININFO& info);
 
-                if( pfnCreateNew == NULL ) {
-#ifdef _MSC_VER
-                    pfnCreate = (PluginExportFn_CreateInterface)_SysLoadSym(plibrary, "?CreateInterface@@YA?AV?$shared_ptr@VInterfaceBase@OpenRAVE@@@boost@@W4InterfaceType@OpenRAVE@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PBDV?$shared_ptr@VEnvironmentBase@OpenRAVE@@@2@@Z");
-#else
-                    pfnCreate = (PluginExportFn_CreateInterface)_SysLoadSym(plibrary, "_Z15CreateInterfaceN8OpenRAVE10InterfaceTypeERKSsPKcN5boost10shared_ptrINS_15EnvironmentBaseEEE");
-#endif
-                    if( pfnCreate == NULL ) {
-                        pfnCreate = (PluginExportFn_CreateInterface)_SysLoadSym(plibrary, "CreateInterface");
-                        if( pfnCreate == NULL ) {
-                            return false;
-                        }
-                    }
-                }
-            }
-            return pfnCreateNew!=NULL||pfnCreate!=NULL;
-        }
+        virtual bool Load_CreateInterfaceGlobal();
 
-        virtual bool Load_GetPluginAttributes()
-        {
-            _confirmLibrary();
-            if(( pfnGetPluginAttributesNew == NULL) ||( pfnGetPluginAttributes == NULL) ) {
-                if( pfnGetPluginAttributesNew == NULL ) {
-                    pfnGetPluginAttributesNew = (PluginExportFn_OpenRAVEGetPluginAttributes)_SysLoadSym(plibrary,"OpenRAVEGetPluginAttributes");
-                }
-                if( pfnGetPluginAttributesNew == NULL ) {
-#ifdef _MSC_VER
-                    pfnGetPluginAttributes = (PluginExportFn_GetPluginAttributes)_SysLoadSym(plibrary, "?GetPluginAttributes@@YA_NPAUPLUGININFO@OpenRAVE@@H@Z");
-#else
-                    pfnGetPluginAttributes = (PluginExportFn_GetPluginAttributes)_SysLoadSym(plibrary, "_Z19GetPluginAttributesPN8OpenRAVE10PLUGININFOEi");
-#endif
-                    if( !pfnGetPluginAttributes ) {
-                        pfnGetPluginAttributes = (PluginExportFn_GetPluginAttributes)_SysLoadSym(plibrary, "GetPluginAttributes");
-                        if( !pfnGetPluginAttributes ) {
-                            return false;
-                        }
-                    }
-                }
-            }
-            return pfnGetPluginAttributesNew!=NULL||pfnGetPluginAttributes!=NULL;
-        }
+        virtual bool Load_GetPluginAttributes();
 
-        virtual bool Load_DestroyPlugin()
-        {
-            _confirmLibrary();
-            if( pfnDestroyPlugin == NULL ) {
-#ifdef _MSC_VER
-                pfnDestroyPlugin = (PluginExportFn_DestroyPlugin)_SysLoadSym(plibrary, "?DestroyPlugin@@YAXXZ");
-#else
-                pfnDestroyPlugin = (PluginExportFn_DestroyPlugin)_SysLoadSym(plibrary, "_Z13DestroyPluginv");
-#endif
-                if( pfnDestroyPlugin == NULL ) {
-                    pfnDestroyPlugin = (PluginExportFn_DestroyPlugin)_SysLoadSym(plibrary, "DestroyPlugin");
-                    if( pfnDestroyPlugin == NULL ) {
-                        RAVELOG_WARN(str(boost::format("%s: can't load DestroyPlugin function, passing...\n")%ppluginname));
-                        return false;
-                    }
-                }
-            }
-            return pfnDestroyPlugin!=NULL;
-        }
+        virtual bool Load_DestroyPlugin();
 
-        virtual bool Load_OnRaveInitialized()
-        {
-            _confirmLibrary();
-            if( pfnOnRaveInitialized == NULL ) {
-#ifdef _MSC_VER
-                pfnOnRaveInitialized = (PluginExportFn_OnRaveInitialized)_SysLoadSym(plibrary, "?OnRaveInitialized@@YAXXZ");
-#else
-                pfnOnRaveInitialized = (PluginExportFn_OnRaveInitialized)_SysLoadSym(plibrary, "_Z17OnRaveInitializedv");
-#endif
-                if( pfnOnRaveInitialized == NULL ) {
-                    pfnOnRaveInitialized = (PluginExportFn_OnRaveInitialized)_SysLoadSym(plibrary, "OnRaveInitialized");
-                    if( pfnOnRaveInitialized == NULL ) {
-                        //RAVELOG_VERBOSE(str(boost::format("%s: can't load OnRaveInitialized function, passing...\n")%ppluginname));
-                        return false;
-                    }
-                }
-            }
-            return pfnOnRaveInitialized!=NULL;
-        }
+        virtual bool Load_OnRaveInitialized();
 
-        virtual bool Load_OnRavePreDestroy()
-        {
-            _confirmLibrary();
-            if( pfnOnRavePreDestroy == NULL ) {
-#ifdef _MSC_VER
-                pfnOnRavePreDestroy = (PluginExportFn_OnRavePreDestroy)_SysLoadSym(plibrary, "?OnRavePreDestroy@@YAXXZ");
-#else
-                pfnOnRavePreDestroy = (PluginExportFn_OnRavePreDestroy)_SysLoadSym(plibrary, "_Z16OnRavePreDestroyv");
-#endif
-                if( pfnOnRavePreDestroy == NULL ) {
-                    pfnOnRavePreDestroy = (PluginExportFn_OnRavePreDestroy)_SysLoadSym(plibrary, "OnRavePreDestroy");
-                    if( pfnOnRavePreDestroy == NULL ) {
-                        //RAVELOG_VERBOSE(str(boost::format("%s: can't load OnRavePreDestroy function, passing...\n")%ppluginname));
-                        return false;
-                    }
-                }
-            }
-            return pfnOnRavePreDestroy!=NULL;
-        }
+        virtual bool Load_OnRavePreDestroy();
 
+        bool HasInterface(InterfaceType type, const std::string& name);
 
-        bool HasInterface(InterfaceType type, const string& name)
-        {
-            if( name.size() == 0 ) {
-                return false;
-            }
-            std::map<InterfaceType, std::vector<std::string> >::iterator itregisterednames = _infocached.interfacenames.find(type);
-            if( itregisterednames == _infocached.interfacenames.end() ) {
-                return false;
-            }
-            FOREACH(it,itregisterednames->second) {
-                if(( name.size() >= it->size()) &&( _strnicmp(name.c_str(),it->c_str(),it->size()) == 0) ) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        InterfaceBasePtr CreateInterface(InterfaceType type, const std::string& name, const char* interfacehash, EnvironmentBasePtr penv) {
-            pair< InterfaceType, string> p(type,utils::ConvertToLowerCase(name));
-            if( _setBadInterfaces.find(p) != _setBadInterfaces.end() ) {
-                return InterfaceBasePtr();
-            }
-
-            if( !HasInterface(type,name) ) {
-                return InterfaceBasePtr();
-            }
-
-            try {
-                if( !Load_CreateInterfaceGlobal() ) {
-                    throw openrave_exception(str(boost::format(_("%s: can't load CreateInterface function\n"))%ppluginname),ORE_InvalidPlugin);
-                }
-                InterfaceBasePtr pinterface;
-                if( pfnCreateNew != NULL ) {
-                    pinterface = pfnCreateNew(type,name,interfacehash,OPENRAVE_ENVIRONMENT_HASH,penv);
-                }
-                else if( pfnCreate != NULL ) {
-                    pinterface = pfnCreate(type,name,interfacehash,penv);
-                }
-                return pinterface;
-            }
-            catch(const openrave_exception& ex) {
-                RAVELOG_ERROR(str(boost::format("Create Interface: openrave exception , plugin %s: %s\n")%ppluginname%ex.what()));
-                if( ex.GetCode() == ORE_InvalidPlugin ) {
-                    RAVELOG_DEBUG(str(boost::format("shared object %s is not a valid openrave plugin\n")%ppluginname));
-                    Destroy();
-                }
-                else if( ex.GetCode() == ORE_InvalidInterfaceHash ) {
-                    _setBadInterfaces.insert(p);
-                }
-            }
-            catch(const std::exception& ex) {
-                RAVELOG_ERROR(str(boost::format("Create Interface: unknown exception, plugin %s: %s\n")%ppluginname%ex.what()));
-            }
-            catch(...) {
-                RAVELOG_ERROR(str(boost::format("Create Interface: unknown exception, plugin %s\n")%ppluginname));
-            }
-            return InterfaceBasePtr();
-        }
+        InterfaceBasePtr CreateInterface(InterfaceType type, const std::string& name, const char* interfacehash, EnvironmentBasePtr penv);
 
         /// \brief call to initialize the plugin, if initialized already, then ignore the call.
-        void OnRaveInitialized()
-        {
-            if( Load_OnRaveInitialized() ) {
-                if( !!pfnOnRaveInitialized && !_bHasCalledOnRaveInitialized ) {
-                    pfnOnRaveInitialized();
-                    _bHasCalledOnRaveInitialized = true;
-                }
-            }
-        }
+        void OnRaveInitialized();
 
-        void OnRavePreDestroy()
-        {
-            if( Load_OnRavePreDestroy() ) {
-                // always call destroy regardless of initialization state (safest)
-                if( !!pfnOnRavePreDestroy ) {
-                    pfnOnRavePreDestroy();
-                    _bHasCalledOnRaveInitialized = false;
-                }
-            }
-        }
+        void OnRavePreDestroy();
 
-protected:
+    protected:
         /// if the library is not loaded yet, wait for it.
-        void _confirmLibrary()
-        {
-            // first test the library before locking
-            if( plibrary == NULL ) {
-                std::unique_lock<std::mutex> lock(_mutex);
-                _pdatabase.lock()->_AddToLoader(shared_from_this());
-                do {
-                    if( plibrary ) {
-                        return;
-                    }
-                    if( _bShutdown ) {
-                        throw openrave_exception(_("library is shutting down"),ORE_InvalidPlugin);
-                    }
-                    _cond.wait(lock);
-                } while(1);
-            }
-        }
+        void _confirmLibrary();
 
         boost::weak_ptr<RaveDatabase> _pdatabase;
-        std::set<pair< InterfaceType, string> > _setBadInterfaces;         ///< interfaces whose hash is wrong and shouldn't be tried for this plugin
-        string ppluginname;
+        std::set<std::pair< InterfaceType, std::string> > _setBadInterfaces;         ///< interfaces whose hash is wrong and shouldn't be tried for this plugin
+        std::string ppluginname;
 
         void* plibrary;         // loaded library (NULL if not loaded)
         PluginExportFn_CreateInterface pfnCreate;
@@ -383,11 +106,8 @@ protected:
     typedef boost::shared_ptr<Plugin const> PluginConstPtr;
     friend class Plugin;
 
-    RaveDatabase() : _bShutdown(false) {
-    }
-    virtual ~RaveDatabase() {
-        Destroy();
-    }
+    RaveDatabase();
+    virtual ~RaveDatabase();
 
     RobotBasePtr CreateRobot(EnvironmentBasePtr penv, const std::string& name) {
         return RaveInterfaceCast<RobotBase>(Create(penv, PT_Robot, name));
@@ -429,705 +149,67 @@ protected:
         return RaveInterfaceCast<SpaceSamplerBase>(Create(penv, PT_SpaceSampler, name));
     }
 
-    virtual bool Init(bool bLoadAllPlugins)
-    {
-        _threadPluginLoader = boost::make_shared<std::thread>(std::bind(&RaveDatabase::_PluginLoaderThread, this));
-        std::vector<std::string> vplugindirs;
-#ifdef _WIN32
-        const char* delim = ";";
-#else
-        const char* delim = ":";
-#endif
-        char* pOPENRAVE_PLUGINS = getenv("OPENRAVE_PLUGINS"); // getenv not thread-safe?
-        if( pOPENRAVE_PLUGINS != NULL ) {
-            utils::TokenizeString(pOPENRAVE_PLUGINS, delim, vplugindirs);
-        }
-        for(int iplugindir=vplugindirs.size()-1;iplugindir>0;iplugindir--){
-            int jplugindir=0;
-            for(;jplugindir<iplugindir;jplugindir++){
-                if(vplugindirs[iplugindir]==vplugindirs[jplugindir]){
-                    break;
-                }
-            }
-            if(jplugindir<iplugindir){
-                vplugindirs.erase(vplugindirs.begin()+iplugindir);
-            }
-        }
-        bool bExists=false;
-        string installdir = OPENRAVE_PLUGINS_INSTALL_DIR;
-#ifdef HAVE_BOOST_FILESYSTEM
-        if( !boost::filesystem::is_directory(boost::filesystem::path(installdir)) ) {
-#ifdef _WIN32
-            HKEY hkey;
-            if(RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("Software\\OpenRAVE\\" OPENRAVE_VERSION_STRING), 0, KEY_QUERY_VALUE, &hkey) == ERROR_SUCCESS) {
-                DWORD dwType = REG_SZ;
-                CHAR szInstallRoot[4096];     // dont' take chances, it is windows
-                DWORD dwSize = sizeof(szInstallRoot);
-                RegQueryValueEx(hkey, TEXT("InstallRoot"), NULL, &dwType, (PBYTE)szInstallRoot, &dwSize);
-                RegCloseKey(hkey);
-                installdir.assign(szInstallRoot);
-                installdir += str(boost::format("%cshare%copenrave-%d.%d%cplugins")%s_filesep%s_filesep%OPENRAVE_VERSION_MAJOR%OPENRAVE_VERSION_MINOR%s_filesep);
-                RAVELOG_VERBOSE(str(boost::format("window registry plugin dir '%s'")%installdir));
-            }
-            else
-#endif
-            {
-                RAVELOG_WARN(str(boost::format("%s doesn't exist")%installdir));
-            }
-        }
-        boost::filesystem::path pluginsfilename = boost::filesystem::absolute(boost::filesystem::path(installdir));
-        FOREACH(itname, vplugindirs) {
-            if( pluginsfilename == boost::filesystem::absolute(boost::filesystem::path(*itname)) ) {
-                bExists = true;
-                break;
-            }
-        }
-#else
-        string pluginsfilename=installdir;
-        FOREACH(itname, vplugindirs) {
-            if( pluginsfilename == *itname ) {
-                bExists = true;
-                break;
-            }
-        }
-#endif
-        if( !bExists ) {
-            vplugindirs.push_back(installdir);
-        }
-        FOREACH(it, vplugindirs) {
-            if( it->size() > 0 ) {
-                _listplugindirs.push_back(*it);
-                RAVELOG_VERBOSE(str(boost::format("plugin dir: %s")%*it));
-            }
-        }
-        if( bLoadAllPlugins ) {
-            FOREACH(it, vplugindirs) {
-                if( it->size() > 0 ) {
-                    AddDirectory(*it);
-                }
-            }
-        }
-        return true;
-    }
+    virtual bool Init(bool bLoadAllPlugins);
 
     /// Destroy all plugins and directories
-    virtual void Destroy()
-    {
-        RAVELOG_DEBUG("plugin database shutting down...\n");
-        {
-            std::lock_guard<std::mutex> lock(_mutexPluginLoader);
-            _bShutdown = true;
-            _condLoaderHasWork.notify_all();
-        }
-        if( !!_threadPluginLoader ) {
-            _threadPluginLoader->join();
-            _threadPluginLoader.reset();
-        }
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            _listplugins.clear();
-        }
-        // cannot lock mutex due to __erase_iterator
-        // cannot clear _listRegisteredInterfaces since there are destructors that will remove items from the list
-        //_listRegisteredInterfaces.clear();
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            _CleanupUnusedLibraries();
-        }
-        _listplugindirs.clear();
-        RAVELOG_DEBUG("openrave plugin database destroyed\n");
-    }
+    virtual void Destroy();
 
-    void GetPlugins(std::list<PluginPtr>& listplugins) const
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        listplugins = _listplugins;
-    }
+    void GetPlugins(std::list<PluginPtr>& listplugins) const;
 
-    InterfaceBasePtr Create(EnvironmentBasePtr penv, InterfaceType type, const std::string& _name)
-    {
-        std::string name=_name;
-        InterfaceBasePtr pointer;
-        if( name.size() == 0 ) {
-            switch(type) {
-            case PT_KinBody: {
-                pointer.reset(new KinBody(PT_KinBody,penv));
-                pointer->__strxmlid = ""; // don't set to KinBody since there's no officially registered interface
-                break;
-            }
-            case PT_PhysicsEngine: name = "GenericPhysicsEngine"; break;
-            case PT_CollisionChecker: name = "GenericCollisionChecker"; break;
-            case PT_Robot: name = "GenericRobot"; break;
-            case PT_Trajectory: name = "GenericTrajectory"; break;
-            default: break;
-            }
-        }
-
-        if( !pointer ) {
-            size_t nInterfaceNameLength = name.find_first_of(' ');
-            if( nInterfaceNameLength == string::npos ) {
-                nInterfaceNameLength = name.size();
-            }
-            if( nInterfaceNameLength == 0 ) {
-                RAVELOG_WARN(str(boost::format("interface %s name \"%s\" needs to start with a valid character\n")%RaveGetInterfaceName(type)%name));
-                return InterfaceBasePtr();
-            }
-
-            // have to copy in order to allow plugins to register stuff inside their creation methods
-            std::list< boost::weak_ptr<RegisteredInterface> > listRegisteredInterfaces;
-            list<PluginPtr> listplugins;
-            {
-                std::lock_guard<std::mutex> lock(_mutex);
-                listRegisteredInterfaces = _listRegisteredInterfaces;
-                listplugins = _listplugins;
-            }
-            FOREACH(it, listRegisteredInterfaces) {
-                RegisteredInterfacePtr registration = it->lock();
-                if( !!registration ) {
-                    if(( nInterfaceNameLength >= registration->_name.size()) &&( _strnicmp(name.c_str(),registration->_name.c_str(),registration->_name.size()) == 0) ) {
-                        std::stringstream sinput(name);
-                        std::string interfacename;
-                        sinput >> interfacename;
-                        std::transform(interfacename.begin(), interfacename.end(), interfacename.begin(), ::tolower);
-                        pointer = registration->_createfn(penv,sinput);
-                        if( !!pointer ) {
-                            if( pointer->GetInterfaceType() != type ) {
-                                RAVELOG_FATAL(str(boost::format("plugin interface name %s, type %s, types do not match\n")%name%RaveGetInterfaceName(type)));
-                                pointer.reset();
-                            }
-                            else {
-                                pointer = InterfaceBasePtr(pointer.get(), utils::smart_pointer_deleter<InterfaceBasePtr>(pointer,INTERFACE_PREDELETER));
-                                pointer->__strpluginname = "__internal__";
-                                pointer->__strxmlid = name;
-                                //pointer->__plugin; // need to protect resources?
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if( !pointer ) {
-                const char* hash = RaveGetInterfaceHash(type);
-                list<PluginPtr>::iterator itplugin = listplugins.begin();
-                while(itplugin != listplugins.end()) {
-                    pointer = (*itplugin)->CreateInterface(type, name, hash, penv);
-                    if( !!pointer ) {
-                        if( strcmp(pointer->GetHash(), hash) ) {
-                            RAVELOG_FATAL(str(boost::format("plugin interface name %s, %s has invalid hash, might be compiled with stale openrave files\n")%name%RaveGetInterfaceName(type)));
-                            (*itplugin)->_setBadInterfaces.insert(make_pair(type,utils::ConvertToLowerCase(name)));
-                            pointer.reset();
-                        }
-                        else if( pointer->GetInterfaceType() != type ) {
-                            RAVELOG_FATAL(str(boost::format("plugin interface name %s, type %s, types do not match\n")%name%RaveGetInterfaceName(type)));
-                            (*itplugin)->_setBadInterfaces.insert(make_pair(type,utils::ConvertToLowerCase(name)));
-                            pointer.reset();
-                        }
-                        else {
-                            pointer = InterfaceBasePtr(pointer.get(), utils::smart_pointer_deleter<InterfaceBasePtr>(pointer,INTERFACE_PREDELETER, INTERFACE_POSTDELETER(name, *itplugin)));
-                            pointer->__strpluginname = (*itplugin)->ppluginname;
-                            pointer->__strxmlid = name;
-                            pointer->__plugin = *itplugin;
-                            break;
-                        }
-                    }
-                    if( !(*itplugin)->IsValid() ) {
-                        std::lock_guard<std::mutex> lock(_mutex);
-                        _listplugins.remove(*itplugin);
-                    }
-                    ++itplugin;
-                }
-            }
-        }
-
-        if( !!pointer ) {
-            if( type == PT_Robot ) {
-                RobotBasePtr probot = RaveInterfaceCast<RobotBase>(pointer);
-                if( strcmp(probot->GetKinBodyHash(), OPENRAVE_KINBODY_HASH) ) {
-                    RAVELOG_FATAL_FORMAT("plugin interface Robot, name %s has invalid hash, might be compiled with stale openrave files", name);
-                    pointer.reset();
-                }
-                if( !probot->IsRobot() ) {
-                    RAVELOG_FATAL_FORMAT("interface Robot, name %s should have IsRobot() return true", name);
-                    pointer.reset();
-                }
-            }
-        }
-        if( !pointer ) {
-            RAVELOG_WARN_FORMAT("env=%d failed to create name %s, interface %s\n", penv->GetId()%name%RaveGetInterfaceNamesMap().find(type)->second);
-        }
-        return pointer;
-    }
+    InterfaceBasePtr Create(EnvironmentBasePtr penv, InterfaceType type, const std::string& _name);
 
     /// loads all the plugins in this dir
     /// If pdir is already specified, reloads all
-    bool AddDirectory(const std::string& pdir)
-    {
-#ifdef _WIN32
-        WIN32_FIND_DATAA FindFileData;
-        HANDLE hFind;
-        string strfind = pdir;
-        strfind += "\\*";
-        strfind += PLUGIN_EXT;
+    bool AddDirectory(const std::string& pdir);
 
-        hFind = FindFirstFileA(strfind.c_str(), &FindFileData);
-        if (hFind == INVALID_HANDLE_VALUE) {
-            RAVELOG_DEBUG("No plugins in dir: %s (GetLastError reports %d)\n", pdir.c_str(), GetLastError ());
-            return false;
-        }
-        else  {
-            do {
-                RAVELOG_DEBUG("Adding plugin %s\n", FindFileData.cFileName);
-                string strplugin = pdir;
-                strplugin += "\\";
-                strplugin += FindFileData.cFileName;
-                LoadPlugin(strplugin);
-            } while (FindNextFileA(hFind, &FindFileData) != 0);
-            FindClose(hFind);
-        }
-#else
-        // linux
-        DIR *dp;
-        struct dirent *ep;
-        dp = opendir (pdir.c_str());
-        if (dp != NULL) {
-            while ( (ep = readdir (dp)) != NULL ) {
-                // check for a .so in every file
-                // check that filename ends with .so
-                if( strlen(ep->d_name) >= strlen(PLUGIN_EXT) &&
-                    strcmp(ep->d_name + strlen(ep->d_name) - strlen(PLUGIN_EXT), PLUGIN_EXT) == 0 ) {
-                    string strplugin = pdir;
-                    strplugin += "/";
-                    strplugin += ep->d_name;
-                    LoadPlugin(strplugin);
-                }
-            }
-            (void) closedir (dp);
-        }
-        else {
-            RAVELOG_DEBUG("Couldn't open directory %s\n", pdir.c_str());
-        }
-#endif
-        return true;
-    }
+    void ReloadPlugins();
 
-    void ReloadPlugins()
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        FOREACH(itplugin,_listplugins) {
-            PluginPtr newplugin = _LoadPlugin((*itplugin)->ppluginname);
-            if( !!newplugin ) {
-                *itplugin = newplugin;
-            }
-        }
-        _CleanupUnusedLibraries();
-    }
+    void OnRaveInitialized();
 
-    void OnRaveInitialized()
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        FOREACH(itplugin, _listplugins) {
-            (*itplugin)->OnRaveInitialized();
-        }
-    }
+    void OnRavePreDestroy();
 
-    void OnRavePreDestroy()
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        FOREACH(itplugin, _listplugins) {
-            (*itplugin)->OnRavePreDestroy();
-        }
-    }
+    bool LoadPlugin(const std::string& pluginname);
 
-    bool LoadPlugin(const std::string& pluginname)
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        std::list<PluginPtr>::iterator it = _GetPlugin(pluginname);
-        string newpluginname;
-        if( it != _listplugins.end() ) {
-            // since we got a match, use the old name and remove the old library
-            newpluginname = (*it)->ppluginname;
-            _listplugins.erase(it);
-        }
-        else {
-            newpluginname = pluginname;
-        }
-        PluginPtr p = _LoadPlugin(newpluginname);
-        if( !!p ) {
-            _listplugins.push_back(p);
-        }
-        _CleanupUnusedLibraries();
-        return !!p;
-    }
+    bool RemovePlugin(const std::string& pluginname);
 
-    bool RemovePlugin(const std::string& pluginname)
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        std::list<PluginPtr>::iterator it = _GetPlugin(pluginname);
-        if( it == _listplugins.end() ) {
-            return false;
-        }
-        _listplugins.erase(it);
-        _CleanupUnusedLibraries();
-        return true;
-    }
+    virtual bool HasInterface(InterfaceType type, const std::string& interfacename);
 
-    virtual bool HasInterface(InterfaceType type, const string& interfacename)
-    {
-        std::lock_guard<std::mutex> lock(_mutex);
-        FOREACHC(it,_listRegisteredInterfaces) {
-            RegisteredInterfacePtr registration = it->lock();
-            if( !!registration ) {
-                if(( interfacename.size() >= registration->_name.size()) &&( _strnicmp(interfacename.c_str(),registration->_name.c_str(),registration->_name.size()) == 0) ) {
-                    return true;
-                }
-            }
-        }
-        FOREACHC(itplugin, _listplugins) {
-            if( (*itplugin)->HasInterface(type,interfacename) ) {
-                return true;
-            }
-        }
-        return false;
-    }
+    void GetPluginInfo(std::list< std::pair<std::string, PLUGININFO> >& plugins) const;
 
-    void GetPluginInfo(std::list< std::pair<std::string, PLUGININFO> >& plugins) const
-    {
-        plugins.clear();
-        std::lock_guard<std::mutex> lock(_mutex);
-        FOREACHC(itplugin, _listplugins) {
-            PLUGININFO info;
-            if( (*itplugin)->GetInfo(info) ) {
-                plugins.emplace_back((*itplugin)->GetName(),info);
-            }
-        }
-        if( !_listRegisteredInterfaces.empty() ) {
-            plugins.emplace_back("__internal__", PLUGININFO());
-            plugins.back().second.version = OPENRAVE_VERSION;
-            FOREACHC(it,_listRegisteredInterfaces) {
-                RegisteredInterfacePtr registration = it->lock();
-                if( !!registration ) {
-                    plugins.back().second.interfacenames[registration->_type].push_back(registration->_name);
-                }
-            }
-        }
-    }
+    void GetLoadedInterfaces(std::map<InterfaceType, std::vector<std::string> >& interfacenames) const;
 
-    void GetLoadedInterfaces(std::map<InterfaceType, std::vector<std::string> >& interfacenames) const
-    {
-        interfacenames.clear();
-        std::lock_guard<std::mutex> lock(_mutex);
-        FOREACHC(it,_listRegisteredInterfaces) {
-            RegisteredInterfacePtr registration = it->lock();
-            if( !!registration ) {
-                interfacenames[registration->_type].push_back(registration->_name);
-            }
-        }
-        FOREACHC(itplugin, _listplugins) {
-            PLUGININFO localinfo;
-            if( !(*itplugin)->GetInfo(localinfo) ) {
-                RAVELOG_WARN(str(boost::format("failed to get plugin info: %s\n")%(*itplugin)->GetName()));
-            }
-            else {
-                // for now just return the cached info (so quering is faster)
-                FOREACH(it,localinfo.interfacenames) {
-                    std::vector<std::string>& vnames = interfacenames[it->first];
-                    vnames.insert(vnames.end(),it->second.begin(),it->second.end());
-                }
-            }
-        }
-    }
-
-    UserDataPtr RegisterInterface(InterfaceType type, const std::string& name, const char* interfacehash, const char* envhash, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn) {
-        BOOST_ASSERT(interfacehash != NULL && envhash != NULL);
-        BOOST_ASSERT(!!createfn);
-        BOOST_ASSERT(name.size()>0);
-        if( strcmp(envhash, OPENRAVE_ENVIRONMENT_HASH) ) {
-            throw openrave_exception(str(boost::format(_("environment invalid hash %s!=%s\n"))%envhash%OPENRAVE_ENVIRONMENT_HASH),ORE_InvalidInterfaceHash);
-        }
-        if( strcmp(interfacehash, RaveGetInterfaceHash(type)) ) {
-            throw openrave_exception(str(boost::format(_("interface %s invalid hash %s!=%s\n"))%RaveGetInterfaceName(type)%interfacehash%RaveGetInterfaceHash(type)),ORE_InvalidInterfaceHash);
-        }
-        std::lock_guard<std::mutex> lock(_mutex);
-        RegisteredInterfacePtr pdata(new RegisteredInterface(type,name,createfn,shared_from_this()));
-        pdata->_iterator = _listRegisteredInterfaces.insert(_listRegisteredInterfaces.end(),pdata);
-        return pdata;
-    }
-
-    static const char* GetInterfaceHash(InterfaceBasePtr pint) {
-        return pint->GetHash();
-    }
+    UserDataPtr RegisterInterface(InterfaceType type, const std::string& name, const char* interfacehash, const char* envhash, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn);
 
 protected:
-    void _CleanupUnusedLibraries()
-    {
-        FOREACH(it,_listDestroyLibraryQueue) {
-            RaveDatabase::_SysCloseLibrary(*it);
-        }
-        _listDestroyLibraryQueue.clear();
-    }
+    void _CleanupUnusedLibraries();
 
     /// \brief Deletes the plugin from the database
     ///
     /// It is safe to delete a plugin even if interfaces currently reference it because this function just decrements
     /// the reference count instead of unloading from memory.
-    std::list<PluginPtr>::iterator _GetPlugin(const std::string& pluginname)
-    {
-        FOREACH(it,_listplugins) {
-            if( pluginname == (*it)->ppluginname ) {
-                return it;
-            }
-        }
-#if defined(HAVE_BOOST_FILESYSTEM) && BOOST_VERSION >= 103600 // stem() was introduced in 1.36
-        // try matching partial base names without path and extension
-#if defined(BOOST_FILESYSTEM_VERSION) && BOOST_FILESYSTEM_VERSION >= 3
-        boost::filesystem::path pluginpath(pluginname);
-        string stem = pluginpath.stem().string();
-#else
-        boost::filesystem::path pluginpath(pluginname, boost::filesystem::native);
-        string stem = pluginpath.stem();
-#endif
-        FOREACH(it, _listplugins) {
-#if defined(BOOST_FILESYSTEM_VERSION) && BOOST_FILESYSTEM_VERSION >= 3
-            if( stem == boost::filesystem::path((*it)->ppluginname).stem() )
-#else
-            if( stem == boost::filesystem::path((*it)->ppluginname, boost::filesystem::native).stem() )
-#endif
-            {
-                return it;
-            }
-        }
-#endif
-        return _listplugins.end();
-    }
+    std::list<PluginPtr>::iterator _GetPlugin(const std::string& pluginname);
 
-    PluginPtr _LoadPlugin(const string& _libraryname)
-    {
-        string libraryname = _libraryname;
-        void* plibrary = _SysLoadLibrary(libraryname,OPENRAVE_LAZY_LOADING);
-        if( plibrary == NULL ) {
-            // check if PLUGIN_EXT is missing
-            if( libraryname.find(PLUGIN_EXT) == string::npos ) {
-                libraryname += PLUGIN_EXT;
-                plibrary = _SysLoadLibrary(libraryname,OPENRAVE_LAZY_LOADING);
-            }
-        }
-#ifndef _WIN32
-        if( plibrary == NULL ) {
-            // unix libraries are prefixed with 'lib', first have to split
-#if defined(HAVE_BOOST_FILESYSTEM) && BOOST_VERSION >= 103600 // stem() was introduced in 1.36
-#if defined(BOOST_FILESYSTEM_VERSION) && BOOST_FILESYSTEM_VERSION >= 3
-            boost::filesystem::path _librarypath(libraryname);
-            string librarypath = _librarypath.parent_path().string();
-            string libraryfilename = _librarypath.filename().string();
-#else
-            boost::filesystem::path _librarypath(libraryname, boost::filesystem::native);
-            string librarypath = _librarypath.parent_path().string();
-            string libraryfilename = _librarypath.filename();
-#endif
-            if(( libraryfilename.size() > 3) &&( libraryfilename.substr(0,3) != string("lib")) ) {
-                libraryname = librarypath;
-                if( libraryname.size() > 0 ) {
-                    libraryname += s_filesep;
-                }
-                libraryname += string("lib");
-                libraryname += libraryfilename;
-                plibrary = _SysLoadLibrary(libraryname.c_str(),OPENRAVE_LAZY_LOADING);
-            }
-#endif
-        }
-#endif
+    PluginPtr _LoadPlugin(const std::string& _libraryname);
 
-#ifdef HAVE_BOOST_FILESYSTEM
-        if( plibrary == NULL ) {
-            // try adding from the current plugin libraries
-            FOREACH(itdir,_listplugindirs) {
-                string newlibraryname = boost::filesystem::absolute(libraryname,*itdir).string();
-                plibrary = _SysLoadLibrary(newlibraryname,OPENRAVE_LAZY_LOADING);
-                if( !!plibrary ) {
-                    libraryname = newlibraryname;
-                    break;
-                }
-            }
-        }
-#endif
-        if( plibrary == NULL ) {
-            RAVELOG_WARN("failed to load: %s\n", _libraryname.c_str());
-            return PluginPtr();
-        }
+    static void* _SysLoadLibrary(const std::string& lib, bool bLazy=false);
 
-        PluginPtr p(new Plugin(shared_from_this()));
-        p->ppluginname = libraryname;
-        p->plibrary = plibrary;
+    static void* _SysLoadSym(void* lib, const std::string& sym);
 
-        try {
-            if( !p->Load_GetPluginAttributes() ) {
-                // might not be a plugin
-                RAVELOG_VERBOSE(str(boost::format("%s: can't load GetPluginAttributes function, might not be an OpenRAVE plugin\n")%libraryname));
-                return PluginPtr();
-            }
+    static void _SysCloseLibrary(void* lib);
 
-            if( p->pfnGetPluginAttributesNew != NULL ) {
-                p->pfnGetPluginAttributesNew(&p->_infocached, sizeof(p->_infocached),OPENRAVE_PLUGININFO_HASH);
-            }
-            else {
-                if( !p->pfnGetPluginAttributes(&p->_infocached, sizeof(p->_infocached)) ) {
-                    RAVELOG_WARN(str(boost::format("%s: GetPluginAttributes failed\n")%libraryname));
-                    return PluginPtr();
-                }
-            }
-        }
-        catch(const std::exception& ex) {
-            RAVELOG_WARN(str(boost::format("%s failed to load: %s\n")%libraryname%ex.what()));
-            return PluginPtr();
-        }
-        catch(...) {
-            RAVELOG_WARN(str(boost::format("%s: unknown exception\n")%libraryname));
-            return PluginPtr();
-        }
+    void _QueueLibraryDestruction(void* lib);
 
-#ifndef _WIN32
-        Dl_info info;
-        if( p->pfnGetPluginAttributesNew != NULL ) {
-            dladdr((void*)p->pfnGetPluginAttributesNew, &info);
-        }
-        else {
-            dladdr((void*)p->pfnGetPluginAttributes, &info);
-        }
-        RAVELOG_DEBUG("loading plugin: %s\n", info.dli_fname);
-#endif
-
-        p->_bInitializing = false;
-        if( OPENRAVE_LAZY_LOADING ) {
-            // have confirmed that plugin is ok, so reload with no-lazy loading
-            p->plibrary = NULL;     // NOTE: for some reason, closing the lazy loaded library can make the system crash, so instead keep the pointer around, but create a new one with RTLD_NOW
-            p->Destroy();
-            p->_bShutdown = false;
-        }
-
-        p->OnRaveInitialized(); // openrave runtime is most likely loaded already, so can safely initialize
-        return p;
-    }
-
-    static void* _SysLoadLibrary(const std::string& lib, bool bLazy=false)
-    {
-        // check if file exists first
-        if( !ifstream(lib.c_str()) ) {
-            return NULL;
-        }
-#ifdef _WIN32
-        void* plib = LoadLibraryA(lib.c_str());
-        if( plib == NULL ) {
-            RAVELOG_WARN("Failed to load %s\n", lib.c_str());
-        }
-#else
-        dlerror();     // clear error
-        void* plib = dlopen(lib.c_str(), bLazy ? RTLD_LAZY : RTLD_NOW);
-        char* pstr = dlerror();
-        if( pstr != NULL ) {
-            RAVELOG_WARN("%s: %s\n",lib.c_str(),pstr);
-            if( plib != NULL ) {
-                dlclose(plib);     //???
-            }
-            return NULL;
-        }
-#endif
-        return plib;
-    }
-
-    static void* _SysLoadSym(void* lib, const std::string& sym)
-    {
-#ifdef _WIN32
-        return GetProcAddress((HINSTANCE)lib, sym.c_str());
-#else
-        dlerror();     // clear existing error
-        void* psym = dlsym(lib, sym.c_str());
-        char* errorstring = dlerror();
-        if( errorstring != NULL ) {
-            return psym;
-        }
-        if( psym != NULL ) {
-            // check for errors if something valid is returned since we'll be executing it
-            if( errorstring != NULL ) {
-                throw openrave_exception(errorstring,ORE_InvalidPlugin);
-            }
-        }
-        return psym;
-#endif
-    }
-
-    static void _SysCloseLibrary(void* lib)
-    {
-#ifdef _WIN32
-        FreeLibrary((HINSTANCE)lib);
-#else
-        // can segfault if opened library clashes with other
-        // need to use some combination of setjmp, longjmp to get this to work corectly
-        //sighandler_t tprev = signal(SIGSEGV,fault_handler);
-        dlclose(lib);
-        //signal(SIGSEGV,tprev);
-#endif
-    }
-
-    void _QueueLibraryDestruction(void* lib)
-    {
-        _listDestroyLibraryQueue.push_back(lib);
-    }
-
-    void _InterfaceDestroyCallbackShared(void const* pinterface)
-    {
-        if( pinterface != NULL ) {
-        }
-    }
+    void _InterfaceDestroyCallbackShared(void const* pinterface);
 
     /// \brief makes sure plugin is in scope until after pointer is completely deleted
-    void _InterfaceDestroyCallbackSharedPost(std::string name, UserDataPtr plugin)
-    {
-        // post-processing for deleting interfaces
-        plugin.reset();
-    }
+    void _InterfaceDestroyCallbackSharedPost(std::string name, UserDataPtr plugin);
 
-    void _AddToLoader(PluginPtr p)
-    {
-        std::lock_guard<std::mutex> lock(_mutexPluginLoader);
-        _listPluginsToLoad.push_back(p);
-        _condLoaderHasWork.notify_all();
-    }
+    void _AddToLoader(PluginPtr p);
 
-    void _PluginLoaderThread()
-    {
-        while(!_bShutdown) {
-            list<PluginPtr> listPluginsToLoad;
-            {
-                std::unique_lock<std::mutex> lock(_mutexPluginLoader);
-                if( _listPluginsToLoad.empty() ) {
-                    _condLoaderHasWork.wait(lock);
-                    if( _bShutdown ) {
-                        break;
-                    }
-                }
-                listPluginsToLoad.swap(_listPluginsToLoad);
-            }
-            FOREACH(itplugin,listPluginsToLoad) {
-                if( _bShutdown ) {
-                    break;
-                }
-                std::lock_guard<std::mutex> lockplugin((*itplugin)->_mutex);
-                if( _bShutdown ) {
-                    break;
-                }
-                (*itplugin)->plibrary = _SysLoadLibrary((*itplugin)->ppluginname,false);
-                if( (*itplugin)->plibrary == NULL ) {
-                    // for some reason cannot load the library, so shut it down
-                    (*itplugin)->_bShutdown = true;
-                }
-                (*itplugin)->_cond.notify_all();
-            }
-        }
-    }
+    void _PluginLoaderThread();
 
-    list<PluginPtr> _listplugins;
-    mutable std::mutex _mutex;     ///< changing plugin database
+    std::list<PluginPtr> _listplugins;
+    mutable boost::mutex _mutex;     ///< changing plugin database
     std::list<void*> _listDestroyLibraryQueue;
     std::list< boost::weak_ptr<RegisteredInterface> > _listRegisteredInterfaces;
     std::list<std::string> _listplugindirs;
@@ -1150,3 +232,5 @@ BOOST_TYPEOF_REGISTER_TYPE(RaveDatabase::Plugin)
 #endif
 
 #endif
+
+#include "plugindatabase_impl.hpp"

--- a/src/libopenrave/plugindatabase_impl.hpp
+++ b/src/libopenrave/plugindatabase_impl.hpp
@@ -1,0 +1,1067 @@
+// -*- coding: utf-8 -*-
+// Copyright (C) 2022 Rosen Diankov (rdiankov@cs.cmu.edu)
+//
+// This file is part of OpenRAVE.
+// OpenRAVE is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#ifndef RAVE_PLUGIN_DATABASE_IMPL_H
+#define RAVE_PLUGIN_DATABASE_IMPL_H
+
+#include "libopenrave.h"
+#include "plugindatabase.h"
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+
+#ifdef HAVE_BOOST_FILESYSTEM
+#include <boost/filesystem.hpp>
+#endif
+#include <boost/version.hpp>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#define PLUGIN_EXT ".dll"
+#define OPENRAVE_LAZY_LOADING false
+#else
+#define OPENRAVE_LAZY_LOADING true
+#include <dlfcn.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <dirent.h>
+
+#ifdef __APPLE_CC__
+#define PLUGIN_EXT ".dylib"
+#else
+#define PLUGIN_EXT ".so"
+#endif
+
+#endif
+
+#define INTERFACE_PREDELETER boost::function<void(void const*)>()
+#define INTERFACE_POSTDELETER(name, plugin) boost::bind(&RaveDatabase::_InterfaceDestroyCallbackSharedPost,shared_from_this(),name,plugin)
+
+#ifdef _WIN32
+const char s_filesep = '\\';
+#else
+const char s_filesep = '/';
+#endif
+
+namespace OpenRAVE {
+
+RaveDatabase::RegisteredInterface::RegisteredInterface(InterfaceType type, const std::string& name, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn, boost::shared_ptr<RaveDatabase> database)
+    : _type(type)
+    , _name(name)
+    , _createfn(createfn)
+    , _database(database)
+{
+}
+
+RaveDatabase::RegisteredInterface::~RegisteredInterface()
+{
+    boost::shared_ptr<RaveDatabase> database = _database.lock();
+    if( !!database ) {
+        boost::mutex::scoped_lock lock(database->_mutex);
+        database->_listRegisteredInterfaces.erase(_iterator);
+    }
+}
+
+RaveDatabase::Plugin::Plugin(boost::shared_ptr<RaveDatabase> pdatabase)
+    : _pdatabase(pdatabase)
+    , plibrary(NULL)
+    , pfnCreate(NULL)
+    , pfnCreateNew(NULL)
+    , pfnGetPluginAttributes(NULL)
+    , pfnGetPluginAttributesNew(NULL)
+    , pfnDestroyPlugin(NULL)
+    , pfnOnRaveInitialized(NULL)
+    , pfnOnRavePreDestroy(NULL)
+    , _bShutdown(false)
+    , _bInitializing(true)
+    , _bHasCalledOnRaveInitialized(false)
+{
+}
+
+RaveDatabase::Plugin::~Plugin()
+{
+    Destroy();
+}
+
+void RaveDatabase::Plugin::Destroy()
+{
+    if( _bInitializing ) {
+        if( plibrary ) {
+            if( OPENRAVE_LAZY_LOADING ) {
+                // NOTE: for some reason, closing the lazy loaded library can make the system crash, so instead keep the memory around, and create a new one with RTLD_NOW if necessary
+            }
+            else {
+                RaveDatabase::_SysCloseLibrary(plibrary);
+            }
+            plibrary = NULL;
+        }
+    }
+    else {
+        if( plibrary ) {
+            Load_DestroyPlugin();
+        }
+        boost::mutex::scoped_lock lock(_mutex);
+        // do some more checking here, there still might be instances of robots, planners, and sensors out there
+        if (plibrary) {
+            RAVELOG_DEBUG("RaveDatabase: closing plugin %s\n", ppluginname.c_str());        // Sleep(10);
+            if( pfnDestroyPlugin != NULL ) {
+                pfnDestroyPlugin();
+            }
+            boost::shared_ptr<RaveDatabase> pdatabase = _pdatabase.lock();
+            if( !!pdatabase ) {
+                pdatabase->_QueueLibraryDestruction(plibrary);
+            }
+            plibrary = NULL;
+        }
+    }
+    pfnCreate = NULL;
+    pfnCreateNew = NULL;
+    pfnDestroyPlugin = NULL;
+    pfnOnRaveInitialized = NULL;
+    pfnOnRavePreDestroy = NULL;
+    pfnGetPluginAttributes = NULL;
+    pfnGetPluginAttributesNew = NULL;
+    _bShutdown = true;
+}
+
+bool RaveDatabase::Plugin::IsValid()
+{
+    return !_bShutdown;
+}
+
+const std::string& RaveDatabase::Plugin::GetName() const
+{
+    return ppluginname;
+}
+
+bool RaveDatabase::Plugin::GetInfo(PLUGININFO& info)
+{
+    info = _infocached;
+    return true;
+}
+
+bool RaveDatabase::Plugin::Load_CreateInterfaceGlobal()
+{
+    _confirmLibrary();
+    if ((pfnCreateNew == NULL) &&( pfnCreate == NULL)) {
+        if (pfnCreateNew == NULL) {
+            pfnCreateNew = (PluginExportFn_OpenRAVECreateInterface)_SysLoadSym(plibrary, "OpenRAVECreateInterface");
+        }
+
+        if (pfnCreateNew == NULL) {
+#ifdef _MSC_VER
+            pfnCreate = (PluginExportFn_CreateInterface)_SysLoadSym(plibrary, "?CreateInterface@@YA?AV?$shared_ptr@VInterfaceBase@OpenRAVE@@@boost@@W4InterfaceType@OpenRAVE@@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PBDV?$shared_ptr@VEnvironmentBase@OpenRAVE@@@2@@Z");
+#else
+            pfnCreate = (PluginExportFn_CreateInterface)_SysLoadSym(plibrary, "_Z15CreateInterfaceN8OpenRAVE10InterfaceTypeERKSsPKcN5boost10shared_ptrINS_15EnvironmentBaseEEE");
+#endif
+            if (pfnCreate == NULL) {
+                pfnCreate = (PluginExportFn_CreateInterface)_SysLoadSym(plibrary, "CreateInterface");
+                if (pfnCreate == NULL) {
+                    return false;
+                }
+            }
+        }
+    }
+    return pfnCreateNew != NULL || pfnCreate != NULL;
+}
+
+bool RaveDatabase::Plugin::Load_GetPluginAttributes()
+{
+    _confirmLibrary();
+    if ((pfnGetPluginAttributesNew == NULL) || (pfnGetPluginAttributes == NULL)) {
+        if (pfnGetPluginAttributesNew == NULL) {
+            pfnGetPluginAttributesNew = (PluginExportFn_OpenRAVEGetPluginAttributes)_SysLoadSym(plibrary,"OpenRAVEGetPluginAttributes");
+        }
+        if(pfnGetPluginAttributesNew == NULL ) {
+#ifdef _MSC_VER
+            pfnGetPluginAttributes = (PluginExportFn_GetPluginAttributes)_SysLoadSym(plibrary, "?GetPluginAttributes@@YA_NPAUPLUGININFO@OpenRAVE@@H@Z");
+#else
+            pfnGetPluginAttributes = (PluginExportFn_GetPluginAttributes)_SysLoadSym(plibrary, "_Z19GetPluginAttributesPN8OpenRAVE10PLUGININFOEi");
+#endif
+            if( !pfnGetPluginAttributes ) {
+                pfnGetPluginAttributes = (PluginExportFn_GetPluginAttributes)_SysLoadSym(plibrary, "GetPluginAttributes");
+                if( !pfnGetPluginAttributes ) {
+                    return false;
+                }
+            }
+        }
+    }
+    return pfnGetPluginAttributesNew != NULL || pfnGetPluginAttributes != NULL;
+}
+
+bool RaveDatabase::Plugin::Load_DestroyPlugin()
+{
+    _confirmLibrary();
+    if( pfnDestroyPlugin == NULL ) {
+#ifdef _MSC_VER
+        pfnDestroyPlugin = (PluginExportFn_DestroyPlugin)_SysLoadSym(plibrary, "?DestroyPlugin@@YAXXZ");
+#else
+        pfnDestroyPlugin = (PluginExportFn_DestroyPlugin)_SysLoadSym(plibrary, "_Z13DestroyPluginv");
+#endif
+        if( pfnDestroyPlugin == NULL ) {
+            pfnDestroyPlugin = (PluginExportFn_DestroyPlugin)_SysLoadSym(plibrary, "DestroyPlugin");
+            if( pfnDestroyPlugin == NULL ) {
+                RAVELOG_WARN(str(boost::format("%s: can't load DestroyPlugin function, passing...\n")%ppluginname));
+                return false;
+            }
+        }
+    }
+    return pfnDestroyPlugin != NULL;
+}
+
+bool RaveDatabase::Plugin::Load_OnRaveInitialized()
+{
+    _confirmLibrary();
+    if( pfnOnRaveInitialized == NULL ) {
+#ifdef _MSC_VER
+        pfnOnRaveInitialized = (PluginExportFn_OnRaveInitialized)_SysLoadSym(plibrary, "?OnRaveInitialized@@YAXXZ");
+#else
+        pfnOnRaveInitialized = (PluginExportFn_OnRaveInitialized)_SysLoadSym(plibrary, "_Z17OnRaveInitializedv");
+#endif
+        if( pfnOnRaveInitialized == NULL ) {
+            pfnOnRaveInitialized = (PluginExportFn_OnRaveInitialized)_SysLoadSym(plibrary, "OnRaveInitialized");
+            if( pfnOnRaveInitialized == NULL ) {
+                //RAVELOG_VERBOSE(str(boost::format("%s: can't load OnRaveInitialized function, passing...\n")%ppluginname));
+                return false;
+            }
+        }
+    }
+    return pfnOnRaveInitialized!=NULL;
+}
+
+bool RaveDatabase::Plugin::Load_OnRavePreDestroy()
+{
+    _confirmLibrary();
+    if( pfnOnRavePreDestroy == NULL ) {
+#ifdef _MSC_VER
+        pfnOnRavePreDestroy = (PluginExportFn_OnRavePreDestroy)_SysLoadSym(plibrary, "?OnRavePreDestroy@@YAXXZ");
+#else
+        pfnOnRavePreDestroy = (PluginExportFn_OnRavePreDestroy)_SysLoadSym(plibrary, "_Z16OnRavePreDestroyv");
+#endif
+        if( pfnOnRavePreDestroy == NULL ) {
+            pfnOnRavePreDestroy = (PluginExportFn_OnRavePreDestroy)_SysLoadSym(plibrary, "OnRavePreDestroy");
+            if( pfnOnRavePreDestroy == NULL ) {
+                //RAVELOG_VERBOSE(str(boost::format("%s: can't load OnRavePreDestroy function, passing...\n")%ppluginname));
+                return false;
+            }
+        }
+    }
+    return pfnOnRavePreDestroy!=NULL;
+}
+
+bool RaveDatabase::Plugin::HasInterface(InterfaceType type, const std::string& name)
+{
+    if( name.size() == 0 ) {
+        return false;
+    }
+    std::map<InterfaceType, std::vector<std::string> >::iterator itregisterednames = _infocached.interfacenames.find(type);
+    if( itregisterednames == _infocached.interfacenames.end() ) {
+        return false;
+    }
+    FOREACH(it,itregisterednames->second) {
+        if(( name.size() >= it->size()) &&( _strnicmp(name.c_str(),it->c_str(),it->size()) == 0) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+InterfaceBasePtr RaveDatabase::Plugin::CreateInterface(InterfaceType type, const std::string& name, const char* interfacehash, EnvironmentBasePtr penv)
+{
+    std::pair<InterfaceType, std::string> p(type, utils::ConvertToLowerCase(name));
+    if( _setBadInterfaces.find(p) != _setBadInterfaces.end() ) {
+        return InterfaceBasePtr();
+    }
+
+    if( !HasInterface(type,name) ) {
+        return InterfaceBasePtr();
+    }
+
+    try {
+        if( !Load_CreateInterfaceGlobal() ) {
+            throw openrave_exception(str(boost::format(_("%s: can't load CreateInterface function\n"))%ppluginname),ORE_InvalidPlugin);
+        }
+        InterfaceBasePtr pinterface;
+        if( pfnCreateNew != NULL ) {
+            pinterface = pfnCreateNew(type,name,interfacehash,OPENRAVE_ENVIRONMENT_HASH,penv);
+        }
+        else if( pfnCreate != NULL ) {
+            pinterface = pfnCreate(type,name,interfacehash,penv);
+        }
+        return pinterface;
+    }
+    catch(const openrave_exception& ex) {
+        RAVELOG_ERROR(str(boost::format("Create Interface: openrave exception , plugin %s: %s\n")%ppluginname%ex.what()));
+        if( ex.GetCode() == ORE_InvalidPlugin ) {
+            RAVELOG_DEBUG(str(boost::format("shared object %s is not a valid openrave plugin\n")%ppluginname));
+            Destroy();
+        }
+        else if( ex.GetCode() == ORE_InvalidInterfaceHash ) {
+            _setBadInterfaces.insert(p);
+        }
+    }
+    catch(const std::exception& ex) {
+        RAVELOG_ERROR(str(boost::format("Create Interface: unknown exception, plugin %s: %s\n")%ppluginname%ex.what()));
+    }
+    catch(...) {
+        RAVELOG_ERROR(str(boost::format("Create Interface: unknown exception, plugin %s\n")%ppluginname));
+    }
+    return InterfaceBasePtr();
+}
+
+void RaveDatabase::Plugin::OnRaveInitialized()
+{
+    if( Load_OnRaveInitialized() ) {
+        if( !!pfnOnRaveInitialized && !_bHasCalledOnRaveInitialized ) {
+            pfnOnRaveInitialized();
+            _bHasCalledOnRaveInitialized = true;
+        }
+    }
+}
+
+void RaveDatabase::Plugin::OnRavePreDestroy()
+{
+    if( Load_OnRavePreDestroy() ) {
+        // always call destroy regardless of initialization state (safest)
+        if( !!pfnOnRavePreDestroy ) {
+            pfnOnRavePreDestroy();
+            _bHasCalledOnRaveInitialized = false;
+        }
+    }
+}
+
+void RaveDatabase::Plugin::_confirmLibrary()
+{
+    // first test the library before locking
+    if( plibrary == NULL ) {
+        boost::mutex::scoped_lock lock(_mutex);
+        _pdatabase.lock()->_AddToLoader(shared_from_this());
+        do {
+            if( plibrary ) {
+                return;
+            }
+            if( _bShutdown ) {
+                throw openrave_exception(_("library is shutting down"),ORE_InvalidPlugin);
+            }
+            _cond.wait(lock);
+        } while(1);
+    }
+}
+
+RaveDatabase::RaveDatabase() : _bShutdown(false)
+{
+}
+
+RaveDatabase::~RaveDatabase()
+{
+    Destroy();
+}
+
+bool RaveDatabase::Init(bool bLoadAllPlugins)
+{
+    _threadPluginLoader.reset(new boost::thread(boost::bind(&RaveDatabase::_PluginLoaderThread, this)));
+    std::vector<std::string> vplugindirs;
+#ifdef _WIN32
+    const char* delim = ";";
+#else
+    const char* delim = ":";
+#endif
+    char* pOPENRAVE_PLUGINS = getenv("OPENRAVE_PLUGINS"); // getenv not thread-safe?
+    if( pOPENRAVE_PLUGINS != NULL ) {
+        utils::TokenizeString(pOPENRAVE_PLUGINS, delim, vplugindirs);
+    }
+    for (int iplugindir = vplugindirs.size() - 1; iplugindir > 0; iplugindir--) {
+        int jplugindir = 0;
+        for(; jplugindir < iplugindir; jplugindir++) {
+            if(vplugindirs[iplugindir] == vplugindirs[jplugindir]) {
+                break;
+            }
+        }
+        if (jplugindir < iplugindir) {
+            vplugindirs.erase(vplugindirs.begin()+iplugindir);
+        }
+    }
+    bool bExists = false;
+    std::string installdir = OPENRAVE_PLUGINS_INSTALL_DIR;
+#ifdef HAVE_BOOST_FILESYSTEM
+    if( !boost::filesystem::is_directory(boost::filesystem::path(installdir)) ) {
+#ifdef _WIN32
+        HKEY hkey;
+        if(RegOpenKeyEx(HKEY_LOCAL_MACHINE, TEXT("Software\\OpenRAVE\\" OPENRAVE_VERSION_STRING), 0, KEY_QUERY_VALUE, &hkey) == ERROR_SUCCESS) {
+            DWORD dwType = REG_SZ;
+            CHAR szInstallRoot[4096];     // dont' take chances, it is windows
+            DWORD dwSize = sizeof(szInstallRoot);
+            RegQueryValueEx(hkey, TEXT("InstallRoot"), NULL, &dwType, (PBYTE)szInstallRoot, &dwSize);
+            RegCloseKey(hkey);
+            installdir.assign(szInstallRoot);
+            installdir += str(boost::format("%cshare%copenrave-%d.%d%cplugins")%s_filesep%s_filesep%OPENRAVE_VERSION_MAJOR%OPENRAVE_VERSION_MINOR%s_filesep);
+            RAVELOG_VERBOSE(str(boost::format("window registry plugin dir '%s'")%installdir));
+        }
+        else
+#endif
+        {
+            RAVELOG_WARN(str(boost::format("%s doesn't exist")%installdir));
+        }
+    }
+    boost::filesystem::path pluginsfilename = boost::filesystem::absolute(boost::filesystem::path(installdir));
+    FOREACH(itname, vplugindirs) {
+        if( pluginsfilename == boost::filesystem::absolute(boost::filesystem::path(*itname)) ) {
+            bExists = true;
+            break;
+        }
+    }
+#else
+    std::string pluginsfilename=installdir;
+    FOREACH(itname, vplugindirs) {
+        if( pluginsfilename == *itname ) {
+            bExists = true;
+            break;
+        }
+    }
+#endif
+    if( !bExists ) {
+        vplugindirs.push_back(installdir);
+    }
+    FOREACH(it, vplugindirs) {
+        if( it->size() > 0 ) {
+            _listplugindirs.push_back(*it);
+            RAVELOG_VERBOSE(str(boost::format("plugin dir: %s")%*it));
+        }
+    }
+    if( bLoadAllPlugins ) {
+        FOREACH(it, vplugindirs) {
+            if( it->size() > 0 ) {
+                AddDirectory(*it);
+            }
+        }
+    }
+    return true;
+}
+
+void RaveDatabase::Destroy()
+{
+    RAVELOG_DEBUG("plugin database shutting down...\n");
+    {
+        boost::mutex::scoped_lock lock(_mutexPluginLoader);
+        _bShutdown = true;
+        _condLoaderHasWork.notify_all();
+    }
+    if( !!_threadPluginLoader ) {
+        _threadPluginLoader->join();
+        _threadPluginLoader.reset();
+    }
+    {
+        boost::mutex::scoped_lock lock(_mutex);
+        _listplugins.clear();
+    }
+    // cannot lock mutex due to __erase_iterator
+    // cannot clear _listRegisteredInterfaces since there are destructors that will remove items from the list
+    //_listRegisteredInterfaces.clear();
+    {
+        boost::mutex::scoped_lock lock(_mutex);
+        _CleanupUnusedLibraries();
+    }
+    _listplugindirs.clear();
+    RAVELOG_DEBUG("openrave plugin database destroyed\n");
+}
+
+void RaveDatabase::GetPlugins(std::list<PluginPtr>& listplugins) const
+{
+    boost::mutex::scoped_lock lock(_mutex);
+    listplugins = _listplugins;
+}
+
+InterfaceBasePtr RaveDatabase::Create(EnvironmentBasePtr penv, InterfaceType type, const std::string& _name)
+{
+    std::string name=_name;
+    InterfaceBasePtr pointer;
+    if( name.size() == 0 ) {
+        switch(type) {
+        case PT_KinBody: {
+            pointer.reset(new KinBody(PT_KinBody,penv));
+            pointer->__strxmlid = ""; // don't set to KinBody since there's no officially registered interface
+            break;
+        }
+        case PT_PhysicsEngine: name = "GenericPhysicsEngine"; break;
+        case PT_CollisionChecker: name = "GenericCollisionChecker"; break;
+        case PT_Robot: name = "GenericRobot"; break;
+        case PT_Trajectory: name = "GenericTrajectory"; break;
+        default: break;
+        }
+    }
+
+    if( !pointer ) {
+        size_t nInterfaceNameLength = name.find_first_of(' ');
+        if( nInterfaceNameLength == std::string::npos ) {
+            nInterfaceNameLength = name.size();
+        }
+        if( nInterfaceNameLength == 0 ) {
+            RAVELOG_WARN(str(boost::format("interface %s name \"%s\" needs to start with a valid character\n")%RaveGetInterfaceName(type)%name));
+            return InterfaceBasePtr();
+        }
+
+        // have to copy in order to allow plugins to register stuff inside their creation methods
+        std::list< boost::weak_ptr<RegisteredInterface> > listRegisteredInterfaces;
+        std::list<PluginPtr> listplugins;
+        {
+            boost::mutex::scoped_lock lock(_mutex);
+            listRegisteredInterfaces = _listRegisteredInterfaces;
+            listplugins = _listplugins;
+        }
+        FOREACH(it, listRegisteredInterfaces) {
+            RegisteredInterfacePtr registration = it->lock();
+            if( !!registration ) {
+                if(( nInterfaceNameLength >= registration->_name.size()) &&( _strnicmp(name.c_str(),registration->_name.c_str(),registration->_name.size()) == 0) ) {
+                    std::stringstream sinput(name);
+                    std::string interfacename;
+                    sinput >> interfacename;
+                    std::transform(interfacename.begin(), interfacename.end(), interfacename.begin(), ::tolower);
+                    pointer = registration->_createfn(penv,sinput);
+                    if( !!pointer ) {
+                        if( pointer->GetInterfaceType() != type ) {
+                            RAVELOG_FATAL(str(boost::format("plugin interface name %s, type %s, types do not match\n")%name%RaveGetInterfaceName(type)));
+                            pointer.reset();
+                        }
+                        else {
+                            pointer = InterfaceBasePtr(pointer.get(), utils::smart_pointer_deleter<InterfaceBasePtr>(pointer,INTERFACE_PREDELETER));
+                            pointer->__strpluginname = "__internal__";
+                            pointer->__strxmlid = name;
+                            //pointer->__plugin; // need to protect resources?
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if( !pointer ) {
+            const char* hash = RaveGetInterfaceHash(type);
+            std::list<PluginPtr>::iterator itplugin = listplugins.begin();
+            while(itplugin != listplugins.end()) {
+                pointer = (*itplugin)->CreateInterface(type, name, hash, penv);
+                if( !!pointer ) {
+                    if( strcmp(pointer->GetHash(), hash) ) {
+                        RAVELOG_FATAL(str(boost::format("plugin interface name %s, %s has invalid hash, might be compiled with stale openrave files\n")%name%RaveGetInterfaceName(type)));
+                        (*itplugin)->_setBadInterfaces.insert(std::make_pair(type,utils::ConvertToLowerCase(name)));
+                        pointer.reset();
+                    }
+                    else if( pointer->GetInterfaceType() != type ) {
+                        RAVELOG_FATAL(str(boost::format("plugin interface name %s, type %s, types do not match\n")%name%RaveGetInterfaceName(type)));
+                        (*itplugin)->_setBadInterfaces.insert(std::make_pair(type,utils::ConvertToLowerCase(name)));
+                        pointer.reset();
+                    }
+                    else {
+                        pointer = InterfaceBasePtr(pointer.get(), utils::smart_pointer_deleter<InterfaceBasePtr>(pointer,INTERFACE_PREDELETER, INTERFACE_POSTDELETER(name, *itplugin)));
+                        pointer->__strpluginname = (*itplugin)->ppluginname;
+                        pointer->__strxmlid = name;
+                        pointer->__plugin = *itplugin;
+                        break;
+                    }
+                }
+                if( !(*itplugin)->IsValid() ) {
+                    boost::mutex::scoped_lock lock(_mutex);
+                    _listplugins.remove(*itplugin);
+                }
+                ++itplugin;
+            }
+        }
+    }
+
+    if( !!pointer ) {
+        if( type == PT_Robot ) {
+            RobotBasePtr probot = RaveInterfaceCast<RobotBase>(pointer);
+            if( strcmp(probot->GetKinBodyHash(), OPENRAVE_KINBODY_HASH) ) {
+                RAVELOG_FATAL_FORMAT("plugin interface Robot, name %s has invalid hash, might be compiled with stale openrave files", name);
+                pointer.reset();
+            }
+            if( !probot->IsRobot() ) {
+                RAVELOG_FATAL_FORMAT("interface Robot, name %s should have IsRobot() return true", name);
+                pointer.reset();
+            }
+        }
+    }
+    if( !pointer ) {
+        RAVELOG_WARN_FORMAT("env=%d failed to create name %s, interface %s\n", penv->GetId()%name%RaveGetInterfaceNamesMap().find(type)->second);
+    }
+    return pointer;
+}
+
+bool RaveDatabase::AddDirectory(const std::string& pdir)
+{
+#ifdef _WIN32
+    WIN32_FIND_DATAA FindFileData;
+    HANDLE hFind;
+    std::string strfind = pdir;
+    strfind += "\\*";
+    strfind += PLUGIN_EXT;
+
+    hFind = FindFirstFileA(strfind.c_str(), &FindFileData);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        RAVELOG_DEBUG("No plugins in dir: %s (GetLastError reports %d)\n", pdir.c_str(), GetLastError ());
+        return false;
+    }
+    else  {
+        do {
+            RAVELOG_DEBUG("Adding plugin %s\n", FindFileData.cFileName);
+            std::string strplugin = pdir;
+            strplugin += "\\";
+            strplugin += FindFileData.cFileName;
+            LoadPlugin(strplugin);
+        } while (FindNextFileA(hFind, &FindFileData) != 0);
+        FindClose(hFind);
+    }
+#else
+    // linux
+    DIR *dp;
+    struct dirent *ep;
+    dp = opendir (pdir.c_str());
+    if (dp != NULL) {
+        while ( (ep = readdir (dp)) != NULL ) {
+            // check for a .so in every file
+            // check that filename ends with .so
+            if( strlen(ep->d_name) >= strlen(PLUGIN_EXT) &&
+                strcmp(ep->d_name + strlen(ep->d_name) - strlen(PLUGIN_EXT), PLUGIN_EXT) == 0 ) {
+                std::string strplugin = pdir;
+                strplugin += "/";
+                strplugin += ep->d_name;
+                LoadPlugin(strplugin);
+            }
+        }
+        (void) closedir (dp);
+    }
+    else {
+        RAVELOG_DEBUG("Couldn't open directory %s\n", pdir.c_str());
+    }
+#endif
+    return true;
+}
+
+void RaveDatabase::ReloadPlugins()
+{
+    boost::mutex::scoped_lock lock(_mutex);
+    FOREACH(itplugin,_listplugins) {
+        PluginPtr newplugin = _LoadPlugin((*itplugin)->ppluginname);
+        if( !!newplugin ) {
+            *itplugin = newplugin;
+        }
+    }
+    _CleanupUnusedLibraries();
+}
+
+void RaveDatabase::OnRaveInitialized()
+{
+    boost::mutex::scoped_lock lock(_mutex);
+    FOREACH(itplugin, _listplugins) {
+        (*itplugin)->OnRaveInitialized();
+    }
+}
+
+void RaveDatabase::OnRavePreDestroy()
+{
+    boost::mutex::scoped_lock lock(_mutex);
+    FOREACH(itplugin, _listplugins) {
+        (*itplugin)->OnRavePreDestroy();
+    }
+}
+
+bool RaveDatabase::LoadPlugin(const std::string& pluginname)
+{
+    boost::mutex::scoped_lock lock(_mutex);
+    std::list<PluginPtr>::iterator it = _GetPlugin(pluginname);
+    std::string newpluginname;
+    if( it != _listplugins.end() ) {
+        // since we got a match, use the old name and remove the old library
+        newpluginname = (*it)->ppluginname;
+        _listplugins.erase(it);
+    }
+    else {
+        newpluginname = pluginname;
+    }
+    PluginPtr p = _LoadPlugin(newpluginname);
+    if( !!p ) {
+        _listplugins.push_back(p);
+    }
+    _CleanupUnusedLibraries();
+    return !!p;
+}
+
+bool RaveDatabase::RemovePlugin(const std::string& pluginname)
+{
+    boost::mutex::scoped_lock lock(_mutex);
+    std::list<PluginPtr>::iterator it = _GetPlugin(pluginname);
+    if( it == _listplugins.end() ) {
+        return false;
+    }
+    _listplugins.erase(it);
+    _CleanupUnusedLibraries();
+    return true;
+}
+
+bool RaveDatabase::HasInterface(InterfaceType type, const std::string& interfacename)
+{
+    boost::mutex::scoped_lock lock(_mutex);
+    FOREACHC(it,_listRegisteredInterfaces) {
+        RegisteredInterfacePtr registration = it->lock();
+        if( !!registration ) {
+            if(( interfacename.size() >= registration->_name.size()) &&( _strnicmp(interfacename.c_str(),registration->_name.c_str(),registration->_name.size()) == 0) ) {
+                return true;
+            }
+        }
+    }
+    FOREACHC(itplugin, _listplugins) {
+        if( (*itplugin)->HasInterface(type,interfacename) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void RaveDatabase::GetPluginInfo(std::list< std::pair<std::string, PLUGININFO> >& plugins) const
+{
+    plugins.clear();
+    boost::mutex::scoped_lock lock(_mutex);
+    FOREACHC(itplugin, _listplugins) {
+        PLUGININFO info;
+        if( (*itplugin)->GetInfo(info) ) {
+            plugins.emplace_back((*itplugin)->GetName(),info);
+        }
+    }
+    if( !_listRegisteredInterfaces.empty() ) {
+        plugins.emplace_back("__internal__", PLUGININFO());
+        plugins.back().second.version = OPENRAVE_VERSION;
+        FOREACHC(it,_listRegisteredInterfaces) {
+            RegisteredInterfacePtr registration = it->lock();
+            if( !!registration ) {
+                plugins.back().second.interfacenames[registration->_type].push_back(registration->_name);
+            }
+        }
+    }
+}
+
+void RaveDatabase::GetLoadedInterfaces(std::map<InterfaceType, std::vector<std::string> >& interfacenames) const
+{
+    interfacenames.clear();
+    boost::mutex::scoped_lock lock(_mutex);
+    FOREACHC(it,_listRegisteredInterfaces) {
+        RegisteredInterfacePtr registration = it->lock();
+        if( !!registration ) {
+            interfacenames[registration->_type].push_back(registration->_name);
+        }
+    }
+    FOREACHC(itplugin, _listplugins) {
+        PLUGININFO localinfo;
+        if( !(*itplugin)->GetInfo(localinfo) ) {
+            RAVELOG_WARN(str(boost::format("failed to get plugin info: %s\n")%(*itplugin)->GetName()));
+        }
+        else {
+            // for now just return the cached info (so quering is faster)
+            FOREACH(it,localinfo.interfacenames) {
+                std::vector<std::string>& vnames = interfacenames[it->first];
+                vnames.insert(vnames.end(),it->second.begin(),it->second.end());
+            }
+        }
+    }
+}
+
+UserDataPtr RaveDatabase::RegisterInterface(InterfaceType type, const std::string& name, const char* interfacehash, const char* envhash, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn)
+{
+    BOOST_ASSERT(interfacehash != NULL && envhash != NULL);
+    BOOST_ASSERT(!!createfn);
+    BOOST_ASSERT(name.size()>0);
+    if( strcmp(envhash, OPENRAVE_ENVIRONMENT_HASH) ) {
+        throw openrave_exception(str(boost::format(_("environment invalid hash %s!=%s\n"))%envhash%OPENRAVE_ENVIRONMENT_HASH),ORE_InvalidInterfaceHash);
+    }
+    if( strcmp(interfacehash, RaveGetInterfaceHash(type)) ) {
+        throw openrave_exception(str(boost::format(_("interface %s invalid hash %s!=%s\n"))%RaveGetInterfaceName(type)%interfacehash%RaveGetInterfaceHash(type)),ORE_InvalidInterfaceHash);
+    }
+    boost::mutex::scoped_lock lock(_mutex);
+    RegisteredInterfacePtr pdata(new RegisteredInterface(type,name,createfn,shared_from_this()));
+    pdata->_iterator = _listRegisteredInterfaces.insert(_listRegisteredInterfaces.end(),pdata);
+    return pdata;
+}
+
+void RaveDatabase::_CleanupUnusedLibraries()
+{
+    FOREACH(it,_listDestroyLibraryQueue) {
+        RaveDatabase::_SysCloseLibrary(*it);
+    }
+    _listDestroyLibraryQueue.clear();
+}
+
+/// \brief Deletes the plugin from the database
+///
+/// It is safe to delete a plugin even if interfaces currently reference it because this function just decrements
+/// the reference count instead of unloading from memory.
+std::list<RaveDatabase::PluginPtr>::iterator RaveDatabase::_GetPlugin(const std::string& pluginname)
+{
+    FOREACH(it,_listplugins) {
+        if( pluginname == (*it)->ppluginname ) {
+            return it;
+        }
+    }
+#if defined(HAVE_BOOST_FILESYSTEM) && BOOST_VERSION >= 103600 // stem() was introduced in 1.36
+    // try matching partial base names without path and extension
+#if defined(BOOST_FILESYSTEM_VERSION) && BOOST_FILESYSTEM_VERSION >= 3
+    boost::filesystem::path pluginpath(pluginname);
+    std::string stem = pluginpath.stem().string();
+#else
+    boost::filesystem::path pluginpath(pluginname, boost::filesystem::native);
+    std::string stem = pluginpath.stem();
+#endif
+    FOREACH(it, _listplugins) {
+#if defined(BOOST_FILESYSTEM_VERSION) && BOOST_FILESYSTEM_VERSION >= 3
+        if( stem == boost::filesystem::path((*it)->ppluginname).stem() )
+#else
+        if( stem == boost::filesystem::path((*it)->ppluginname, boost::filesystem::native).stem() )
+#endif
+        {
+            return it;
+        }
+    }
+#endif
+    return _listplugins.end();
+}
+
+RaveDatabase::PluginPtr RaveDatabase::_LoadPlugin(const std::string& _libraryname)
+{
+    std::string libraryname = _libraryname;
+    void* plibrary = _SysLoadLibrary(libraryname,OPENRAVE_LAZY_LOADING);
+    if( plibrary == NULL ) {
+        // check if PLUGIN_EXT is missing
+        if( libraryname.find(PLUGIN_EXT) == std::string::npos ) {
+            libraryname += PLUGIN_EXT;
+            plibrary = _SysLoadLibrary(libraryname,OPENRAVE_LAZY_LOADING);
+        }
+    }
+#ifndef _WIN32
+    if( plibrary == NULL ) {
+        // unix libraries are prefixed with 'lib', first have to split
+#if defined(HAVE_BOOST_FILESYSTEM) && BOOST_VERSION >= 103600 // stem() was introduced in 1.36
+#if defined(BOOST_FILESYSTEM_VERSION) && BOOST_FILESYSTEM_VERSION >= 3
+        boost::filesystem::path _librarypath(libraryname);
+        std::string librarypath = _librarypath.parent_path().string();
+        std::string libraryfilename = _librarypath.filename().string();
+#else
+        boost::filesystem::path _librarypath(libraryname, boost::filesystem::native);
+        std::string librarypath = _librarypath.parent_path().string();
+        std::string libraryfilename = _librarypath.filename();
+#endif
+        if(( libraryfilename.size() > 3) &&( libraryfilename.substr(0,3) != std::string("lib")) ) {
+            libraryname = librarypath;
+            if( libraryname.size() > 0 ) {
+                libraryname += s_filesep;
+            }
+            libraryname += std::string("lib");
+            libraryname += libraryfilename;
+            plibrary = _SysLoadLibrary(libraryname.c_str(),OPENRAVE_LAZY_LOADING);
+        }
+#endif
+    }
+#endif
+
+#ifdef HAVE_BOOST_FILESYSTEM
+    if( plibrary == NULL ) {
+        // try adding from the current plugin libraries
+        FOREACH(itdir,_listplugindirs) {
+            std::string newlibraryname = boost::filesystem::absolute(libraryname,*itdir).string();
+            plibrary = _SysLoadLibrary(newlibraryname,OPENRAVE_LAZY_LOADING);
+            if( !!plibrary ) {
+                libraryname = newlibraryname;
+                break;
+            }
+        }
+    }
+#endif
+    if( plibrary == NULL ) {
+        RAVELOG_WARN("failed to load: %s\n", _libraryname.c_str());
+        return PluginPtr();
+    }
+
+    PluginPtr p(new Plugin(shared_from_this()));
+    p->ppluginname = libraryname;
+    p->plibrary = plibrary;
+
+    try {
+        if( !p->Load_GetPluginAttributes() ) {
+            // might not be a plugin
+            RAVELOG_VERBOSE(str(boost::format("%s: can't load GetPluginAttributes function, might not be an OpenRAVE plugin\n")%libraryname));
+            return PluginPtr();
+        }
+
+        if( p->pfnGetPluginAttributesNew != NULL ) {
+            p->pfnGetPluginAttributesNew(&p->_infocached, sizeof(p->_infocached),OPENRAVE_PLUGININFO_HASH);
+        }
+        else {
+            if( !p->pfnGetPluginAttributes(&p->_infocached, sizeof(p->_infocached)) ) {
+                RAVELOG_WARN(str(boost::format("%s: GetPluginAttributes failed\n")%libraryname));
+                return PluginPtr();
+            }
+        }
+    }
+    catch(const std::exception& ex) {
+        RAVELOG_WARN(str(boost::format("%s failed to load: %s\n")%libraryname%ex.what()));
+        return PluginPtr();
+    }
+    catch(...) {
+        RAVELOG_WARN(str(boost::format("%s: unknown exception\n")%libraryname));
+        return PluginPtr();
+    }
+
+#ifndef _WIN32
+    Dl_info info;
+    if( p->pfnGetPluginAttributesNew != NULL ) {
+        dladdr((void*)p->pfnGetPluginAttributesNew, &info);
+    }
+    else {
+        dladdr((void*)p->pfnGetPluginAttributes, &info);
+    }
+    RAVELOG_DEBUG("loading plugin: %s\n", info.dli_fname);
+#endif
+
+    p->_bInitializing = false;
+    if( OPENRAVE_LAZY_LOADING ) {
+        // have confirmed that plugin is ok, so reload with no-lazy loading
+        p->plibrary = NULL;     // NOTE: for some reason, closing the lazy loaded library can make the system crash, so instead keep the pointer around, but create a new one with RTLD_NOW
+        p->Destroy();
+        p->_bShutdown = false;
+    }
+
+    p->OnRaveInitialized(); // openrave runtime is most likely loaded already, so can safely initialize
+    return p;
+}
+
+void* RaveDatabase::_SysLoadLibrary(const std::string& lib, bool bLazy)
+{
+    // check if file exists first
+    if( !ifstream(lib.c_str()) ) {
+        return NULL;
+    }
+#ifdef _WIN32
+    void* plib = LoadLibraryA(lib.c_str());
+    if( plib == NULL ) {
+        RAVELOG_WARN("Failed to load %s\n", lib.c_str());
+    }
+#else
+    dlerror();     // clear error
+    void* plib = dlopen(lib.c_str(), bLazy ? RTLD_LAZY : RTLD_NOW);
+    char* pstr = dlerror();
+    if( pstr != NULL ) {
+        RAVELOG_WARN("%s: %s\n",lib.c_str(),pstr);
+        if( plib != NULL ) {
+            dlclose(plib);     //???
+        }
+        return NULL;
+    }
+#endif
+    return plib;
+}
+
+void* RaveDatabase::_SysLoadSym(void* lib, const std::string& sym)
+{
+#ifdef _WIN32
+    return GetProcAddress((HINSTANCE)lib, sym.c_str());
+#else
+    dlerror();     // clear existing error
+    void* psym = dlsym(lib, sym.c_str());
+    char* errorstring = dlerror();
+    if( errorstring != NULL ) {
+        return psym;
+    }
+    if( psym != NULL ) {
+        // check for errors if something valid is returned since we'll be executing it
+        if( errorstring != NULL ) {
+            throw openrave_exception(errorstring,ORE_InvalidPlugin);
+        }
+    }
+    return psym;
+#endif
+}
+
+void RaveDatabase::_SysCloseLibrary(void* lib)
+{
+#ifdef _WIN32
+    FreeLibrary((HINSTANCE)lib);
+#else
+    // can segfault if opened library clashes with other
+    // need to use some combination of setjmp, longjmp to get this to work corectly
+    //sighandler_t tprev = signal(SIGSEGV,fault_handler);
+    dlclose(lib);
+    //signal(SIGSEGV,tprev);
+#endif
+}
+
+void RaveDatabase::_QueueLibraryDestruction(void* lib)
+{
+    _listDestroyLibraryQueue.push_back(lib);
+}
+
+void RaveDatabase::_InterfaceDestroyCallbackShared(void const* pinterface)
+{
+    if( pinterface != NULL ) {
+    }
+}
+
+/// \brief makes sure plugin is in scope until after pointer is completely deleted
+void RaveDatabase::_InterfaceDestroyCallbackSharedPost(std::string name, UserDataPtr plugin)
+{
+    // post-processing for deleting interfaces
+    plugin.reset();
+}
+
+void RaveDatabase::_AddToLoader(PluginPtr p)
+{
+    boost::mutex::scoped_lock lock(_mutexPluginLoader);
+    _listPluginsToLoad.push_back(p);
+    _condLoaderHasWork.notify_all();
+}
+
+void RaveDatabase::_PluginLoaderThread()
+{
+    while(!_bShutdown) {
+        std::list<PluginPtr> listPluginsToLoad;
+        {
+            boost::mutex::scoped_lock lock(_mutexPluginLoader);
+            if( _listPluginsToLoad.empty() ) {
+                _condLoaderHasWork.wait(lock);
+                if( _bShutdown ) {
+                    break;
+                }
+            }
+            listPluginsToLoad.swap(_listPluginsToLoad);
+        }
+        FOREACH(itplugin,listPluginsToLoad) {
+            if( _bShutdown ) {
+                break;
+            }
+            boost::mutex::scoped_lock lockplugin((*itplugin)->_mutex);
+            if( _bShutdown ) {
+                break;
+            }
+            (*itplugin)->plibrary = _SysLoadLibrary((*itplugin)->ppluginname,false);
+            if( (*itplugin)->plibrary == NULL ) {
+                // for some reason cannot load the library, so shut it down
+                (*itplugin)->_bShutdown = true;
+            }
+            (*itplugin)->_cond.notify_all();
+        }
+    }
+}
+
+} // namespace OpenRAVE
+
+#endif // RAVE_PLUGIN_DATABASE_IMPL_H


### PR DESCRIPTION
Part of the changes I'm making to implement a statically linked plugin database.

In this change, the original plugin database implementation is split into a compilation unit (as opposed to the previous header-only implementation) to facilitate the next set of changes. This is done so that each step of changes is easy to understand and review. Aside from a bit of rearrangement of code, there are no logic changes.

pipeline ID: 257006