### PR TITLE
add __hash__ for all classes comparing pointer. fixed the hash type to long.

### DIFF
--- a/python/bindings/include/openravepy/openravepy_environmentbase.h
+++ b/python/bindings/include/openravepy/openravepy_environmentbase.h
@@ -332,6 +332,7 @@ public:
 
     bool __eq__(PyEnvironmentBasePtr p);
     bool __ne__(PyEnvironmentBasePtr p);
+    long __hash__();
     std::string __repr__();
     std::string __str__();
     object __unicode__();

--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -683,8 +683,8 @@ public:
     virtual py::object __unicode__() {
         return ConvertStringToUnicode(__str__());
     }
-    virtual int __hash__() {
-        return static_cast<int>(uintptr_t(_pbase.get()));
+    virtual long __hash__() {
+        return static_cast<long>(uintptr_t(_pbase.get()));
     }
     virtual bool __eq__(PyInterfaceBasePtr p) {
         return !!p && _pbase == p->GetInterfaceBase();

--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -274,7 +274,7 @@ public:
         object ComputeInnerEmptyVolume() const;
         bool __eq__(OPENRAVE_SHARED_PTR<PyGeometry> p);
         bool __ne__(OPENRAVE_SHARED_PTR<PyGeometry> p);
-        int __hash__();
+        long __hash__();
     };
 
     PyLink(KinBody::LinkPtr plink, PyEnvironmentBasePtr pyenv);
@@ -373,7 +373,7 @@ public:
     object __unicode__();
     bool __eq__(OPENRAVE_SHARED_PTR<PyLink> p);
     bool __ne__(OPENRAVE_SHARED_PTR<PyLink> p);
-    int __hash__();
+    long __hash__();
 };
 
 class PyJoint
@@ -487,7 +487,7 @@ public:
     object __unicode__();
     bool __eq__(OPENRAVE_SHARED_PTR<PyJoint> p);
     bool __ne__(OPENRAVE_SHARED_PTR<PyJoint> p);
-    int __hash__();
+    long __hash__();
 };
 
 class PyKinBodyStateSaver
@@ -536,6 +536,7 @@ public:
     object __unicode__();
     bool __eq__(OPENRAVE_SHARED_PTR<PyManageData> p);
     bool __ne__(OPENRAVE_SHARED_PTR<PyManageData> p);
+    long __hash__();
 };
 typedef OPENRAVE_SHARED_PTR<PyManageData> PyManageDataPtr;
 typedef OPENRAVE_SHARED_PTR<PyManageData const> PyManageDataConstPtr;

--- a/python/bindings/include/openravepy/openravepy_plannerbase.h
+++ b/python/bindings/include/openravepy/openravepy_plannerbase.h
@@ -123,6 +123,7 @@ public:
         object __unicode__();
         bool __eq__(OPENRAVE_SHARED_PTR<PyPlannerParameters> p);
         bool __ne__(OPENRAVE_SHARED_PTR<PyPlannerParameters> p);
+        long __hash__();
     };
 
     typedef OPENRAVE_SHARED_PTR<PyPlannerParameters> PyPlannerParametersPtr;

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -2842,6 +2842,9 @@ bool PyEnvironmentBase::__eq__(PyEnvironmentBasePtr p) {
 bool PyEnvironmentBase::__ne__(PyEnvironmentBasePtr p) {
     return !p || _penv!=p->_penv;
 }
+long PyEnvironmentBase::__hash__() {
+    return static_cast<long>(uintptr_t(_penv.get()));
+}
 std::string PyEnvironmentBase::__repr__() {
     return boost::str(boost::format("RaveGetEnvironment(%d)")%RaveGetEnvironmentId(_penv));
 }
@@ -3674,6 +3677,7 @@ Because race conditions can pop up when trying to lock the openrave environment 
                      .def("GetUInt64Parameter", &PyEnvironmentBase::GetUInt64Parameter, PY_ARGS("parameterName", "defaultValue") DOXY_FN(EnvironmentBase,GetUInt64Parameter))
                      .def("__enter__",&PyEnvironmentBase::__enter__)
                      .def("__exit__",&PyEnvironmentBase::__exit__)
+                     .def("__hash__",&PyEnvironmentBase::__hash__)
                      .def("__eq__",&PyEnvironmentBase::__eq__)
                      .def("__ne__",&PyEnvironmentBase::__ne__)
                      .def("__repr__",&PyEnvironmentBase::__repr__)

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -1334,8 +1334,8 @@ bool PyLink::PyGeometry::__eq__(OPENRAVE_SHARED_PTR<PyGeometry> p) {
 bool PyLink::PyGeometry::__ne__(OPENRAVE_SHARED_PTR<PyGeometry> p) {
     return !p || _pgeometry != p->_pgeometry;
 }
-int PyLink::PyGeometry::__hash__() {
-    return static_cast<int>(uintptr_t(_pgeometry.get()));
+long PyLink::PyGeometry::__hash__() {
+    return static_cast<long>(uintptr_t(_pgeometry.get()));
 }
 
 PyLink::PyLink(KinBody::LinkPtr plink, PyEnvironmentBasePtr pyenv) : _plink(plink), _pyenv(pyenv) {
@@ -1695,8 +1695,8 @@ bool PyLink::__eq__(OPENRAVE_SHARED_PTR<PyLink> p) {
 bool PyLink::__ne__(OPENRAVE_SHARED_PTR<PyLink> p) {
     return !p || _plink != p->_plink;
 }
-int PyLink::__hash__() {
-    return static_cast<int>(uintptr_t(_plink.get()));
+long PyLink::__hash__() {
+    return static_cast<long>(uintptr_t(_plink.get()));
 }
 
 PyLinkPtr toPyLink(KinBody::LinkPtr plink, PyEnvironmentBasePtr pyenv)
@@ -2053,8 +2053,8 @@ bool PyJoint::__eq__(OPENRAVE_SHARED_PTR<PyJoint> p) {
 bool PyJoint::__ne__(OPENRAVE_SHARED_PTR<PyJoint> p) {
     return !p || _pjoint!=p->_pjoint;
 }
-int PyJoint::__hash__() {
-    return static_cast<int>(uintptr_t(_pjoint.get()));
+long PyJoint::__hash__() {
+    return static_cast<long>(uintptr_t(_pjoint.get()));
 }
 
 PyJointPtr toPyJoint(KinBody::JointPtr pjoint, PyEnvironmentBasePtr pyenv)
@@ -2173,6 +2173,9 @@ bool PyManageData::__eq__(OPENRAVE_SHARED_PTR<PyManageData> p) {
 }
 bool PyManageData::__ne__(OPENRAVE_SHARED_PTR<PyManageData> p) {
     return !p || _pdata!=p->_pdata;
+}
+long PyManageData::__hash__() {
+    return static_cast<long>(uintptr_t(_pdata.get()));
 }
 
 PyKinBody::PyGrabbedInfo::PyGrabbedInfo() {
@@ -6081,6 +6084,7 @@ void init_openravepy_kinbody()
                                 .def("__unicode__", &PyManageData::__unicode__)
                                 .def("__eq__",&PyManageData::__eq__)
                                 .def("__ne__",&PyManageData::__ne__)
+                                .def("__hash__",&PyManageData::__hash__)
             ;
         }
     }

--- a/python/bindings/openravepy_planner.cpp
+++ b/python/bindings/openravepy_planner.cpp
@@ -283,6 +283,9 @@ bool PyPlannerBase::PyPlannerParameters::__eq__(OPENRAVE_SHARED_PTR<PyPlannerPar
 bool PyPlannerBase::PyPlannerParameters::__ne__(OPENRAVE_SHARED_PTR<PyPlannerParameters> p) {
     return !p || _paramsread != p->_paramsread;
 }
+long PyPlannerBase::PyPlannerParameters::__hash__() {
+    return static_cast<long>(uintptr_t(_paramsread.get()));
+}
 
 typedef OPENRAVE_SHARED_PTR<PyPlannerBase::PyPlannerParameters> PyPlannerParametersPtr;
 typedef OPENRAVE_SHARED_PTR<PyPlannerBase::PyPlannerParameters const> PyPlannerParametersConstPtr;
@@ -571,6 +574,7 @@ void init_openravepy_planner()
         .def("__repr__",&PyPlannerBase::PyPlannerParameters::__repr__)
         .def("__eq__",&PyPlannerBase::PyPlannerParameters::__eq__)
         .def("__ne__",&PyPlannerBase::PyPlannerParameters::__ne__)
+        .def("__hash__",&PyPlannerBase::PyPlannerParameters::__hash__)
         ;
     }
 


### PR DESCRIPTION
some tasks uses env as dict key, so env should implement `__hash__`. also, openravepy_robotbase.h uses long as `__hash__` return type and others should use long as well.

----

pipelineid=259984