### PR TITLE
Virtualize the interface of RaveDatabase

### DIFF
--- a/include/openrave/interface.h
+++ b/include/openrave/interface.h
@@ -349,7 +349,7 @@ private:
 #endif
 #endif
     friend class ColladaReader;
-    friend class RaveDatabase;
+    friend class DynamicRaveDatabase;
 };
 
 } // end namespace OpenRAVE

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -3496,7 +3496,7 @@ private:
     friend class CollisionCheckerBase;
     friend class ViewerBase;
     friend class SensorSystemBase;
-    friend class RaveDatabase;
+    friend class DynamicRaveDatabase;
     friend class ChangeCallbackData;
     friend class Grabbed;
 };

--- a/include/openrave/robot.h
+++ b/include/openrave/robot.h
@@ -1416,7 +1416,7 @@ private:
 #endif
     friend class ColladaWriter;
     friend class ColladaReader;
-    friend class RaveDatabase;
+    friend class DynamicRaveDatabase;
     friend class Grabbed;
 };
 

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -444,7 +444,7 @@ public:
         }
 
         // since initialization depends on _pdatabase, have pdatabase be local until it is complete
-        boost::shared_ptr<RaveDatabase> pdatabase(new RaveDatabase());
+        boost::shared_ptr<RaveDatabase> pdatabase = boost::make_shared<DynamicRaveDatabase>();
         if( !pdatabase->Init(bLoadAllPlugins) ) {
             RAVELOG_FATAL("failed to create the openrave plugin database\n");
         }

--- a/src/libopenrave/plugindatabase.cpp
+++ b/src/libopenrave/plugindatabase.cpp
@@ -422,7 +422,7 @@ void Plugin::_confirmLibrary()
     }
 }
 
-RaveDatabase::RegisteredInterface::RegisteredInterface(InterfaceType type, const std::string& name, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn, boost::shared_ptr<RaveDatabase> database)
+RegisteredInterface::RegisteredInterface(InterfaceType type, const std::string& name, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn, boost::shared_ptr<RaveDatabase> database)
     : _type(type)
     , _name(name)
     , _createfn(createfn)
@@ -430,7 +430,7 @@ RaveDatabase::RegisteredInterface::RegisteredInterface(InterfaceType type, const
 {
 }
 
-RaveDatabase::RegisteredInterface::~RegisteredInterface()
+RegisteredInterface::~RegisteredInterface()
 {
     boost::shared_ptr<RaveDatabase> database = _database.lock();
     if( !!database ) {

--- a/src/libopenrave/plugindatabase.cpp
+++ b/src/libopenrave/plugindatabase.cpp
@@ -172,7 +172,7 @@ void Plugin::Destroy()
     }
     else {
         if( plibrary ) {
-            Load_DestroyPlugin();
+            _Load_DestroyPlugin();
         }
         std::lock_guard<std::mutex> lock(_mutex);
         // do some more checking here, there still might be instances of robots, planners, and sensors out there
@@ -214,7 +214,7 @@ bool Plugin::GetInfo(PLUGININFO& info)
     return true;
 }
 
-bool Plugin::Load_CreateInterfaceGlobal()
+bool Plugin::_Load_CreateInterfaceGlobal()
 {
     _confirmLibrary();
     if ((pfnCreateNew == NULL) &&( pfnCreate == NULL)) {
@@ -239,7 +239,7 @@ bool Plugin::Load_CreateInterfaceGlobal()
     return pfnCreateNew != NULL || pfnCreate != NULL;
 }
 
-bool Plugin::Load_GetPluginAttributes()
+bool Plugin::_Load_GetPluginAttributes()
 {
     _confirmLibrary();
     if ((pfnGetPluginAttributesNew == NULL) || (pfnGetPluginAttributes == NULL)) {
@@ -263,7 +263,7 @@ bool Plugin::Load_GetPluginAttributes()
     return pfnGetPluginAttributesNew != NULL || pfnGetPluginAttributes != NULL;
 }
 
-bool Plugin::Load_DestroyPlugin()
+bool Plugin::_Load_DestroyPlugin()
 {
     _confirmLibrary();
     if( pfnDestroyPlugin == NULL ) {
@@ -283,7 +283,7 @@ bool Plugin::Load_DestroyPlugin()
     return pfnDestroyPlugin != NULL;
 }
 
-bool Plugin::Load_OnRaveInitialized()
+bool Plugin::_Load_OnRaveInitialized()
 {
     _confirmLibrary();
     if( pfnOnRaveInitialized == NULL ) {
@@ -303,7 +303,7 @@ bool Plugin::Load_OnRaveInitialized()
     return pfnOnRaveInitialized!=NULL;
 }
 
-bool Plugin::Load_OnRavePreDestroy()
+bool Plugin::_Load_OnRavePreDestroy()
 {
     _confirmLibrary();
     if( pfnOnRavePreDestroy == NULL ) {
@@ -352,7 +352,7 @@ InterfaceBasePtr Plugin::CreateInterface(InterfaceType type, const std::string& 
     }
 
     try {
-        if( !Load_CreateInterfaceGlobal() ) {
+        if( !_Load_CreateInterfaceGlobal() ) {
             throw openrave_exception(str(boost::format(_("%s: can't load CreateInterface function\n"))%ppluginname),ORE_InvalidPlugin);
         }
         InterfaceBasePtr pinterface;
@@ -385,7 +385,7 @@ InterfaceBasePtr Plugin::CreateInterface(InterfaceType type, const std::string& 
 
 void Plugin::OnRaveInitialized()
 {
-    if( Load_OnRaveInitialized() ) {
+    if( _Load_OnRaveInitialized() ) {
         if( !!pfnOnRaveInitialized && !_bHasCalledOnRaveInitialized ) {
             pfnOnRaveInitialized();
             _bHasCalledOnRaveInitialized = true;
@@ -395,7 +395,7 @@ void Plugin::OnRaveInitialized()
 
 void Plugin::OnRavePreDestroy()
 {
-    if( Load_OnRavePreDestroy() ) {
+    if( _Load_OnRavePreDestroy() ) {
         // always call destroy regardless of initialization state (safest)
         if( !!pfnOnRavePreDestroy ) {
             pfnOnRavePreDestroy();
@@ -979,7 +979,7 @@ PluginPtr RaveDatabase::_LoadPlugin(const std::string& _libraryname)
     p->plibrary = plibrary;
 
     try {
-        if( !p->Load_GetPluginAttributes() ) {
+        if( !p->_Load_GetPluginAttributes() ) {
             // might not be a plugin
             RAVELOG_VERBOSE(str(boost::format("%s: can't load GetPluginAttributes function, might not be an OpenRAVE plugin\n")%libraryname));
             return PluginPtr();

--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -56,16 +56,6 @@ public:
 
     bool GetInfo(PLUGININFO& info);
 
-    virtual bool Load_CreateInterfaceGlobal();
-
-    virtual bool Load_GetPluginAttributes();
-
-    virtual bool Load_DestroyPlugin();
-
-    virtual bool Load_OnRaveInitialized();
-
-    virtual bool Load_OnRavePreDestroy();
-
     bool HasInterface(InterfaceType type, const std::string& name);
 
     InterfaceBasePtr CreateInterface(InterfaceType type, const std::string& name, const char* interfacehash, EnvironmentBasePtr penv);
@@ -76,6 +66,16 @@ public:
     void OnRavePreDestroy();
 
 protected:
+    virtual bool _Load_CreateInterfaceGlobal();
+
+    virtual bool _Load_GetPluginAttributes();
+
+    virtual bool _Load_DestroyPlugin();
+
+    virtual bool _Load_OnRaveInitialized();
+
+    virtual bool _Load_OnRavePreDestroy();
+
     /// if the library is not loaded yet, wait for it.
     void _confirmLibrary();
 

--- a/src/libopenrave/plugindatabase.h
+++ b/src/libopenrave/plugindatabase.h
@@ -103,25 +103,28 @@ protected:
 typedef boost::shared_ptr<Plugin> PluginPtr;
 typedef boost::shared_ptr<Plugin const> PluginConstPtr;
 
+struct RegisteredInterface : public UserData
+{
+    friend class RaveDatabase;
+
+    RegisteredInterface(InterfaceType type, const std::string& name, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn, boost::shared_ptr<RaveDatabase> database);
+    virtual ~RegisteredInterface();
+
+    InterfaceType _type;
+    std::string _name;
+    boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)> _createfn;
+    std::list< boost::weak_ptr<RegisteredInterface> >::iterator _iterator;
+protected:
+    boost::weak_ptr<RaveDatabase> _database;
+};
+typedef boost::shared_ptr<RegisteredInterface> RegisteredInterfacePtr;
+
 /// \brief database of interfaces from plugins
 class RaveDatabase : public boost::enable_shared_from_this<RaveDatabase>
 {
-    struct RegisteredInterface : public UserData
-    {
-        RegisteredInterface(InterfaceType type, const std::string& name, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn, boost::shared_ptr<RaveDatabase> database);
-        virtual ~RegisteredInterface();
-
-        InterfaceType _type;
-        std::string _name;
-        boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)> _createfn;
-        std::list< boost::weak_ptr<RegisteredInterface> >::iterator _iterator;
-    protected:
-        boost::weak_ptr<RaveDatabase> _database;
-    };
-    typedef boost::shared_ptr<RegisteredInterface> RegisteredInterfacePtr;
-
 public:
     friend class Plugin;
+    friend class RegisteredInterface;
 
     RaveDatabase();
     virtual ~RaveDatabase();

--- a/src/libopenrave/plugindatabase_virtual.h
+++ b/src/libopenrave/plugindatabase_virtual.h
@@ -1,0 +1,103 @@
+// -*- coding: utf-8 -*-
+// Copyright (C) 2022 Rosen Diankov (rdiankov@cs.cmu.edu)
+//
+// This file is part of OpenRAVE.
+// OpenRAVE is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#ifndef RAVE_PLUGIN_DATABASE_VIRTUAL_H
+#define RAVE_PLUGIN_DATABASE_VIRTUAL_H
+
+#include "openrave/openrave.h"
+
+namespace OpenRAVE {
+
+class RegisteredInterface;
+
+class PluginBase : public UserData
+{
+public:
+    virtual ~PluginBase() {}
+    virtual void Destroy() = 0;
+    virtual bool IsValid() = 0;
+    virtual const std::string& GetName() const = 0;
+    virtual bool GetInfo(PLUGININFO& info) = 0;
+    virtual bool HasInterface(InterfaceType type, const std::string& name) = 0;
+    virtual InterfaceBasePtr CreateInterface(InterfaceType type, const std::string& name, const char* interfacehash, EnvironmentBasePtr penv) = 0;
+    virtual void OnRaveInitialized() = 0;
+    virtual void OnRavePreDestroy() = 0;
+};
+
+class RaveDatabase
+{
+public:
+    friend class RegisteredInterface;
+    virtual ~RaveDatabase() {}
+
+    virtual bool Init(bool bLoadAllPlugins) = 0;
+    virtual void Destroy() = 0;
+    //virtual void GetPlugins(std::list<PluginPtr>& listplugins) const = 0;
+    virtual InterfaceBasePtr Create(EnvironmentBasePtr penv, InterfaceType type, const std::string& _name) = 0;
+    //virtual bool AddDirectory(const std::string& pdir) = 0;
+    virtual void ReloadPlugins() = 0;
+    virtual void OnRaveInitialized() = 0;
+    virtual void OnRavePreDestroy() = 0;
+    virtual bool LoadPlugin(const std::string& pluginname) = 0;
+    virtual bool RemovePlugin(const std::string& pluginname) = 0;
+    virtual bool HasInterface(InterfaceType type, const std::string& interfacename) = 0;
+    virtual void GetPluginInfo(std::list< std::pair<std::string, PLUGININFO> >& plugins) const = 0;
+    virtual void GetLoadedInterfaces(std::map<InterfaceType, std::vector<std::string> >& interfacenames) const = 0;
+    virtual UserDataPtr RegisterInterface(InterfaceType type, const std::string& name, const char* interfacehash, const char* envhash, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn) = 0;
+
+    // Locks the mutex of this database and return the lock.
+    inline std::unique_lock<std::mutex> Lock() const noexcept {
+        return std::unique_lock<std::mutex>(_mutex);
+    }
+
+protected:
+    mutable std::mutex _mutex; ///< changing plugin database
+
+    std::list<boost::weak_ptr<RegisteredInterface>> _listRegisteredInterfaces;
+};
+
+struct RegisteredInterface : public UserData
+{
+    RegisteredInterface(InterfaceType type, const std::string& name, const boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)>& createfn, boost::shared_ptr<RaveDatabase> database)
+        : UserData()
+        , _type(type)
+        , _name(name)
+        , _createfn(createfn)
+        , _database(database)
+    {
+    }
+
+    virtual ~RegisteredInterface()
+    {
+        boost::shared_ptr<RaveDatabase> database = _database.lock();
+        if( !!database ) {
+            std::unique_lock<std::mutex> lock = database->Lock();
+            database->_listRegisteredInterfaces.erase(_iterator);
+        }
+    }
+
+    InterfaceType _type;
+    std::string _name;
+    boost::function<InterfaceBasePtr(EnvironmentBasePtr, std::istream&)> _createfn;
+    std::list< boost::weak_ptr<RegisteredInterface> >::iterator _iterator;
+protected:
+    boost::weak_ptr<RaveDatabase> _database;
+};
+typedef boost::shared_ptr<RegisteredInterface> RegisteredInterfacePtr;
+
+} // namespace OpenRAVE
+
+#endif // RAVE_PLUGIN_DATABASE_VIRTUAL_H


### PR DESCRIPTION
We want to make it an option to statically compile certain plugins. To do that we have to make an alternative RaveDatabase implementation, and to achieve this I need to make the interfaces of RaveDatabase and Plugins virtual, and the current (dynamic/shared obj) RaveDatabase should inherit from this pure virtual class.

- The `Load_XXX` methods used to load functions from shared objects is now protected, in order to minimize the PluginBase virtual class (since statically loaded plugins have no use for these). Calling these methods from outside the influence of RaveDatabase is probably a misuse of API anyway.

- RegisteredInterface has been lifted out of RaveDatabase, since the static version will need to use it as well.

- Encapsulated access to the mutex in RaveDatabase, so that RegisteredInterface can lock it from a base class.

Created in file plugindatabase_virtual.h (name subj to change):
`RaveDatabase` - extracted base class of original RaveDatabase now renamed to DynamicRaveDatabase
`PluginBase` - extracted base class of Plugin
`RegisteredInterface`, moved from previous location

Pipeline #347801