### PR TITLE
Propagate geometry name when the robot.xml is loaded

### DIFF
--- a/src/libopenrave-core/xmlreaders-core.cpp
+++ b/src/libopenrave-core/xmlreaders-core.cpp
@@ -1053,6 +1053,7 @@ public:
                             listGeometryInfos.front()._vCollisionScale = info->_vCollisionScale*geomspacescale;
                             listGeometryInfos.front()._filenamecollision = info->_filenamecollision;
                             listGeometryInfos.front()._bVisible = info->_bVisible;
+                            listGeometryInfos.front()._name = info->_name;
                             FOREACH(itinfo, listGeometryInfos) {
                                 _plink->_vGeometries.push_back(KinBody::Link::GeometryPtr(new KinBody::Link::Geometry(_plink,*itinfo)));
                             }


### PR DESCRIPTION
- geometry name in `robot.xml` is not propagated and resultant geometry name is always empty. this PR fixes it.
- not fully sure whether it needs to set the names to all of `listGeometryInfos`, or it's ok to set `listGeometryInfo.front()`. for now, i set the name to `front`.