### PR TITLE
Check vec bodies get robot

### DIFF
--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -1225,6 +1225,9 @@ public:
         }
 
         SharedLock lock412(_mutexInterfaces);
+        if (_vecbodies.empty()) {
+            return RobotBasePtr();
+        }
         const int envBodyIndex = _FindBodyIndexByName(pname);
         const KinBodyPtr& pbody = _vecbodies.at(envBodyIndex);
         if (!!pbody && pbody->IsRobot()) {


### PR DESCRIPTION
https://github.com/rdiankov/openrave/commit/a27dc20256f419c6a6ed6a0b4c4d8a821b78c071#diff-c5c3a9bad867a7032c72acc1708c24dde1866ad3d1c43ae5fca006461105f850R1127 had to be added to GetRobot as well.

```
openrave.py -i

env.GetRobot('foo')
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
openrave.py in <module>()
----> 1 env.GetRobot('foo')

IndexError: vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
```

it happens if test code's env.Load fails.

(env.Load failure could raise exception, but it is another topic. anyway, this exception message is not informative.)