### PR TITLE
prohibit missing return

### DIFF
--- a/3rdparty/convexdecomposition/NvHashMap.h
+++ b/3rdparty/convexdecomposition/NvHashMap.h
@@ -1351,7 +1351,7 @@ namespace CONVEX_DECOMPOSITION
 	to choose from.  I only looked at a billion or so.
 	--------------------------------------------------------------------
 	*/
-	NX_INLINE NxU32 hashMix(NxU32 &a, NxU32 &b, NxU32 &c)
+	NX_INLINE void hashMix(NxU32 &a, NxU32 &b, NxU32 &c)
 	{
 		a -= b; a -= c; a ^= (c>>13);
 		b -= c; b -= a; b ^= (a<<8);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ endif()
 
 if( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG)
   add_definitions("-fno-strict-aliasing -Wall -Werror=shadow")
+  add_definitions("-Werror=return-type")
 endif()
 
 set(OPENRAVE_EXPORT_CXXFLAGS)


### PR DESCRIPTION
Overview
===============

- This MR adds ``-Werror=return-type`` to compiler option to fail to build functions without proper return.

Background
===============

- I ran into an mysterious segfault with function missing proper return.
- I think there was a behavior change in g++ around how it treats following code, somewhere between version 7.5.0 and 8.4.0.

```c++
#include <iostream>

bool SomeFunc(int& i)
{
    std::cout << i << std::endl;
    if (i > 0) {
        i--;
        SomeFunc(i);
    }
    //return true;
}

int main()
{
    int i = 1;
    SomeFunc(i);
    return 0;
}
```
without return, 
  - g++ 8.4 without optimization -> fine
  - g++ 8.4 with ``O2`` -> segfault
  - g++ 7.5 with ``O2`` -> fine
