### PR TITLE
Fix so import on Py3

### DIFF
--- a/python/__init__.py.in
+++ b/python/__init__.py.in
@@ -37,9 +37,6 @@ else:
 if openravepy_currentversion is not None:
     from sys import modules
     modules['openravepy'] = openravepy_currentversion
-    # caused modules reloaded; has to reimport sys.modules
-    del modules
-    from sys import modules
     from sys import version_info
     from types import ModuleType
     if version_info[0] >= 3:

--- a/python/__init__.py.in
+++ b/python/__init__.py.in
@@ -26,8 +26,6 @@ def _loadversion(targetname):
 
 from platform import system
 from sys import platform
-from sys import version_info
-from types import ModuleType
 if platform.startswith('win') or system().lower() == 'windows':
     openravepy_currentversion = loadlatest()
 else:
@@ -39,6 +37,11 @@ else:
 if openravepy_currentversion is not None:
     from sys import modules
     modules['openravepy'] = openravepy_currentversion
+    # caused modules reloaded; has to reimport sys.modules
+    del modules
+    from sys import modules
+    from sys import version_info
+    from types import ModuleType
     if version_info[0] >= 3:
         # have to resolve so modules so that they are not initialized twice
         for name, value in modules['openravepy'].__dict__.items():

--- a/python/__init__.py.in
+++ b/python/__init__.py.in
@@ -26,6 +26,8 @@ def _loadversion(targetname):
 
 from platform import system
 from sys import platform
+from sys import version_info
+from types import ModuleType
 if platform.startswith('win') or system().lower() == 'windows':
     openravepy_currentversion = loadlatest()
 else:
@@ -37,6 +39,12 @@ else:
 if openravepy_currentversion is not None:
     from sys import modules
     modules['openravepy'] = openravepy_currentversion
+    if version_info[0] >= 3:
+        # have to resolve so modules so that they are not initialized twice
+        for name, value in modules['openravepy'].__dict__.items():
+            if isinstance(value, ModuleType):
+                if hasattr(value, '__file__') and value.__file__.endswith(('.so', '.pyd')):
+                    modules['openravepy.' + name] = value
 
 # necessary in order to generate documentation
 try:


### PR DESCRIPTION
otherwise we will get strange error on Py3:

```
In [1]: from openravepy import interfaces

In [2]: import openravepy.interfaces
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-2-9cacc8e081f9> in <module>
----> 1 import openravepy.interfaces

/usr/local/lib/python3.9/dist-packages/openravepy/_openravepy_/interfaces/__init__.py in <module>
      1 """Interface bindings
      2 """
----> 3 from .BaseManipulation import BaseManipulation
      4 from .Grasper import Grasper
      5 from .TaskManipulation import TaskManipulation

/usr/local/lib/python3.9/dist-packages/openravepy/_openravepy_/interfaces/BaseManipulation.py in <module>
     14 __license__ = 'Apache License, Version 2.0'
     15 # python 2.5 raises 'import *' not allowed with 'from .'
---> 16 from ..openravepy_int import RaveCreateModule, RaveCreateTrajectory, matrixSerialization, IkParameterization
     17 from .. import PlanningError
     18 

ImportError: generic_type: type "Environment" is already registered!
```