### PR TITLE
Check parentFilename before constructing an invalid uri out of it.

### DIFF
--- a/src/libopenrave-core/jsonparser/jsonreader.cpp
+++ b/src/libopenrave-core/jsonparser/jsonreader.cpp
@@ -128,7 +128,9 @@ static std::string CanonicalizeURI(const std::string& suburi, const std::string&
             ParseURI(parentUri, scheme2, path2, fragment2);
             return scheme2 + ":" + path2 + "#" + fragment;
         }
-        return std::string("file:") + parentFilename + "#" + fragment;
+        if (!parentFilename.empty()) {
+            return std::string("file:") + parentFilename + "#" + fragment;
+        }
     }
     return suburi;
 }


### PR DESCRIPTION
Prevent the creation of uri such as `file:#123` that breaks many systems.

`_filename` is not always set depending on how the environment is loaded. If the scene didn't come from a file probably the correct thing to do is preserve its original uri.