### PR TITLE
Fix self collision check edge case

### DIFF
--- a/plugins/fclrave/fclspace.h
+++ b/plugins/fclrave/fclspace.h
@@ -619,7 +619,7 @@ public:
         if( !!pinfo ) {
             return GetLinkBV(*pinfo, index);
         } else {
-            RAVELOG_WARN(str(boost::format("KinBody %s is not initialized in fclspace %s, env %d")%body.GetName()%_userdatakey%_penv->GetId()));
+            RAVELOG_WARN(str(boost::format("env=%s, KinBody '%s' is not initialized in fclspace %s (self=%d)")%_penv->GetNameId()%body.GetName()%_userdatakey%_bIsSelfCollisionChecker));
             return CollisionObjectPtr();
         }
     }

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -3974,6 +3974,13 @@ void KinBody::SetSelfCollisionChecker(CollisionCheckerBasePtr collisionchecker)
         if( !!_selfcollisionchecker && _selfcollisionchecker != GetEnv()->GetCollisionChecker() ) {
             // collision checking will not be automatically updated with environment calls, so need to do this manually
             _selfcollisionchecker->InitKinBody(shared_kinbody());
+
+            // self collision checker initializes internal data structure at the time of grab, so need to do it here for newly set self collision checker.
+            std::vector<KinBodyPtr> vGrabbed;
+            GetGrabbed(vGrabbed);
+            for (const KinBodyPtr& pgrabbed : vGrabbed) {
+                _selfcollisionchecker->InitKinBody(pgrabbed);
+            }
         }
     }
 }


### PR DESCRIPTION
Overview
=========

Under following scenario, self collision check between grabbed part and robot does not work properly.

0. Initially, robot has no self collision checker
1. robot grabs a body
2. set self collision checker to robot
3. self collision check does not work properly for grabbed part

Problem
=========
Following code in ``KinBody::Grab`` is responsible for initializing self collision checker's info for grabbed body.
```
    if( !!_selfcollisionchecker && _selfcollisionchecker != GetEnv()->GetCollisionChecker() ) {
        // collision checking will not be automatically updated with environment calls, so need to do this manually
        _selfcollisionchecker->InitKinBody(pGrabbedBody);
    }
```
However, when self collision checker is set after grab, ``InitKinBody`` for the grabbed body does not happen and self collision check does not work properly.

