### PR TITLE
Fix compile errors

### DIFF
--- a/src/libopenrave-core/jsonparser/jsonreader.cpp
+++ b/src/libopenrave-core/jsonparser/jsonreader.cpp
@@ -23,6 +23,7 @@
 #include <openrave/openravejson.h>
 #include <openrave/openravemsgpack.h>
 #include <openrave/openrave.h>
+#include <openrave/openraveexception.h>
 #include <rapidjson/istreamwrapper.h>
 #include <string>
 #include <fstream>
@@ -165,7 +166,7 @@ public:
 #if OPENRAVE_CURL
                 _pDownloader = boost::make_shared<JSONDownloader>(_rapidJSONDocuments, itatt->second, _vOpenRAVESchemeAliases);
 #else
-                throw OPENRAVE_EXCEPTION_FORMAT("\"remoteurl\" option is not supported, have to compile openrave with CURL support first", filename, ORE_InvalidArguments);
+                throw OPENRAVE_EXCEPTION_FORMAT("\"remoteurl\" option is not supported, have to compile openrave with CURL support first", _filename, ORE_InvalidArguments);
 #endif
             }
             else if (itatt->first == "timeout") {
@@ -407,7 +408,11 @@ public:
 
     bool IsDownloadingFromRemote() const
     {
+#if OPENRAVE_CURL
         return !!_pDownloader;
+#else
+        return false;
+#endif
     }
 
     /// \brief open and cache a json document remotly

--- a/src/libopenrave/CMakeLists.txt
+++ b/src/libopenrave/CMakeLists.txt
@@ -60,7 +60,7 @@ set_target_properties(libopenrave PROPERTIES OUTPUT_NAME openrave${OPENRAVE_LIBR
                                   CLEAN_DIRECT_OUTPUT 1
                                   COMPILE_FLAGS "${LIBOPENRAVE_COMPILE_FLAGS} ${FPARSER_CXX_FLAGS} -DOPENRAVE_DLL_EXPORTS -DOPENRAVE_DLL"
                                   LINK_FLAGS "${LIBOPENRAVE_LINK_FLAGS} ${FPARSER_LINK_FLAGS}")
-target_link_libraries(libopenrave PRIVATE boost_assertion_failed PUBLIC ${openrave_libraries} ${FPARSER_LIBRARIES} ${Intl_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(libopenrave PRIVATE boost_assertion_failed PUBLIC Boost::filesystem ${openrave_libraries} ${FPARSER_LIBRARIES} ${Intl_LIBRARIES} ${CMAKE_DL_LIBS})
 if( MSVC )
   install(TARGETS libopenrave EXPORT openrave-targets RUNTIME DESTINATION bin COMPONENT ${COMPONENT_PREFIX}base LIBRARY DESTINATION bin COMPONENT ${COMPONENT_PREFIX}base ARCHIVE DESTINATION lib${LIB_SUFFIX} COMPONENT ${COMPONENT_PREFIX}base)
 else()

--- a/src/libopenrave/openravemsgpack.cpp
+++ b/src/libopenrave/openravemsgpack.cpp
@@ -47,7 +47,7 @@ struct convert< rapidjson::GenericDocument<Encoding, Allocator, StackAllocator> 
                 for (; ptr < END; ++ptr)
                 {
                     rapidjson::GenericDocument<Encoding, Allocator, StackAllocator> element(&v.GetAllocator());
-                    ptr->convert(&element);
+                    ptr->convert(element);
                     v.PushBack(static_cast<rapidjson::GenericValue<Encoding, Allocator>&>(element), v.GetAllocator());
                 }
             }
@@ -60,7 +60,7 @@ struct convert< rapidjson::GenericDocument<Encoding, Allocator, StackAllocator> 
                 {
                     rapidjson::GenericValue<Encoding, Allocator> key(ptr->key.via.str.ptr, ptr->key.via.str.size, v.GetAllocator());
                     rapidjson::GenericDocument<Encoding, Allocator, StackAllocator> val(&v.GetAllocator());
-                    ptr->val.convert(&val);
+                    ptr->val.convert(val);
 
                     v.AddMember(key, val, v.GetAllocator());
                 }
@@ -284,26 +284,26 @@ private:
 void OpenRAVE::MsgPack::DumpMsgPack(const rapidjson::Value& value, std::ostream& os)
 {
     msgpack::osbuffer buf(os);
-    msgpack::pack(&buf, value);
+    msgpack::pack(buf, value);
 }
 
 void OpenRAVE::MsgPack::DumpMsgPack(const rapidjson::Value& value, std::vector<char>& output)
 {   
     msgpack::vbuffer buf(output);
-    msgpack::pack(&buf, value);
+    msgpack::pack(buf, value);
 }
 
 void OpenRAVE::MsgPack::ParseMsgPack(rapidjson::Document& d, const std::string& str)
 {
     msgpack::unpacked unpacked;
-    msgpack::unpack(&unpacked, str.data(), str.size());
+    msgpack::unpack(unpacked, str.data(), str.size());
     unpacked.get().convert(d);
 }
 
 void OpenRAVE::MsgPack::ParseMsgPack(rapidjson::Document& d, const void* data, size_t size)
 {
     msgpack::unpacked unpacked;
-    msgpack::unpack(&unpacked, (const char*) data, size);
+    msgpack::unpack(unpacked, (const char*) data, size);
     unpacked.get().convert(d);
 }
 

--- a/src/libopenrave/openravemsgpack.cpp
+++ b/src/libopenrave/openravemsgpack.cpp
@@ -333,6 +333,11 @@ void OpenRAVE::MsgPack::ParseMsgPack(rapidjson::Document& d, const std::string& 
     throw OPENRAVE_EXCEPTION_FORMAT0("MsgPack support is not enabled", ORE_NotImplemented);
 }
 
+void OpenRAVE::MsgPack::ParseMsgPack(rapidjson::Document& d, const void* data, size_t size)
+{
+    throw OPENRAVE_EXCEPTION_FORMAT0("MsgPack support is not enabled", ORE_NotImplemented);
+}
+
 void OpenRAVE::MsgPack::ParseMsgPack(rapidjson::Document& d, std::istream& is)
 {
     throw OPENRAVE_EXCEPTION_FORMAT0("MsgPack support is not enabled", ORE_NotImplemented);


### PR DESCRIPTION
92bd5bd62bfc6523adc86d82246b7b85a3f060c2: Missing dummy function leads to compilation failure when Curl is enabled but MsgPack is disabled.

36d32763eec10ac2715f32845cf537d49e85c87f: Incorrectly spelled variable name, missing include (Can't find OPENRAVE_EXCEPTION_FORMAT otherwise).

763c0243b3b71e565b9ed6d14aadeea95ca5bce9: Under certain flag combinations, the boost filesystem library is not linked properly.

ccea434d5b91b0aad58baeca29dcdcc07e6c7b00: The pointer-based API in msgpack [is](https://github.com/mujin/msgpack-c/blob/master/include/msgpack/v1/unpack.hpp#L1569) [obsolete](https://github.com/mujin/msgpack-c/blob/master/include/msgpack/v1/object.hpp#L1084) and is removed in a future version.