### PR TITLE
fix memory leak by not decrementing ref count

### DIFF
--- a/python/bindings/openravepy_trajectory.cpp
+++ b/python/bindings/openravepy_trajectory.cpp
@@ -71,7 +71,7 @@ inline bool ExtractContiguousArrayToVector(py::object oContiguousArray,
     }
 
     PyArrayObject* arrPtr = PyArray_GETCONTIGUOUS((PyArrayObject*)oContiguousArray.ptr());
-    AutoPyArrayObjectDereferencer psaver(openravepy::AutoPyArrayObjectDereferencer(arrPtr));
+    AutoPyArrayObjectDereferencer psaver(arrPtr);
     if( !arrPtr || !arrPtr->data) {
         RAVELOG_WARN("Input data is not contigous so have to use slow conversion. Please use numpy array to take advantage of faster conversion making use of contiguous memory allocation of it.");
         return false;
@@ -106,7 +106,7 @@ inline int ExtractContiguousArrayToPointer(py::object oContiguousArray,
     }
 
     PyArrayObject* arrPtr = PyArray_GETCONTIGUOUS((PyArrayObject*)oContiguousArray.ptr());
-    AutoPyArrayObjectDereferencer psaver(openravepy::AutoPyArrayObjectDereferencer(arrPtr));
+    AutoPyArrayObjectDereferencer psaver(arrPtr);
     if( !arrPtr || !arrPtr->data) {
         RAVELOG_WARN("Input data is not contigous so have to use slow conversion. Please use numpy array to take advantage of faster conversion making use of contiguous memory allocation of it.");
         return -1;


### PR DESCRIPTION
Background
==============
- Memory leak was introduced https://github.com/rdiankov/openrave/pull/1142
- Problem was that reference count was not getting decremented in the destructor of ``AutoPyArrayObjectDereferencer``.
-  ``AutoPyArrayObjectDereferencer psaver(openravepy::AutoPyArrayObjectDereferencer(arrPtr));`` is actually a function declaration according to c++ spec so destructor was not being called.
    - https://en.wikipedia.org/wiki/Most_vexing_parse#Example_with_classes