### PR TITLE
Add PyCollisionReport::Reset

### DIFF
--- a/python/bindings/include/openravepy/openravepy_collisionreport.h
+++ b/python/bindings/include/openravepy/openravepy_collisionreport.h
@@ -46,6 +46,7 @@ public:
 
     std::string __str__();
     object __unicode__();
+    void Reset(int coloptions=0);
 
     int options;
     object plink1 = py::none_();

--- a/python/bindings/openravepy_collisionchecker.cpp
+++ b/python/bindings/openravepy_collisionchecker.cpp
@@ -803,7 +803,7 @@ void init_openravepy_collisionchecker()
 #else
     .def("Reset",&PyCollisionReport::Reset,
          Reset_overloads(PY_ARGS("coloptions")
-                                      "Reset report"))
+                         "Reset report"))
 #endif
     ;
 

--- a/python/bindings/openravepy_collisionchecker.cpp
+++ b/python/bindings/openravepy_collisionchecker.cpp
@@ -125,6 +125,10 @@ void PyCollisionReport::init(PyEnvironmentBasePtr pyenv)
     vLinkColliding = newLinkColliding;
 }
 
+void PyCollisionReport::Reset(int coloptions)
+{
+    return report->Reset(coloptions);
+}
 std::string PyCollisionReport::__str__()
 {
     return report->__str__();
@@ -720,6 +724,7 @@ PyCollisionCheckerBasePtr RaveCreateCollisionChecker(PyEnvironmentBasePtr pyenv,
 
 #ifndef USE_PYBIND11_PYTHON_BINDINGS
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(CheckCollisionRays_overloads, CheckCollisionRays, 2, 3)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Reset_overloads, Reset, 0, 1)
 #endif
 
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
@@ -790,6 +795,16 @@ void init_openravepy_collisionchecker()
     .def_readonly("nKeepPrevious", &PyCollisionReport::nKeepPrevious)
     .def("__str__",&PyCollisionReport::__str__)
     .def("__unicode__",&PyCollisionReport::__unicode__)
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+    .def("Reset", &PyCollisionReport::Reset,
+         "coloptions"_a = 0,
+         "Reset report"
+        )
+#else
+    .def("Reset",&PyCollisionReport::Reset,
+         Reset_overloads(PY_ARGS("coloptions")
+                                      "Reset report"))
+#endif
     ;
 
     bool (PyCollisionCheckerBase::*pcolb)(PyKinBodyPtr) = &PyCollisionCheckerBase::CheckCollision;


### PR DESCRIPTION
In airgripper simulator, we are now checking collision in a specific loop. There we want to reuse the same CollisionReport instance, so Resetting is better.