### PR TITLE
allow name mismatch when IAM_AllowRenaming is used

### DIFF
--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -2940,7 +2940,7 @@ public:
                 // for new body or robot
                 KinBodyPtr pNewBody;
                 if (pKinBodyInfo->_isRobot) {
-                    RAVELOG_VERBOSE_FORMAT("add new robot %s", pKinBodyInfo->_id);
+                    RAVELOG_VERBOSE_FORMAT("add new robot id=%s, name=%s", pKinBodyInfo->_id%pKinBodyInfo->_name);
                     RobotBasePtr pRobot = RaveCreateRobot(shared_from_this(), pKinBodyInfo->_interfaceType);
                     if( !pRobot ) {
                         pRobot = RaveCreateRobot(shared_from_this(), "");
@@ -2957,7 +2957,7 @@ public:
                     pNewBody = RaveInterfaceCast<KinBody>(pRobot);
                 }
                 else {
-                    RAVELOG_VERBOSE_FORMAT("add new kinbody %s", pKinBodyInfo->_id);
+                    RAVELOG_VERBOSE_FORMAT("add new kinbody id=%s, name=%s", pKinBodyInfo->_id%pKinBodyInfo->_name);
                     pNewBody = RaveCreateKinBody(shared_from_this(), pKinBodyInfo->_interfaceType);
                     if( !pNewBody ) {
                         pNewBody = RaveCreateKinBody(shared_from_this(), "");
@@ -2984,7 +2984,9 @@ public:
 
             if (!!pInitBody) {
                 // only for init body we need to set name and dofvalues again
-                OPENRAVE_ASSERT_OP_FORMAT0(pInitBody->GetName(), ==, pKinBodyInfo->_name, "names should be matching", ORE_InvalidArguments);
+                if( !!pMatchExistingBody ) {
+                    OPENRAVE_ASSERT_OP_FORMAT0(pInitBody->GetName(), ==, pKinBodyInfo->_name, "names should be matching", ORE_InvalidArguments);
+                }
 
                 // dof value
                 bool bChanged = false;


### PR DESCRIPTION
```json
{
  "name": "hello world file name",
  "keywords": [
    "part"
  ],
  "bodies": [
    {
      "name": "hello world body name",
      "links": [
        {
          "name": "hello world link name",
          "geometries": [
            {
              "type": "box",
              "halfExtents": [
                0.05,
                0.05,
                0.05
              ]
            }
          ]
        }
      ],
      "isRobot": false
    }
  ]
}
```

When I load this file to openrave environment, I get this error.

```
openravepy._openravepy_0_105.openravepy_int._OpenRAVEException: ('openrave (InvalidArguments): [virtual void Environment::UpdateFromInfo(const OpenRAVE::EnvironmentBase::EnvironmentBaseInfo&, std::vector<boost::shared_ptr<OpenRAVE::KinBody> >&, std::vector<boost::shared_ptr<OpenRAVE::KinBody> >&, std::vector<boost::shared_ptr<OpenRAVE::KinBody> >&, OpenRAVE::UpdateFromInfoMode):2987] pInitBody->GetName() == pKinBodyInfo->_name, (eval hello_world_body_name == hello world body name) names should be matching', 'InvalidArguments')
```

This is because when we add a kinbody in `UpdateFromInfo()` of `environment-core.h`, we use `IAM_AllowRenaming` for new body or robot, so name can be changed e.g. ` ` (white space) -> `_` (underscore) but we compare the original name and the renamed name. For new body or robot, we use `IAM_AllowRenaming` so we don't need to check name matching in that case.