### PR TITLE
Silence warnings

### DIFF
--- a/plugins/basecontrollers/idealvelocitycontroller.cpp
+++ b/plugins/basecontrollers/idealvelocitycontroller.cpp
@@ -15,8 +15,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "plugindefs.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/lexical_cast.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 class IdealVelocityController : public ControllerBase
 {

--- a/plugins/basesensors/plugindefs.h
+++ b/plugins/basesensors/plugindefs.h
@@ -55,7 +55,10 @@
 #include <iostream>
 
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 using namespace std;
 using namespace OpenRAVE;

--- a/plugins/configurationcache/configurationcachetree.cpp
+++ b/plugins/configurationcache/configurationcachetree.cpp
@@ -657,7 +657,6 @@ bool CacheTree::_Remove(CacheTreeNodePtr removenode, std::vector< std::vector<Ca
     std::vector<CacheTreeNodePtr>& vNextLevelNodes = vvCoverSetNodes[coverindex];
     vNextLevelNodes.resize(0);
 
-    bool bfound = false;
     FOREACH(itcurrentnode, vvCoverSetNodes.at(coverindex-1)) {
         // only take the children whose distances are within the bound
         if( setLevelRawChildren.find(*itcurrentnode) != setLevelRawChildren.end() ) {
@@ -668,7 +667,6 @@ bool CacheTree::_Remove(CacheTreeNodePtr removenode, std::vector< std::vector<Ca
                     vNextLevelNodes.resize(0);
                     vNextLevelNodes.push_back(*itchild);
                     itchild = (*itcurrentnode)->_vchildren.erase(itchild);
-                    bfound = true;
                 }
                 else {
                     if( curdist <= fLevelBound2 ) {

--- a/plugins/fclrave/fclcollision.h
+++ b/plugins/fclrave/fclcollision.h
@@ -5,7 +5,6 @@
 #include <boost/unordered_set.hpp>
 #include <boost/lexical_cast.hpp>
 #include <openrave/utils.h>
-#include <boost/function_output_iterator.hpp>
 
 #include "fclspace.h"
 #include "fclmanagercache.h"

--- a/plugins/fclrave/plugindefs.h
+++ b/plugins/fclrave/plugindefs.h
@@ -52,12 +52,13 @@
 #include <iostream>
 
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/iterator/transform_iterator.hpp>
 #include <boost/range/concepts.hpp>
-#include <boost/range/detail/any_iterator.hpp>
 #include <boost/unordered_map.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 #define _(msgid) OpenRAVE::RaveGetLocalizedTextForDomain("openrave_plugins_oderave", msgid)
 

--- a/plugins/grasper/plugindefs.h
+++ b/plugins/grasper/plugindefs.h
@@ -58,7 +58,10 @@
 #include <iostream>
 
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 using namespace std;
 using namespace OpenRAVE;

--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -18,7 +18,6 @@
 
 #include "plugindefs.h"
 
-#include <boost/bind.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/lexical_cast.hpp>
 

--- a/plugins/ikfastsolvers/jacobianinverse.h
+++ b/plugins/ikfastsolvers/jacobianinverse.h
@@ -144,7 +144,7 @@ public:
         T firsterror2 = totalerror21;
         T besterror2 = totalerror21;
         _lasterror2 = totalerror21;
-        int armdof = manip.GetArmDOF();
+        //int armdof = manip.GetArmDOF();
         std::vector<dReal>& vbest = _cachevbest; vbest = vsolution;
         std::vector<dReal>& vnew = _cachevnew; vnew = vsolution;
         bool bSuccess = false;

--- a/plugins/ikfastsolvers/plugindefs.h
+++ b/plugins/ikfastsolvers/plugindefs.h
@@ -59,11 +59,12 @@
 #include <cmath>
 
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 
 using namespace std;
 using namespace OpenRAVE;
+using namespace boost::placeholders;
 
 static const dReal g_fEpsilonJointLimit = RavePow(g_fEpsilon,0.8);
 

--- a/plugins/include/openraveplugindefs.h
+++ b/plugins/include/openraveplugindefs.h
@@ -57,7 +57,11 @@
 #include <iostream>
 
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+using boost::placeholders::_3;
+using boost::placeholders::_4;
 
 using namespace std;
 using namespace OpenRAVE;

--- a/plugins/logging/plugindefs.h
+++ b/plugins/logging/plugindefs.h
@@ -57,8 +57,13 @@
 #include <iostream>
 
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/algorithm/string.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+using boost::placeholders::_3;
+using boost::placeholders::_4;
 
 using namespace std;
 using namespace OpenRAVE;

--- a/plugins/oderave/plugindefs.h
+++ b/plugins/oderave/plugindefs.h
@@ -57,7 +57,10 @@
 #include <iostream>
 
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
 
 #define _(msgid) OpenRAVE::RaveGetLocalizedTextForDomain("openrave_plugins_oderave", msgid)
 

--- a/plugins/pqprave/plugindefs.h
+++ b/plugins/pqprave/plugindefs.h
@@ -56,9 +56,10 @@
 #include <iostream>
 
 #include <boost/assert.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 using namespace std;
 using namespace OpenRAVE;
+using namespace boost::placeholders;
 
 #endif

--- a/plugins/qtosgrave/qtosg.h
+++ b/plugins/qtosgrave/qtosg.h
@@ -62,10 +62,14 @@
 #include <iostream>
 #include <sstream>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/assert.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/version.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+using boost::placeholders::_3;
 
 #include <QtCore/QVariant>
 #include <QtWidgets/QAction>

--- a/plugins/rmanipulation/commonmanipulation.h
+++ b/plugins/rmanipulation/commonmanipulation.h
@@ -199,7 +199,7 @@ public:
             if( IS_DEBUGLEVEL(Level_Debug) || (RaveGetDebugLevel() & Level_VerifyPlans) ) {
                 T totalerror2 = _ComputeConstraintError(_pmanip->GetTransform(),_error);
                 if( totalerror2 >= _errorthresh2 ) {
-                    Transform tEE = _tTargetFrameLeft * _pmanip->GetTransform() * _tTargetFrameRight; // for debugging
+                    //Transform tEE = _tTargetFrameLeft * _pmanip->GetTransform() * _tTargetFrameRight; // for debugging
                     throw OPENRAVE_EXCEPTION_FORMAT("initial robot configuration does not satisfy constraints %f>%f",totalerror2%_errorthresh2,ORE_InconsistentConstraints);
                 }
             }

--- a/plugins/rmanipulation/plugindefs.h
+++ b/plugins/rmanipulation/plugindefs.h
@@ -62,9 +62,10 @@
 #include <fstream>
 #include <iostream>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 using namespace std;
 using namespace OpenRAVE;
+using namespace boost::placeholders;
 
 #endif

--- a/plugins/rmanipulation/taskmanipulation.cpp
+++ b/plugins/rmanipulation/taskmanipulation.cpp
@@ -1356,7 +1356,6 @@ protected:
             }
         }
 
-        bool bForceRetime = false;
         {
             // check final trajectory for colliding points
             RobotBase::RobotStateSaver saver2(_robot);
@@ -1366,7 +1365,6 @@ protected:
                 RAVELOG_WARN("robot final configuration is in collision\n");
                 _robot->GetActiveDOFValues(q);
                 ptraj->Insert(ptraj->GetNumWaypoints(),q,_robot->GetActiveConfigurationSpecification());
-                bForceRetime = true;
             }
         }
 
@@ -1502,7 +1500,6 @@ protected:
             }
         }
 
-        bool bForceRetime = false;
         {
             // check final trajectory for colliding points
             RobotBase::RobotStateSaver saver2(_robot);
@@ -1512,7 +1509,6 @@ protected:
                 RAVELOG_WARN("robot final configuration is in collision\n");
                 _robot->GetActiveDOFValues(q);
                 ptraj->Insert(ptraj->GetNumWaypoints(),q,_robot->GetActiveConfigurationSpecification());
-                bForceRetime = true;
             }
         }
 

--- a/plugins/rplanners/ParabolicPathSmooth/ppramp.cpp
+++ b/plugins/rplanners/ParabolicPathSmooth/ppramp.cpp
@@ -73,7 +73,7 @@ bool PPRamp::SolveMinTime(Real amax)
         //Real c = (Sqr(dx0)-Sqr(dx1))*0.5/a+x0-x1;
         Real b = 2.0*_a1*dx0; //2.0*(dx0-dx1);
         Real c = (Sqr(dx0)-Sqr(dx1))*0.5+(x0-x1)*_a1;
-        Real t1,t2;
+        Real t1 = 0.0, t2 = 0.0;
         int res=SolveQuadratic(_a1*_a1,b,c,t1,t2);
         PARABOLICWARN("Quadratic equation %.15e x^2 + %.15e x + %.15e = 0\n",_a1*_a1,b,c);
         PARABOLICWARN("%d results, %.15e %.15e\n",res,t1,t2);
@@ -151,7 +151,7 @@ bool PPRamp::SolveMinTime2(Real amax,Real timeLowerBound)
         //Real c = (Sqr(dx0)-Sqr(dx1))*0.5/a+x0-x1;
         Real b = 2.0*_a1*dx0; //2.0*(dx0-dx1);
         Real c = (Sqr(dx0)-Sqr(dx1))*0.5+(x0-x1)*_a1;
-        Real t1,t2;
+        Real t1 = 0.0, t2 = 0.0;
         int res_=SolveQuadratic(_a1*_a1,b,c,t1,t2);
         PARABOLICWARN("Quadratic equation %.15e x^2 + %.15e x + %.15e = 0\n",_a1*_a1,b,c);
         PARABOLICWARN("%d results, %.15e %.15e\n",res_,t1,t2);
@@ -298,7 +298,7 @@ bool PPRamp::SolveMinAccel(Real endTime)
             Real b=sign*(2.0*(dx0+dx1)*endTime+4.0*(x0-x1));
             Real c=-Sqr(dx1-dx0);
             PARABOLICWARN("Quadratic %.15e x^2 + %.15e x + %.15e = 0\n",a,b,c);
-            Real t1,t2;
+            Real t1 = 0.0, t2 = 0.0;
             int res = SolveQuadratic(a,b,c,t1,t2);
             PARABOLICWARN("Solutions: %d, %.15e and %.15e\n",res,t1,t2);
         }
@@ -308,7 +308,7 @@ bool PPRamp::SolveMinAccel(Real endTime)
             Real b=sign*(2.0*(dx0+dx1)*endTime+4.0*(x0-x1));
             Real c=-Sqr(dx1-dx0);
             PARABOLICWARN("Quadratic %.15e x^2 + %.15e x + %.15e = 0\n",a,b,c);
-            Real t1,t2;
+            Real t1 = 0.0, t2 = 0.0;
             int res = SolveQuadratic(a,b,c,t1,t2);
             PARABOLICWARN("Solutions: %d, %.15e and %.15e\n",res,t1,t2);
         }
@@ -429,7 +429,7 @@ int PPRamp::CalcSwitchTimes(Real a,Real& t1,Real& t2) const
 
 Real PPRamp::CalcSwitchTime(Real a) const
 {
-    Real t1,t2;
+    Real t1 = 0.0, t2 = 0.0;
     int res = CalcSwitchTimes(a,t1,t2);
     if(res == 0) {
         return -1;

--- a/plugins/rplanners/cubicretimer.cpp
+++ b/plugins/rplanners/cubicretimer.cpp
@@ -254,18 +254,18 @@ protected:
             _v0vel[i] = *(itdataprev+info->gvel.offset+i);
             _v1vel[i] = *(itdata+info->gvel.offset+i);
         }
-        dReal deltatime = *(itdata+_timeoffset);
-        dReal ideltatime = 1/deltatime;
-        dReal ideltatime2 = ideltatime*ideltatime;
-        for(int i=0; i < info->gvel.dof; ++i) {
-            dReal px = *(itdata+info->gpos.offset+i) - *(itdataprev+info->gpos.offset+i);
-            dReal v0 = *(itdataprev+info->gvel.offset+i);
-            dReal v1 = *(itdata+info->gvel.offset+i);
-            dReal c3 = (v1 + v0 - 2*px*ideltatime)*ideltatime2;
-            dReal c2 = (3*px*ideltatime - (2*v0 + v1))*ideltatime;
+//        dReal deltatime = *(itdata+_timeoffset);
+//        dReal ideltatime = 1/deltatime;
+//        dReal ideltatime2 = ideltatime*ideltatime;
+//        for(int i=0; i < info->gvel.dof; ++i) {
+//            dReal px = *(itdata+info->gpos.offset+i) - *(itdataprev+info->gpos.offset+i);
+//            dReal v0 = *(itdataprev+info->gvel.offset+i);
+//            dReal v1 = *(itdata+info->gvel.offset+i);
+//            dReal c3 = (v1 + v0 - 2*px*ideltatime)*ideltatime2;
+//            dReal c2 = (3*px*ideltatime - (2*v0 + v1))*ideltatime;
 //            dReal a1 = 6*c3, a0 = 2*c2;
 //            *(itdata+info->gaccel.offset+i) = a0 + deltatime*a1;
-        }
+//        }
         return true;
     }
 

--- a/plugins/rplanners/cubicsmoother.cpp
+++ b/plugins/rplanners/cubicsmoother.cpp
@@ -802,9 +802,7 @@ public:
                         if( _bManipConstraints && !!_manipConstraintChecker ) {
                             // Scale down accelLimits and/or velLimits based on what constraints are violated.
                             dReal fVelMult, fAccelMult, fJerkMult;
-                            bool maxManipSpeedViolated = false, maxManipAccelViolated = false;
                             if( checkret.fMaxManipAccel > _parameters->maxmanipaccel ) {
-                                maxManipAccelViolated = true;
                                 if( SCALE_ALL_WHEN_TOOLACCEL_VIOLATED ) {
 #ifdef JERK_LIMITED_SMOOTHER_PROGRESS_DEBUG
                                     RAVELOG_DEBUG_FORMAT("env=%d, shortcut iter=%d/%d, t0=%.15e; t1=%.15e; max manip accel violated (%.15e > %.15e). fTimeBasedSurpassMult=%.15e", _envId%iter%numIters%t0%t1%checkret.fMaxManipAccel%_parameters->maxmanipaccel%checkret.fTimeBasedSurpassMult);
@@ -850,7 +848,6 @@ public:
                                 } // end if !SCALE_ALL_WHEN_TOOLACCEL_VIOLATED
                             }
                             else if( checkret.fMaxManipSpeed > _parameters->maxmanipspeed ) {
-                                maxManipSpeedViolated = true;
                                 bScaledDown = true;
 
                                 fVelMult = checkret.fTimeBasedSurpassMult;

--- a/plugins/rplanners/linearshortcutadvanced.cpp
+++ b/plugins/rplanners/linearshortcutadvanced.cpp
@@ -197,7 +197,6 @@ protected:
         int nrejected = 0;
         int iiter = parameters->_nMaxIterations;
         int itercount = 0;
-        int numiters = (int)parameters->_nMaxIterations;
         std::vector<dReal> vnewconfig0(dof), vnewconfig1(dof);
 
         int numshortcuts = 0; // keep track of the number of successful shortcuts

--- a/plugins/rplanners/parabolicsmoother2.cpp
+++ b/plugins/rplanners/parabolicsmoother2.cpp
@@ -63,7 +63,6 @@ public:
         /// \brief Check all constraints on all rampnds in the given vector of rampnds. options is passed to the OpenRAVE check function.
         RampOptimizer::CheckReturn Check2(const std::vector<RampOptimizer::RampND>& rampndVect, int options, std::vector<RampOptimizer::RampND>& rampndVectOut)
         {
-            std::vector<dReal> &vswitchtimes=_vswitchtimes;
             std::vector<dReal> &q0=_q0, &q1=_q1, &dq0=_dq0, &dq1=_dq1;
             std::vector<uint8_t> &vsearchsegments=_vsearchsegments;
 

--- a/plugins/rplanners/piecewisepolynomials/generalrecursiveinterpolator.cpp
+++ b/plugins/rplanners/piecewisepolynomials/generalrecursiveinterpolator.cpp
@@ -209,7 +209,6 @@ PolynomialCheckReturn GeneralRecursiveInterpolator::Compute1DTrajectory(
         dReal delta = deltaX - deltaX1 - deltaX3;
 
         // Note: In the paper, there is no explicit consideration for the case when v is zero.
-        bool bFreeDuration2 = false;
         if( FuzzyZero(v, g_fPolynomialEpsilon) ) {
             // In this case, v == 0 so we are free to choose the duration of this middle part.
             duration2 = 0; // leave it unchosen first. will compute an appropriate value for duration in the end.

--- a/plugins/rplanners/rplanners.h
+++ b/plugins/rplanners/rplanners.h
@@ -950,7 +950,7 @@ private:
         std::vector<NodePtr>& vNextLevelNodes = vvCoverSetNodes[coverindex];
         vNextLevelNodes.resize(0);
 
-        bool bfound = false;
+        //bool bfound = false;
         FOREACH(itcurrentnode, vvCoverSetNodes.at(coverindex-1)) {
             // only take the children whose distances are within the bound
             if( setLevelRawChildren.find(*itcurrentnode) != setLevelRawChildren.end() ) {
@@ -964,7 +964,7 @@ private:
                         if( (*itcurrentnode)->_hasselfchild && _ComputeDistance(*itcurrentnode, *itchild) <= _mindistance) {
                             (*itcurrentnode)->_hasselfchild = 0;
                         }
-                        bfound = true;
+                        //bfound = true;
                         //break;
                     }
                     else {

--- a/plugins/rplanners/workspacetrajectorytracker.cpp
+++ b/plugins/rplanners/workspacetrajectorytracker.cpp
@@ -74,7 +74,6 @@ Planner Parameters\n\
                     RAVELOG_ERROR("failed to set state values\n");
                     return false;
                 }
-                Transform tstate = _manip->GetTransform();
                 _robot->SetActiveDOFs(_manip->GetArmIndices());
                 _robot->GetActiveDOFValues(dummyvalues);
                 for(size_t j = 0; j < dummyvalues.size(); ++j) {
@@ -167,7 +166,7 @@ Planner Parameters\n\
             }
         }
 
-        dReal fstarttime = 0, fendtime = workspacetraj->GetDuration();
+        dReal fstarttime = 0;
         bool bPrevInCollision = true;
         list<Transform> listtransforms;
         dReal ftime = 0;
@@ -183,7 +182,6 @@ Planner Parameters\n\
                 }
                 if( !bPrevInCollision ) {
                     if( ftime >= minimumcompletetime ) {
-                        fendtime = ftime;
                         break;
                     }
                 }
@@ -261,7 +259,6 @@ Planner Parameters\n\
                 else {
                     if( !bPrevInCollision ) {
                         if( ftime >= minimumcompletetime ) {
-                            fendtime = ftime;
                             break;
                         }
                     }

--- a/plugins/textserver/plugindefs.h
+++ b/plugins/textserver/plugindefs.h
@@ -55,7 +55,7 @@
 #include <fstream>
 #include <iostream>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/array.hpp>
 #include <boost/thread/thread.hpp>
@@ -63,6 +63,10 @@
 #include <boost/thread/condition.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/assert.hpp>
+
+using boost::placeholders::_1;
+using boost::placeholders::_2;
+using boost::placeholders::_3;
 
 using namespace std;
 using namespace OpenRAVE;

--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -40,7 +40,7 @@
 #include <boost/format.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/version.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #define PY_ARRAY_UNIQUE_SYMBOL PyArrayHandle
 #ifndef USE_PYBIND11_PYTHON_BINDINGS
@@ -55,6 +55,8 @@
 #define OPENRAVE_BINDINGS_PYARRAY
 #include <openravepy/bindings.h>
 #include <openravepy/docstrings.h>
+
+using namespace boost::placeholders;
 
 #define _(msgid) OpenRAVE::RaveGetLocalizedTextForDomain("openrave", msgid)
 

--- a/python/openrave-createplugin.py.in
+++ b/python/openrave-createplugin.py.in
@@ -113,8 +113,9 @@ int main()
 """
     else:
         code_cpp = """#include <openrave/plugin.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 using namespace OpenRAVE;
+using namespace boost::placeholders;
 
 %s
 // called to create a new plugin

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -3675,7 +3675,7 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
 
                     // p''(t) = 6*a*t + 2*b. Check |p''(timeelapsed) - a1|.
                     dReal accelerationError = RaveFabs( (2*temp1 + temp2) - ddq1.at(idof) );
-                    OPENRAVE_ASSERT_OP_FORMAT(velocityError, <=, 100*g_fEpsilonCubic, "dof %d final acceleration is not consistent", idof, ORE_InvalidArguments);
+                    OPENRAVE_ASSERT_OP_FORMAT(accelerationError, <=, 100*g_fEpsilonCubic, "dof %d final acceleration is not consistent", idof, ORE_InvalidArguments);
                 }
             }
             break;

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -3715,7 +3715,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
     // i travels is simply sum_k |p(t_{k + 1}) - p(t_k)| where t_k is the k-th critical point. Also
     // let the first critical point be t = 0 and the last one t = timeelapsed.
     //
-    int nLargestStepIndex = -1; // index to the DOF that moves the most
     int numSteps = 0; // the number of steps the dof nLargestStepIndex takes along this path
     int totalSteps = 0; // the number of steps of all DOFs combined
     const std::vector<dReal>& vConfigResolution = params->_vConfigResolution;
@@ -3837,7 +3836,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
 
             totalSteps += steps;
             if( steps > numSteps ) {
-                nLargestStepIndex = idof;
                 numSteps = steps;
             }
         } // end for loop iterating through each dof to find discretization steps.
@@ -3856,7 +3854,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
             totalSteps += steps;
             if (steps > numSteps) {
                 numSteps = steps;
-                nLargestStepIndex = idof;
             }
         }
     }
@@ -3929,7 +3926,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
 
     // Checking the rest of the segment starts here
     bool bHasRampDeviatedFromInterpolation = false; // TODO: write a correct description for this variable later
-    bool bHasNewTempConfigToAdd = false; // TODO: write a correct description for this variable later
 
     if( !bUseAllLinearInterpolation && timeelapsed > 0 ) {
         bool bComputeNewTimeStep = true; // TODO: write a correct description for this variable later
@@ -3957,7 +3953,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
                     filterreturn->_configurations.insert(filterreturn->_configurations.end(), _vtempconfig.begin(), _vtempconfig.end());
                     filterreturn->_configurationtimes.push_back(tcur);
                 }
-                bHasNewTempConfigToAdd = false;
             }
             if( nstateret != 0 ) {
                 if( !!filterreturn ) {
@@ -4084,7 +4079,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
             } // end switch maskinterpolation
 
             dReal dqscale = 1.0;  // TODO: write a correct description for this variable later
-            int iScaleIndex = -1; // TODO: write a correct description for this variable later
             dReal fitdiff = 1/(tnext - tprev);
             for( size_t idof = 0; idof < ndof; ++idof ) {
                 if( RaveFabs(dQ[idof]) > vConfigResolution[idof] * 1.01 ) {
@@ -4163,7 +4157,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
                     }
                     if( s < dqscale ) {
                         dqscale = s;
-                        iScaleIndex = (int)idof;
                     }
                 }
                 else {
@@ -4230,7 +4223,6 @@ int DynamicsCollisionConstraint::Check(const std::vector<dReal>& q0, const std::
             if( neighstatus == NSS_SuccessfulWithDeviation ) {
                 bHasRampDeviatedFromInterpolation = true;
             }
-            bHasNewTempConfigToAdd = true;
 
             // Fill in _vtempvelconfig and _vtempaccelconfig
             switch( maskinterpolation ) {


### PR DESCRIPTION
Too many warnings for stuff that's easy to fix, plus one actual copy-paste bug. Trying to find a real problem buried in the verbose text is finding a needle in a haystack.

Before: 4389 lines of output
After: 3657 lines of output
Delta: 732 lines of warnings silenced

Only code that directly resides in main openrave source code is modified, warnings originating from 3rd party dependencies or vendored directories are not modified.

Prefer to fix a warning by Doing the Right Thing™ rather than slapping a define that just sweeps the problem under the carpet.
- `<boost/bind.hpp>` becomes `<boost/bind/bind.hpp>` and `using namespace boost::placeholders`.
- Many unused variables are removed or commented out.