### PR TITLE
Fix regression in master branch (v0.105.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,9 @@ msvc_soqt/
 src/models/
 
 myrelpath.pyc
+
+/build*/
+/.vs/
+/.vscode/
+/__pycache__/
+/sympy/

--- a/include/openrave/logging.h
+++ b/include/openrave/logging.h
@@ -20,6 +20,7 @@
 #ifndef OPENRAVE_LOGGING_H
 #define OPENRAVE_LOGGING_H
 
+#include <string>
 #include <vector>
 
 #if OPENRAVE_LOG4CXX

--- a/include/openrave/logging.h
+++ b/include/openrave/logging.h
@@ -20,6 +20,8 @@
 #ifndef OPENRAVE_LOGGING_H
 #define OPENRAVE_LOGGING_H
 
+#include <vector>
+
 #if OPENRAVE_LOG4CXX
 #include <log4cxx/logger.h>
 #endif

--- a/src/libopenrave/plugindatabase.cpp
+++ b/src/libopenrave/plugindatabase.cpp
@@ -232,7 +232,11 @@ void DynamicRaveDatabase::_LoadPluginsFromPath(const std::string& strpath, bool 
     if (fs::is_empty(path)) {
         return;
     } else if (fs::is_directory(path)) {
+#if BOOST_VERSION >= 107200
         for (const auto entry : fs::directory_iterator(path, fs::directory_options::skip_permission_denied)) {
+#else
+        for (const auto entry : fs::directory_iterator(path)) {
+#endif
             if (fs::is_directory(entry) && recurse) {
                 _LoadPluginsFromPath(entry.path().string(), true);
             } else {


### PR DESCRIPTION
This patchset targets:
* https://github.com/rdiankov/openrave/commit/d6469af022b0c44037df69d11de66a7ac4d14b38: affects Boost <1.72.0 (Ubuntu 20.04 installs 1.71.0, [example](https://github.com/roboticslab-uc3m/openrave-yarp-plugins/actions/runs/4020262953/jobs/6907987221#step:17:364)), cc @undisputed-seraphim
  * fixes https://github.com/rdiankov/openrave/issues/1189
* a long-standing missing header inclusion that for some reason began causing trouble on Ubuntu 20.04/22.04 after the recent merge to master ([example](https://github.com/roboticslab-uc3m/openrave-yarp-plugins/actions/runs/4020262953/jobs/6907987788#step:17:352))
* incidentally, a few usual build-related directories missing in .gitignore