### PR TITLE
replace "auto" with the actual type

### DIFF
--- a/src/libopenrave/iksolver.cpp
+++ b/src/libopenrave/iksolver.cpp
@@ -199,11 +199,11 @@ IkReturnAction IkSolverBase::_CallFilters(std::vector<dReal>& solution, RobotBas
             if( fdiff > g_fEpsilonJointLimit ) {
                 stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
                 ss << "dof " << i << " of solution=[";
-                for( const auto value : solution) {
+                for( const dReal value : solution) {
                     ss << value << ", ";
                 }
                 ss << "] != dof " << dofindex << " of currentvalues=[";
-                for( const auto value : vtestsolution) {
+                for( const dReal value : vtestsolution) {
                     ss << value << ", ";
                 }
                 ss << "]";
@@ -234,11 +234,11 @@ IkReturnAction IkSolverBase::_CallFilters(std::vector<dReal>& solution, RobotBas
                         
                         stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
                         ss << "dof " << dofindex << " of solution=[";
-                        for( const auto value : vtestsolution) {
+                        for( const dReal value : vtestsolution) {
                             ss << value << ", ";
                         }
                         ss << "] != dof " << dofindex << " of currentvalues=[";
-                        for( const auto value : vtestsolution2) {
+                        for( const dReal value : vtestsolution2) {
                             ss << value << ", ";
                         }
                         ss << "]";

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -4298,11 +4298,11 @@ void KinBody::_ComputeInternalInformation()
     if((_veclinks.size() > 0)&&(_vecjoints.size() > 0)) {
         std::vector< std::vector<int> > vlinkadjacency(_veclinks.size());
         // joints with only one attachment are attached to a static link, which is attached to link 0
-        for( const JointPtr joint :_vecjoints) {
+        for( const JointPtr& joint :_vecjoints) {
             vlinkadjacency.at(joint->GetFirstAttached()->GetIndex()).push_back(joint->GetSecondAttached()->GetIndex());
             vlinkadjacency.at(joint->GetSecondAttached()->GetIndex()).push_back(joint->GetFirstAttached()->GetIndex());
         }
-        for( const JointPtr passive : _vPassiveJoints) {
+        for( const JointPtr& passive : _vPassiveJoints) {
             vlinkadjacency.at(passive->GetFirstAttached()->GetIndex()).push_back(passive->GetSecondAttached()->GetIndex());
             vlinkadjacency.at(passive->GetSecondAttached()->GetIndex()).push_back(passive->GetFirstAttached()->GetIndex());
         }

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -4298,15 +4298,15 @@ void KinBody::_ComputeInternalInformation()
     if((_veclinks.size() > 0)&&(_vecjoints.size() > 0)) {
         std::vector< std::vector<int> > vlinkadjacency(_veclinks.size());
         // joints with only one attachment are attached to a static link, which is attached to link 0
-        for( const auto joint :_vecjoints) {
+        for( const JointPtr joint :_vecjoints) {
             vlinkadjacency.at(joint->GetFirstAttached()->GetIndex()).push_back(joint->GetSecondAttached()->GetIndex());
             vlinkadjacency.at(joint->GetSecondAttached()->GetIndex()).push_back(joint->GetFirstAttached()->GetIndex());
         }
-        for( const auto passive : _vPassiveJoints) {
+        for( const JointPtr passive : _vPassiveJoints) {
             vlinkadjacency.at(passive->GetFirstAttached()->GetIndex()).push_back(passive->GetSecondAttached()->GetIndex());
             vlinkadjacency.at(passive->GetSecondAttached()->GetIndex()).push_back(passive->GetFirstAttached()->GetIndex());
         }
-        for( auto &adj : vlinkadjacency) {
+        for( std::vector<int> &adj : vlinkadjacency) {
             sort(adj.begin(), adj.end());
         }
 


### PR DESCRIPTION
Fixing these:
```
$ for i in `find . -name "*.cpp"`; do git blame $i | grep Terenin | grep auto; done
041781d757 src/libopenrave/kinbody.cpp (Leonid Terenin          2022-03-25 16:27:18 +0900 4301)         for( const auto joint :_vecjoints) {
041781d757 src/libopenrave/kinbody.cpp (Leonid Terenin          2022-03-25 16:27:18 +0900 4305)         for( const auto passive : _vPassiveJoints) {
041781d757 src/libopenrave/kinbody.cpp (Leonid Terenin          2022-03-25 16:27:18 +0900 4309)         for( auto &adj : vlinkadjacency) {
```
into
```
for( const JointPtr joint :_vecjoints) {
for( const JointPtr passive : _vPassiveJoints) {
for( std::vector<int> &adj : vlinkadjacency) {
```
the pipeline: #479382