### PR TITLE
pytest: Fix python tests involving RaveLoadPlugin

### DIFF
--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -185,15 +185,15 @@ openrave --loadplugin ./libplugincpp.so
 - Another way is to load it from the C++/Python/APIs:<br/>
 \b C++
 \code
-RaveLoadPlugin(env,"plugincpp");
+RaveLoadPlugin(env,"libplugincpp.so");
 \endcode
 \b Python
 \verbatim
-RaveLoadPlugin('plugincpp')
+RaveLoadPlugin('libplugincpp.so')
 \endverbatim
 \b Octave
 \verbatim
-orEnvLoadPlugin('plugincpp');
+orEnvLoadPlugin('libplugincpp.so');
 \endverbatim
 
 Once the plugin is loaded, we can create the interface and call its commands to load an environment and return the number of bodies:

--- a/docs/source/tutorials/openravepy_beginning.rst
+++ b/docs/source/tutorials/openravepy_beginning.rst
@@ -117,7 +117,7 @@ The following example shows how to start the runtime and load only one plugin:
 
   try:
       RaveInitialize(load_all_plugins=False)
-      success = RaveLoadPlugin('libbasemanipulation')
+      success = RaveLoadPlugin('libbasemanipulation.so')
       # do work
   finally:
       RaveDestroy() # destroy the runtime
@@ -142,7 +142,7 @@ In addition, the OpenRAVE runtime managing plugin resources and environments has
   try:
       env1=Environment()
       env2=Environment()
-      RaveLoadPlugin('myplugin')
+      RaveLoadPlugin('libmyplugin.so')
       # do work
   finally:
       RaveDestroy() # destroys all environments and loaded plugins

--- a/python/openrave-robot.py.in
+++ b/python/openrave-robot.py.in
@@ -62,7 +62,7 @@ if __name__ == "__main__":
                       help='if manipulator name is specified will return the sensor hash of the robot')
     (options, args) = parser.parse_args()
     RaveInitialize(False, DebugLevel.Fatal) # don't want any spurious text
-    RaveLoadPlugin('qtcoinrave') # optional for IV/VRML file reading?
+    RaveLoadPlugin('libqtcoinrave.so') # optional for IV/VRML file reading?
     env=Environment()
     env.StopSimulation() # don't want another thread distributing things
     try:

--- a/test/test_global.py
+++ b/test/test_global.py
@@ -19,8 +19,9 @@ log=logging.getLogger('openravepytest')
 @with_destroy
 def test_pluginloading():
     RaveInitialize(load_all_plugins=False)
-    assert(RaveLoadPlugin('ikfastsolvers'))
-    assert(RaveLoadPlugin('libikfastsolvers'))
+    assert(not RaveLoadPlugin('ikfastsolvers'))
+    assert(not RaveLoadPlugin('libikfastsolvers'))
+    assert(RaveLoadPlugin('libikfastsolvers.so'))
     env=Environment()
     assert(RaveCreateProblem(env,'ikfast') is not None)
 

--- a/test/test_ikfast.py
+++ b/test/test_ikfast.py
@@ -44,8 +44,8 @@ def setup_robotstats():
     global env,ikfastproblem
     # just load the plugin we'll be using
     RaveInitialize(load_all_plugins=False)
-    success = RaveLoadPlugin('basesamplers')
-    success = RaveLoadPlugin('ikfastsolvers')
+    success = RaveLoadPlugin('libbasesamplers.so')
+    success = RaveLoadPlugin('libikfastsolvers.so')
     assert(success)
     RaveSetDebugLevel(DebugLevel.Error) # set to error in order to avoid expected plugin loading errors
     #format = logging.Formatter('%(name)s: %(message)s')


### PR DESCRIPTION
Due to the change in the way plugins are loaded in `RaveLoadPlugins` (https://github.com/rdiankov/openrave/pull/1137): File names must be non-truncated (`myplugin` -> `libmyplugin.so`).

Pipeline #486583