### PR TITLE
Unify InitGeometries behavior

### DIFF
--- a/src/libopenrave/kinbodylink.cpp
+++ b/src/libopenrave/kinbodylink.cpp
@@ -702,8 +702,10 @@ void KinBody::Link::InitGeometries(std::list<KinBody::GeometryInfo>& geometries,
     size_t i = 0;
     FOREACH(itinfo,geometries) {
         _vGeometries[i].reset(new Geometry(shared_from_this(),*itinfo));
-        if( _vGeometries[i]->GetCollisionMesh().vertices.size() == 0 ) {
-            RAVELOG_VERBOSE("geometry has empty collision mesh\n");
+        if( bForceRecomputeMeshCollision || _vGeometries[i]->GetCollisionMesh().vertices.size() == 0 ) {
+            if( !bForceRecomputeMeshCollision ) {
+                RAVELOG_VERBOSE("geometry has empty collision mesh\n");
+            }
             _vGeometries[i]->InitCollisionMesh(); // have to initialize the mesh since some plugins might not understand all geometry types
         }
         ++i;


### PR DESCRIPTION
There are 2 definitions of `InitGeometries` but the behavior for `bForceRecomputeMeshCollision` is different, and I think this is not intentional. `bForceRecomputeMeshCollision` was introduced by 55757fee6bf513d0397d868637cdd6099da5ab3a