### PR TITLE
Use Gary's ConvertStringToUnicode converting implementation

### DIFF
--- a/python/bindings/include/openravepy/pybind11/pybind11_bindings.h
+++ b/python/bindings/include/openravepy/pybind11/pybind11_bindings.h
@@ -114,14 +114,8 @@ namespace py = pybind11;
 
 inline py::object ConvertStringToUnicode(const std::string& s)
 {
-    /*
-       TGN: Is the following an alternative?
-       ```
-       PyObject *pyo = PyUnicode_Decode(s.c_str(), s.size(), "utf-8", nullptr);
-       return py::cast<py::object>(pyo); // py::handle_to_object(pyo);
-       ```
-     */
-    return py::to_object(s);
+    PyObject *pyo = PyUnicode_Decode(s.c_str(), s.size(), "utf-8", nullptr);
+    return py::cast<py::object>(pyo); // py::handle_to_object(pyo);
 }
 
 #ifdef OPENRAVE_BINDINGS_PYARRAY


### PR DESCRIPTION
Without `PyUnicode_Decode `, I found that `robot.GetName()` becomes bytes on Python3, and it is not the same as Python2.

Python2

```
In [1]: 'xyz' == 'xyz'
Out[1]: True

In [2]: b'xyz' == 'xyz'
Out[2]: True

In [3]: u'xyz' == 'xyz'
Out[3]: True
```

Python3

```
In [1]: 'xyz' == 'xyz'
Out[1]: True

In [2]: b'xyz' == 'xyz'
Out[2]: False

In [3]: u'xyz' == 'xyz'
Out[3]: True
```

I have also confirmed that stretch (boost::python)'s `robot.GetName()` type is unicode. so the behavior should be the same on pybind11.

----

pipelineid=338041 Pipeline #492326