### PR TITLE
Fix Python3 WriteToMemory msgpack; should return bytes

### DIFF
--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -1802,11 +1802,7 @@ object PyEnvironmentBase::WriteToMemory(const std::string &filetype, const int o
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
         // https://github.com/pybind/pybind11/issues/1201
 #if PY_MAJOR_VERSION >= 3
-        if( filetype == "msgpack" ) {
-            return py::cast<py::object>(PyBytes_FromStringAndSize(output.data(), output.size()));
-        } else {
-            return py::cast<py::object>(PyUnicode_FromStringAndSize(output.data(), output.size()));
-        }
+        return py::cast<py::object>(PyBytes_FromStringAndSize(output.data(), output.size()));
 #else
         return py::cast<py::object>(PyString_FromStringAndSize(output.data(), output.size()));
 #endif

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -1802,7 +1802,11 @@ object PyEnvironmentBase::WriteToMemory(const std::string &filetype, const int o
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
         // https://github.com/pybind/pybind11/issues/1201
 #if PY_MAJOR_VERSION >= 3
-        return py::cast<py::object>(PyUnicode_FromStringAndSize(output.data(), output.size()));
+        if( filetype == "msgpack" ) {
+            return py::cast<py::object>(PyBytes_FromStringAndSize(output.data(), output.size()));
+        } else {
+            return py::cast<py::object>(PyUnicode_FromStringAndSize(output.data(), output.size()));
+        }
 #else
         return py::cast<py::object>(PyString_FromStringAndSize(output.data(), output.size()));
 #endif


### PR DESCRIPTION
if filetype == "msgpack", bytes have to be returned for sure. but not sure if whether bytes or str should be returned on json/collada.

testopenrave (non-legacy) **fully passed** locally on py3.