### PR TITLE
steal reference count when constructing pybind11::object for PyUnicode_Decode

### DIFF
--- a/python/bindings/include/openravepy/pybind11/pybind11_bindings.h
+++ b/python/bindings/include/openravepy/pybind11/pybind11_bindings.h
@@ -115,7 +115,7 @@ namespace py = pybind11;
 inline py::object ConvertStringToUnicode(const std::string& s)
 {
     PyObject *pyo = PyUnicode_Decode(s.c_str(), s.size(), "utf-8", nullptr);
-    return py::cast<py::object>(pyo); // py::handle_to_object(pyo);
+    return py::reinterpret_steal<py::object>(pyo);
 }
 
 #ifdef OPENRAVE_BINDINGS_PYARRAY

--- a/python/bindings/include/openravepy/pybind11/pybind11_bindings.h
+++ b/python/bindings/include/openravepy/pybind11/pybind11_bindings.h
@@ -42,7 +42,7 @@ inline object to_object(const std::string& t) {
     return bytes(t);
 }
 inline object handle_to_object(PyObject* pyo) {
-    return cast<object>(pyo);
+    return reinterpret_steal<object>(pyo);
 }
 template <typename T>
 inline object to_array_astype(PyObject* pyo) {


### PR DESCRIPTION
According to https://docs.python.org/2.7/c-api/unicode.html#c.PyUnicode_Decode , PyUnicode_Decode returns New reference. Meanwhile, pybind11::object internally increases the reference count when constructed. It seems like the latter causes double-increasing. To disable auto-increasing reference count, we should use py::reinterpret_steal.

This can also be said to handle_to_object, whose user is PyInt_FromLong.