### PR TITLE
specify -Wno-shadow on collada-dom and qhull

### DIFF
--- a/3rdparty/collada-2.4.0/CMakeLists.txt
+++ b/3rdparty/collada-2.4.0/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 add_dependencies(collada15reader libopenrave)
 target_link_libraries(collada15reader ${COLLADA_LIBS})
-set_target_properties(collada15reader PROPERTIES COMPILE_FLAGS "${libpcrecpp_CFLAGS_OTHERS} -DDOM_INCLUDE_LIBXML -DCOLLADA_DOM_DAEFLOAT_IS64 -DCOLLADA_DOM_SUPPORT150 ${Boost_CFLAGS}"
+set_target_properties(collada15reader PROPERTIES COMPILE_FLAGS "${libpcrecpp_CFLAGS_OTHERS} -DDOM_INCLUDE_LIBXML -DCOLLADA_DOM_DAEFLOAT_IS64 -DCOLLADA_DOM_SUPPORT150 -Wno-shadow ${Boost_CFLAGS}"
   LINK_FLAGS "${libpcrecpp_LDFLAGS_OTHERS}")
 
 else()

--- a/3rdparty/qhull/CMakeLists.txt
+++ b/3rdparty/qhull/CMakeLists.txt
@@ -1,2 +1,3 @@
 file(GLOB qhull_files ${CMAKE_CURRENT_SOURCE_DIR}/*.c)
 add_library(qhull STATIC ${qhull_files})
+set_target_properties(qhull PROPERTIES COMPILE_FLAGS "-Wno-shadow")


### PR DESCRIPTION
We install qhull from apt and build collada-dom via jhbuild, but in some cases people could want to build those from openrave/3rdparty. Then -Werror=shadow causes problems.