### PR TITLE
Fix redundant end effector collision check

### DIFF
--- a/plugins/fclrave/fclspace.cpp
+++ b/plugins/fclrave/fclspace.cpp
@@ -169,7 +169,7 @@ FCLSpace::FCLKinBodyInfoPtr FCLSpace::InitKinBody(KinBodyConstPtr pbody, FCLKinB
             CollisionGeometryPtr pfclgeomBV = std::make_shared<fcl::Box>(enclosingBV.max_ - enclosingBV.min_);
             pfclgeomBV->setUserData(nullptr);
             CollisionObjectPtr pfclcollBV = boost::make_shared<fcl::CollisionObject>(pfclgeomBV);
-            Transform trans(Vector(1,0,0,0),ConvertVectorFromFCL(0.5 * (enclosingBV.min_ + enclosingBV.max_)));
+            const Vector trans = ConvertVectorFromFCL(0.5 * (enclosingBV.min_ + enclosingBV.max_));
             pfclcollBV->setUserData(linkinfo.get());
             linkinfo->linkBV = std::make_pair(trans, pfclcollBV);
         }
@@ -498,17 +498,18 @@ void FCLSpace::_Synchronize(FCLKinBodyInfo& info, const KinBody& body)
         if( body.GetLinks().size() != info.vlinks.size() ) {
             throw OpenRAVE::OpenRAVEException(str(boost::format("env=%s, the current number of links in body '%s' are %d, and are not the same as the number cached links %d")%_penv->GetNameId()%body.GetName()%body.GetLinks().size()%info.vlinks.size()), OpenRAVE::ORE_InvalidState);
         }
-        CollisionObjectPtr pcoll;
+
         for(size_t i = 0; i < body.GetLinks().size(); ++i) {
-            const FCLSpace::FCLKinBodyInfo::LinkInfo& linkInfo = *info.vlinks[i];
-            pcoll = linkInfo.linkBV.second;
+            FCLSpace::FCLKinBodyInfo::LinkInfo& linkInfo = *info.vlinks[i];
+            CollisionObjectPtr& pcoll = linkInfo.linkBV.second; // avoid copying shared pointer for performance
             if( !pcoll ) {
                 continue;
             }
             const Transform& linkTransform = body.GetLinks()[i]->GetTransform();
-            Transform pose = linkTransform * linkInfo.linkBV.first;
-            fcl::Vec3f newPosition = ConvertVectorToFCL(pose.trans);
-            fcl::Quaternion3f newOrientation = ConvertQuaternionToFCL(pose.rot);
+            Transform pose = linkTransform;
+            pose.trans += pose.rotate(linkInfo.linkBV.first);
+            const fcl::Vec3f newPosition = ConvertVectorToFCL(pose.trans);
+            const fcl::Quaternion3f newOrientation = ConvertQuaternionToFCL(pose.rot);
 
             pcoll->setTranslation(newPosition);
             pcoll->setQuatRotation(newOrientation);
@@ -518,9 +519,9 @@ void FCLSpace::_Synchronize(FCLKinBodyInfo& info, const KinBody& body)
             //info.vlinks[i]->nLastStamp = info.nLastStamp;
             for (const TransformCollisionPair& pgeom : linkInfo.vgeoms) {
                 fcl::CollisionObject& coll = *pgeom.second;
-                Transform pose1 = linkTransform * pgeom.first;
-                fcl::Vec3f newPosition1 = ConvertVectorToFCL(pose1.trans);
-                fcl::Quaternion3f newOrientation1 = ConvertQuaternionToFCL(pose1.rot);
+                const Transform pose1 = linkTransform * pgeom.first;
+                const fcl::Vec3f newPosition1 = ConvertVectorToFCL(pose1.trans);
+                const fcl::Quaternion3f newOrientation1 = ConvertQuaternionToFCL(pose1.rot);
 
                 coll.setTranslation(newPosition1);
                 coll.setQuatRotation(newOrientation1);

--- a/plugins/fclrave/fclspace.h
+++ b/plugins/fclrave/fclspace.h
@@ -22,6 +22,7 @@ typedef boost::function<CollisionGeometryPtr (std::vector<fcl::Vec3f> const &poi
 typedef std::vector<fcl::CollisionObject *> CollisionGroup;
 typedef boost::shared_ptr<CollisionGroup> CollisionGroupPtr;
 typedef std::pair<Transform, CollisionObjectPtr> TransformCollisionPair;
+typedef std::pair<Vector, CollisionObjectPtr> TranslationCollisionPair;
 
 
 // Helper functions for conversions from OpenRAVE to FCL
@@ -130,7 +131,7 @@ public:
             vector< boost::shared_ptr<FCLGeometryInfo> > vgeominfos; ///< info for every geometry of the link
 
             //int nLastStamp; ///< Tracks if the collision geometries are up to date wrt the body update stamp. This is for narrow phase collision
-            TransformCollisionPair linkBV; ///< pair of the transformation and collision object corresponding to a bounding OBB for the link
+            TranslationCollisionPair linkBV; ///< pair of the translation and collision object corresponding to a bounding OBB for the link
             std::vector<TransformCollisionPair> vgeoms; ///< vector of transformations and collision object; one per geometries
             std::string bodylinkname; // for debugging purposes
             bool bFromKinBodyLink; ///< if true, then from kinbodylink. Otherwise from standalone object that does not have any KinBody associations

--- a/src/libopenrave/kinbodycollision.cpp
+++ b/src/libopenrave/kinbodycollision.cpp
@@ -425,7 +425,6 @@ bool KinBody::CheckLinkSelfCollision(int ilinkindex, CollisionReportPtr report)
     bool bincollision = false;
     LinkPtr plink = _veclinks.at(ilinkindex);
     if( plink->IsEnabled() ) {
-        boost::shared_ptr<TransformSaver<LinkPtr> > linksaver(new TransformSaver<LinkPtr>(plink)); // gcc optimization bug when linksaver is on stack?
         if( pchecker->CheckStandaloneSelfCollision(LinkConstPtr(plink),report) ) {
             if( !bAllLinkCollisions ) { // if checking all collisions, have to continue
                 return true;

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -1666,7 +1666,7 @@ void RobotBase::Manipulator::_ComputeInternalInformation()
             // sanity check
             FOREACHC(itarmdof,__varmdofindices) {
                 if( !probot->DoesAffect(probot->GetJointFromDOFIndex(*itarmdof)->GetJointIndex(), __pEffector->GetIndex()) ) {
-                    throw OPENRAVE_EXCEPTION_FORMAT(_("manipulator \"%s\" is not valid. end effector link \"%s\" is not affected by joint \%s\""), GetName()%__pEffector->GetName()%probot->GetJointFromDOFIndex(*itarmdof)->GetName(), ORE_Failed);
+                    throw OPENRAVE_EXCEPTION_FORMAT(_("manipulator \"%s\" is not valid. end effector link \"%s\" is not affected by joint \"%s\""), GetName()%__pEffector->GetName()%probot->GetJointFromDOFIndex(*itarmdof)->GetName(), ORE_Failed);
                 }
             }
         }


### PR DESCRIPTION
1. end effector collision check functions seem to be computing collision twice for the same link.
2. removed unnecessary `TransformSaver`
3. small optimizations to fclrave

@eisoku9618 