### PR TITLE
Canonicalize libraryname

### DIFF
--- a/src/libopenrave/plugindatabase.cpp
+++ b/src/libopenrave/plugindatabase.cpp
@@ -216,9 +216,11 @@ void DynamicRaveDatabase::ReloadPlugins()
 bool DynamicRaveDatabase::LoadPlugin(const std::string& libraryname)
 {
     std::string canonicalizedLibraryname = libraryname;
+#ifndef _WIN32
     if(canonicalizedLibraryname.substr(0, 3) != "lib") {
         canonicalizedLibraryname = "lib" + canonicalizedLibraryname;
     }
+#endif
     if(canonicalizedLibraryname.substr(canonicalizedLibraryname.size() - PLUGIN_EXT.size()) != PLUGIN_EXT) {
         canonicalizedLibraryname += PLUGIN_EXT;
     }

--- a/src/libopenrave/plugindatabase.cpp
+++ b/src/libopenrave/plugindatabase.cpp
@@ -133,21 +133,19 @@ DynamicRaveDatabase::~DynamicRaveDatabase()
 void DynamicRaveDatabase::Init()
 {
     const char* pOPENRAVE_PLUGINS = getenv("OPENRAVE_PLUGINS"); // getenv not thread-safe?
-    if (!pOPENRAVE_PLUGINS) {
-        RAVELOG_WARN("Failed to read environment variable OPENRAVE_PLUGINS");
-        return;
-    }
     std::vector<std::string> vplugindirs;
-    utils::TokenizeString(pOPENRAVE_PLUGINS, s_delimiter, vplugindirs);
-    for (int iplugindir = vplugindirs.size() - 1; iplugindir > 0; iplugindir--) {
-        int jplugindir = 0;
-        for(; jplugindir < iplugindir; jplugindir++) {
-            if(vplugindirs[iplugindir] == vplugindirs[jplugindir]) {
-                break;
+    if (!!pOPENRAVE_PLUGINS) {
+        utils::TokenizeString(pOPENRAVE_PLUGINS, s_delimiter, vplugindirs);
+        for (int iplugindir = vplugindirs.size() - 1; iplugindir > 0; iplugindir--) {
+            int jplugindir = 0;
+            for(; jplugindir < iplugindir; jplugindir++) {
+                if(vplugindirs[iplugindir] == vplugindirs[jplugindir]) {
+                    break;
+                }
             }
-        }
-        if (jplugindir < iplugindir) {
-            vplugindirs.erase(vplugindirs.begin()+iplugindir);
+            if (jplugindir < iplugindir) {
+                vplugindirs.erase(vplugindirs.begin()+iplugindir);
+            }
         }
     }
     bool bExists = false;

--- a/src/libopenrave/plugindatabase.cpp
+++ b/src/libopenrave/plugindatabase.cpp
@@ -148,6 +148,9 @@ void DynamicRaveDatabase::Init()
             }
         }
     }
+    else {
+        RAVELOG_WARN("Failed to read environment variable OPENRAVE_PLUGINS");
+    }
     bool bExists = false;
     std::string installdir = OPENRAVE_PLUGINS_INSTALL_DIR;
 #ifdef HAVE_BOOST_FILESYSTEM


### PR DESCRIPTION
This pull request tries to resolve two issues:

- Canonicalize LoadPlugin argument
- Allow OPENRAVE_PLUGINS not set, which is useful for plain openrave installation

I checked that test_global.py works.