### PR TITLE
make PyEnvironmentBase a public API

### DIFF
--- a/python/bindings/include/openravepy/openravepy_environmentbase.h
+++ b/python/bindings/include/openravepy/openravepy_environmentbase.h
@@ -23,7 +23,7 @@
 namespace openravepy {
 using py::object;
 
-class PyEnvironmentBase : public OPENRAVE_ENABLE_SHARED_FROM_THIS<PyEnvironmentBase>
+class OPENRAVEPY_API PyEnvironmentBase : public OPENRAVE_ENABLE_SHARED_FROM_THIS<PyEnvironmentBase>
 {
     std::mutex _envmutex;
     std::list<OPENRAVE_SHARED_PTR<EnvironmentLock> > _listenvlocks, _listfreelocks;


### PR DESCRIPTION
Ziyan asked me to write a unified `NotifyEnvironmentChanged` implementation. While working on it, I realize I need to have access to `PyEnvironmentBase` in order to make python binding work. Can we mark this class as a public openrave API?