### PR TITLE
Fix not clearing hash in Destroy

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -486,6 +486,8 @@ void KinBody::Destroy()
 
     _ResetInternalCollisionCache();
     _selfcollisionchecker.reset();
+
+    __hashKinematicsGeometryDynamics.resize(0);
 }
 
 bool KinBody::InitFromBoxes(const std::vector<AABB>& vaabbs, bool visible, const std::string& uri)


### PR DESCRIPTION
In https://github.com/rdiankov/openrave/pull/1240, hash is not cleared any more in the call stack of adding to environment, so instead need to clear it in ``Destroy``