### PR TITLE
fix piecewisepolynomials missing symbol _ZN8OpenRAVE21RampOptimizerInternal21ParabolicInterpolator30_ImposeJointLimitFixedDurationERNS0_14ParabolicCurveEddddb

### DIFF
--- a/plugins/rplanners/piecewisepolynomials/CMakeLists.txt
+++ b/plugins/rplanners/piecewisepolynomials/CMakeLists.txt
@@ -3,7 +3,7 @@ message(STATUS "Eigen3 version: ${Eigen3_VERSION}")
 include_directories(${EIGEN3_INCLUDE_DIRS})
 
 add_library(piecewisepolynomials STATIC polynomialcommon.h polynomialtrajectory.h polynomialtrajectory.cpp polynomialchecker.h polynomialchecker.cpp interpolatorbase.h cubicinterpolator.h cubicinterpolator.cpp quinticinterpolator.h quinticinterpolator.cpp feasibilitychecker.h generalrecursiveinterpolator.h generalrecursiveinterpolator.cpp)
-target_link_libraries(piecewisepolynomials PRIVATE boost_assertion_failed PUBLIC libopenrave)
+target_link_libraries(piecewisepolynomials PRIVATE boost_assertion_failed PUBLIC rampoptimizer libopenrave)
 set_target_properties(piecewisepolynomials PROPERTIES COMPILE_FLAGS "${PLUGIN_COMPILE_FLAGS}" LINK_FLAGS "${PLUGIN_LINK_FLAGS}")
 
 install(TARGETS piecewisepolynomials DESTINATION ${OPENRAVE_PLUGINS_INSTALL_DIR} COMPONENT ${PLUGINS_BASE})


### PR DESCRIPTION
Phenomenon:

```
mujin@desktop59:~ $ ipython2
Python 2.7.18 (default, Jul  3 2022, 03:00:00) 
Type "copyright", "credits" or "license" for more information.

IPython 5.10.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import openravepy

In [2]: import openravepy.openravepy_piecewisepolynomials
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-2-aca189fa2829> in <module>()
----> 1 import openravepy.openravepy_piecewisepolynomials

ImportError: /home/mujin/mujin/jhbuildappcontroller/install/lib/python2.7/site-packages/openravepy/_openravepy_/openravepy_piecewisepolynomials.so: undefined symbol: _ZN8OpenRAVE21RampOptimizerInternal21ParabolicInterpolator30_ImposeJointLimitFixedDurationERNS0_14ParabolicCurveEddddb
```

Where it is used:

plugins/rplanners/piecewisepolynomials/generalrecursiveinterpolator.cpp
84:    bool bFixLimits = parabolicInterpolator._ImposeJointLimitFixedDuration(curve, xmin, xmax, vm, am);

@felixvd