### PR TITLE
Compile error when trying to index a py::object with size_t key

### DIFF
--- a/plugins/rplanners/parabolicsmoother2.cpp
+++ b/plugins/rplanners/parabolicsmoother2.cpp
@@ -12,6 +12,7 @@
 // You should have received a copy of the GNU Lesser General Public License along with this program.
 // If not, see <http://www.gnu.org/licenses/>.
 #include "openraveplugindefs.h"
+#include <cfloat>
 #include <fstream>
 #include <openrave/planningutils.h>
 

--- a/python/bindings/openravepy_global.cpp
+++ b/python/bindings/openravepy_global.cpp
@@ -349,10 +349,11 @@ std::vector<OrientedBox> ExtractOrientedBoxArray(py::object pyOrientedBoxList)
     if( IS_PYTHONOBJECT_NONE(pyOrientedBoxList) ) {
         return {};
     }
-    const size_t arraySize = len(pyOrientedBoxList);
+    py::list pyOrientedBoxArray(pyOrientedBoxList);
+    const size_t arraySize = pyOrientedBoxArray.size();
     std::vector<OrientedBox> vOrientedBox(arraySize);
     for(size_t iOrientedBox = 0; iOrientedBox < arraySize; ++iOrientedBox) {
-        vOrientedBox[iOrientedBox] = ExtractOrientedBox(pyOrientedBoxList[iOrientedBox]);
+        vOrientedBox[iOrientedBox] = ExtractOrientedBox(pyOrientedBoxArray[iOrientedBox]);
     }
     return vOrientedBox;
 }

--- a/python/bindings/openravepy_global.cpp
+++ b/python/bindings/openravepy_global.cpp
@@ -349,11 +349,10 @@ std::vector<OrientedBox> ExtractOrientedBoxArray(py::object pyOrientedBoxList)
     if( IS_PYTHONOBJECT_NONE(pyOrientedBoxList) ) {
         return {};
     }
-    py::list pyOrientedBoxArray(pyOrientedBoxList);
-    const size_t arraySize = pyOrientedBoxArray.size();
+    const size_t arraySize = len(pyOrientedBoxList);
     std::vector<OrientedBox> vOrientedBox(arraySize);
     for(size_t iOrientedBox = 0; iOrientedBox < arraySize; ++iOrientedBox) {
-        vOrientedBox[iOrientedBox] = ExtractOrientedBox(pyOrientedBoxArray[iOrientedBox]);
+        vOrientedBox[iOrientedBox] = ExtractOrientedBox(pyOrientedBoxList[py::to_object(iOrientedBox)]);
     }
     return vOrientedBox;
 }

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -686,19 +686,17 @@ JointControlInfo_RobotControllerPtr PyJointControlInfo_RobotController::GetJoint
         }
     }
     if( !IS_PYTHONOBJECT_NONE(robotControllerAxisMult) ) {
-        py::list robotControllerAxisMultList(robotControllerAxisMult);
-        size_t num = robotControllerAxisMultList.size();
+        size_t num = len(robotControllerAxisMult);
         OPENRAVE_EXCEPTION_FORMAT0(num == info.robotControllerAxisMult.size(), ORE_InvalidState);
         for( size_t i = 0; i < num; ++i ) {
-            info.robotControllerAxisMult[i] = py::extract<dReal>(robotControllerAxisMultList[i]);
+            info.robotControllerAxisMult[i] = py::extract<dReal>(robotControllerAxisMult[py::to_object(i)]);
         }
     }
     if( !IS_PYTHONOBJECT_NONE(robotControllerAxisOffset) ) {
-        py::list robotControllerAxisOffsetList(robotControllerAxisOffset);
-        size_t num = robotControllerAxisOffsetList.size();
+        size_t num = len(robotControllerAxisOffset);
         OPENRAVE_EXCEPTION_FORMAT0(num == info.robotControllerAxisOffset.size(), ORE_InvalidState);
         for( size_t i = 0; i < num; ++i ) {
-            info.robotControllerAxisOffset[i] = py::extract<dReal>(robotControllerAxisOffsetList[i]);
+            info.robotControllerAxisOffset[i] = py::extract<dReal>(robotControllerAxisOffset[py::to_object(i)]);
         }
     }
     if( !IS_PYTHONOBJECT_NONE(robotControllerAxisProductCode) ) {

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -686,17 +686,19 @@ JointControlInfo_RobotControllerPtr PyJointControlInfo_RobotController::GetJoint
         }
     }
     if( !IS_PYTHONOBJECT_NONE(robotControllerAxisMult) ) {
-        size_t num = len(robotControllerAxisMult);
+        py::list robotControllerAxisMultList(robotControllerAxisMult);
+        size_t num = robotControllerAxisMultList.size();
         OPENRAVE_EXCEPTION_FORMAT0(num == info.robotControllerAxisMult.size(), ORE_InvalidState);
         for( size_t i = 0; i < num; ++i ) {
-            info.robotControllerAxisMult[i] = py::extract<dReal>(robotControllerAxisMult[i]);
+            info.robotControllerAxisMult[i] = py::extract<dReal>(robotControllerAxisMultList[i]);
         }
     }
     if( !IS_PYTHONOBJECT_NONE(robotControllerAxisOffset) ) {
-        size_t num = len(robotControllerAxisOffset);
+        py::list robotControllerAxisOffsetList(robotControllerAxisOffset);
+        size_t num = robotControllerAxisOffsetList.size();
         OPENRAVE_EXCEPTION_FORMAT0(num == info.robotControllerAxisOffset.size(), ORE_InvalidState);
         for( size_t i = 0; i < num; ++i ) {
-            info.robotControllerAxisOffset[i] = py::extract<dReal>(robotControllerAxisOffset[i]);
+            info.robotControllerAxisOffset[i] = py::extract<dReal>(robotControllerAxisOffsetList[i]);
         }
     }
     if( !IS_PYTHONOBJECT_NONE(robotControllerAxisProductCode) ) {


### PR DESCRIPTION
When compiling natively with certain combinations of flags:

```
cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
    -DODE_USE_MULTITHREAD=ON \
    -DOPT_IKFAST_FLOAT32=OFF \
    -DOPENRAVE_MSGPACK=OFF  \
    -DOPT_LOG4CXX=ON \
    -DBoost_NO_BOOST_CMAKE=OFF \
    -DUSE_PYBIND11_PYTHON_BINDINGS=ON \
    -DOPT_INSTALL_3DMODELDATA=OFF \
    -DOPT_MSGPACK=OFF \
    -DOPT_CURL=OFF \
    -DOPT_OCTAVE=OFF \
    -DOPT_COLLADA=OFF \
    -DOPT_MATLAB=OFF \
    -DOPT_STATIC=OFF \
    -DOPT_PYTHON=OFF  \
    -DCMAKE_CXX_FLAGS="-Wno-shadow"
```

I ran into a compilation error:

```
/home/user/Code/openrave/python/bindings/openravepy_global.cpp:355:75: error: invalid conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘const char*’ [-fpermissive]
  355 |         vOrientedBox[iOrientedBox] = ExtractOrientedBox(pyOrientedBoxList[iOrientedBox]);
      |                                                                           ^~~~~~~~~~~~
      |                                                                           |
      |                                                                           size_t {aka long unsigned int}
```

The reason is because `py::object::operator[]` takes a string (`const char*`) instead of an integral value like `size_t`.

I imagine that what we really want is to cast the `py::object` into a `py::list` before trying to index it, so I applied a fix that does so accordingly.

I'm not sure why this error is not encountered in other builds. Perhaps it's due to very old versions of pybind11?

----

Edit by ciel: This is a new instances of https://github.com/rdiankov/openrave/pull/1125 .