### PR TITLE
openravepy_int: Switch away from deprecated GIL saving API.

### DIFF
--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -209,12 +209,16 @@ protected:
 class OPENRAVEPY_API PythonGILSaver
 {
 public:
-    PythonGILSaver() {
-        PyEval_ReleaseLock();
+    PythonGILSaver()
+        : _pythreadstate(PyEval_SaveThread()) {
     }
-    virtual ~PythonGILSaver() {
-        PyEval_AcquireLock();
+
+    virtual ~PythonGILSaver() noexcept {
+        PyEval_RestoreThread(_pythreadstate);
     }
+
+private:
+    PyThreadState* _pythreadstate;
 };
 
 class OPENRAVEPY_API AutoPyArrayObjectDereferencer


### PR DESCRIPTION
[From the original issue:](https://github.com/python/cpython/issues/84179)
"The PyEval_AcquireLock() and PyEval_ReleaseLock() functions are misleading and deprecated since Python 3.2."

Also silences another few dozen lines of warnings since the code resides in a header file included in all pybind source.

Pipeline #561855