### PR TITLE
Overwrite uri from atts

### DIFF
--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -1797,6 +1797,14 @@ public:
                 robot->__struri = preader->_filename;
             }
         }
+        if( !!robot ) {
+            // check if have to reset the URI
+            FOREACHC(itatt, atts) {
+                if( itatt->first == "uri" ) {
+                    robot->__struri = itatt->second;
+                }
+            }
+        }
 
         return robot;
     }
@@ -1997,6 +2005,14 @@ public:
             }
             if( body->__struri.empty() ) {
                 body->__struri = preader->_filename;
+            }
+        }
+        if( !!body ) {
+            // check if have to reset the URI
+            FOREACHC(itatt, atts) {
+                if( itatt->first == "uri" ) {
+                    body->__struri = itatt->second;
+                }
             }
         }
 


### PR DESCRIPTION
A recent [commit](https://github.com/rdiankov/openrave/commit/24e05b21716c436c20ba53a8138bc38145ac7f6f) breaks 
`test_robotbridgestate/test_NotifyRobotChanged[True]`. Not sure how to fix it correctly, but allowing overwriting URI from `atts` can fix the test. 