### PR TITLE
Add GetCollisionMesh binding

### DIFF
--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -76,6 +76,7 @@ public:
     object GetConicalFrustumTopRadius() const;
     object GetConicalFrustumBottomRadius() const;
     object GetConicalFrustumHeight() const;
+    object GetCollisionMesh();
 
     std::string __repr__();
     std::string __str__();

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -534,6 +534,13 @@ object PyGeometryInfo::GetConicalFrustumHeight() const {
     return _vGeomData[2];
 }
 
+object PyGeometryInfo::GetCollisionMesh()
+{
+    KinBody::GeometryInfoPtr pgeominfo = GetGeometryInfo();
+    pgeominfo->InitCollisionMesh();
+    return toPyTriMesh(pgeominfo->_meshcollision);
+}
+
 std::string PyGeometryInfo::__repr__()
 {
     rapidjson::Document doc;
@@ -5027,6 +5034,7 @@ void init_openravepy_kinbody()
                           .def("GetConicalFrustumTopRadius",&PyGeometryInfo::GetConicalFrustumTopRadius, DOXY_FN(GeomeryInfo,GetConicalFrustumTopRadius))
                           .def("GetConicalFrustumBottomRadius",&PyGeometryInfo::GetConicalFrustumBottomRadius, DOXY_FN(GeomeryInfo,GetConicalFrustumBottomRadius))
                           .def("GetConicalFrustumHeight",&PyGeometryInfo::GetConicalFrustumHeight, DOXY_FN(GeomeryInfo,GetConicalFrustumHeight))
+                          .def("GetCollisionMesh",&PyGeometryInfo::GetCollisionMesh, DOXY_FN(GeomeryInfo,GetCollisionMesh))
 #ifdef USE_PYBIND11_PYTHON_BINDINGS
                           .def("SerializeJSON", &PyGeometryInfo::SerializeJSON,
                                "unitScale"_a = 1.0,


### PR DESCRIPTION
This PR adds `GetCollisionMesh` binding to `PyGeometryInfo`.