### PR TITLE
Make the unit standard value functions constexpr

### DIFF
--- a/include/openrave/units.h
+++ b/include/openrave/units.h
@@ -156,7 +156,7 @@ inline T GetLengthUnitStandardValue(const std::string& s) {
 
 // \brief how many units in a meter
 template <typename T>
-inline T GetLengthUnitStandardValue(const LengthUnit unit)
+constexpr inline T GetLengthUnitStandardValue(const LengthUnit unit)
 {
     if( unit == OpenRAVE::LU_Meter ) {
         return T(1.0);
@@ -239,7 +239,7 @@ inline T GetMassUnitStandardValue(const std::string& s) {
 
 // \brief how many units in a gram
 template <typename T>
-inline T GetMassUnitStandardValue(const MassUnit unit)
+constexpr inline T GetMassUnitStandardValue(const MassUnit unit)
 {
     if( unit == OpenRAVE::MU_Gram ) {
         return T(1.0);
@@ -310,7 +310,7 @@ inline T GetTimeUnitStandardValue(const std::string& s) {
 
 // \brief how many units in a second
 template <typename T>
-inline T GetTimeUnitStandardValue(const TimeUnit unit)
+constexpr inline T GetTimeUnitStandardValue(const TimeUnit unit)
 {
     if( unit == OpenRAVE::TU_Second ) {
         return T(1.0);
@@ -376,7 +376,7 @@ inline T GetAngleUnitStandardValue(const std::string& s) {
 
 // \brief how many units in a radian
 template <typename T>
-inline T GetAngleUnitStandardValue(const AngleUnit unit)
+constexpr inline T GetAngleUnitStandardValue(const AngleUnit unit)
 {
     if( unit == OpenRAVE::AU_Radian ) {
         return T(1.0);

--- a/include/openrave/units.h
+++ b/include/openrave/units.h
@@ -187,6 +187,7 @@ constexpr inline T GetLengthUnitStandardValue(const LengthUnit unit)
     }
 
     throw OPENRAVE_EXCEPTION_FORMAT("Unsupported length unit '%s'", GetLengthUnitString(unit), ORE_LengthUnitInvalid);
+    return T{};
 }
 
 template <typename T>
@@ -255,6 +256,7 @@ constexpr inline T GetMassUnitStandardValue(const MassUnit unit)
     }
 
     throw OPENRAVE_EXCEPTION_FORMAT("Unsupported mass unit '%s'", GetMassUnitString(unit), ORE_LengthUnitInvalid);
+    return T{};
 }
 
 template <typename T>
@@ -329,6 +331,7 @@ constexpr inline T GetTimeUnitStandardValue(const TimeUnit unit)
     }
 
     throw OPENRAVE_EXCEPTION_FORMAT("Unsupported time unit '%s'", GetTimeUnitString(unit), ORE_LengthUnitInvalid);
+    return T{};
 }
 
 template <typename T>
@@ -386,6 +389,7 @@ constexpr inline T GetAngleUnitStandardValue(const AngleUnit unit)
     }
 
     throw OPENRAVE_EXCEPTION_FORMAT("Unsupported angle unit '%s'", GetAngleUnitString(unit), ORE_LengthUnitInvalid);
+    return T{};
 }
 
 template <typename T>


### PR DESCRIPTION
This change requires c++14 to compile but the code can if needed be changed to support c++11 by writing something like
```
    return unit == OpenRAVE::LU_Meter ? 1.0 :
           unit == OpenRAVE::LU_Millimeter ? 1e3 :
           ...
           throw ...;
```