### PR TITLE
cast GeometryType to int when serializing

### DIFF
--- a/src/libopenrave/kinbodygeometry.cpp
+++ b/src/libopenrave/kinbodygeometry.cpp
@@ -1781,7 +1781,7 @@ AABB KinBody::Geometry::ComputeAABB(const Transform& t) const
 void KinBody::Geometry::serialize(std::ostream& o, int options) const
 {
     SerializeRound(o,_info._t);
-    o << _info._type << " ";
+    o << (int)_info._type << " ";
     SerializeRound3(o,_info._vRenderScale);
     if( _info._type == GT_TriMesh ) {
         _info._meshcollision.serialize(o,options);


### PR DESCRIPTION
https://github.com/rdiankov/openrave/commit/d841c7633ec34cbd95c6486811eb2d5401b198ad#diff-f6b2317998343e31af6a1b2108eb6b453aeadb49c362a4fd3c24b6f36455cbeeR46 changed GeometryType. Usually it is ok as types are coerced, but in serialize(), now `_info._type` is considered as unsigned char. This caused unexpected GetKinematicsGeometryHash change. (I suppose that) this invalidated robot cache (robot.md5).

/cc @ntohge