### PR TITLE
Fix crop margin visualization

### DIFF
--- a/plugins/qtosgrave/osgrenderitem.cpp
+++ b/plugins/qtosgrave/osgrenderitem.cpp
@@ -901,6 +901,7 @@ void KinBodyItem::SetCropContainerMarginsVisible(const std::string& linkName, co
             _visibleCropContainerMargins.insert(linkGeometryNames);
         } else {
             _visibleCropContainerMargins.erase(linkGeometryNames);
+            _cropContainerMarginsLabel = nullptr;
         }
         Load();
     }
@@ -909,6 +910,7 @@ void KinBodyItem::SetCropContainerMarginsVisible(const std::string& linkName, co
             _visibleCropContainerEmptyMargins.insert(linkGeometryNames);
         } else {
             _visibleCropContainerEmptyMargins.erase(linkGeometryNames);
+            _cropContainerEmptyMarginsLabel = nullptr;
         }
         Load();
     }

--- a/plugins/qtosgrave/osgrenderitem.h
+++ b/plugins/qtosgrave/osgrenderitem.h
@@ -272,7 +272,7 @@ private:
     RobotBasePtr _probot;
 };
 
-void DrawCropContainerMargins(OSGGroupPtr pgeometrydata, const Vector& extents, const Vector& negativeCropContainerMargins, const Vector& positiveCropContainerMargins, const RaveVector<float>& color, float transparency);
+void DrawCropContainerMargins(OSGGroupPtr pgeometrydata, const Vector& outerExtents, const Vector& innerExtents, const Vector& negativeCropContainerMargins, const Vector& positiveCropContainerMargins, const RaveVector<float>& color, float transparency);
 
 #ifdef RAVE_REGISTER_BOOST
 #include BOOST_TYPEOF_INCREMENT_REGISTRATION_GROUP()


### PR DESCRIPTION
This PR fixes the following issues with crop margin visualization:

1. Labels remain in the viewer. Fixed by properly removing them when setting crop margin to be invisible. 
2. Crop margin visualization is lower than expected in the z-direction. Fixed by translating the box by the correct value. 

