### PR TITLE
Unbreak export for CMake 3.16 and Python-less consumers

### DIFF
--- a/openrave-config.cmake.in
+++ b/openrave-config.cmake.in
@@ -46,7 +46,6 @@ set_and_check(OpenRAVE_INCLUDE_DIR "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUD
 set_and_check(OpenRAVE_RAPIDJSON_INCLUDE_DIR "@RAPIDJSON_INCLUDES@")
 
 set( OpenRAVE_INCLUDE_DIRS ${OpenRAVE_INCLUDE_DIR} ${OpenRAVE_RAPIDJSON_INCLUDE_DIR} )
-set( OpenRAVE_LIBRARIES libopenrave )
 set( OpenRAVE_Boost_VERSION "@Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@" )
 set( OpenRAVE_BLA_VENDOR "@BLA_VENDOR@" )
 set( OpenRAVE_CXX_FLAGS "-DOPENRAVE_DLL -DOPENRAVE_CORE_DLL" )
@@ -90,15 +89,12 @@ if (OpenRAVE_USE_PYBIND11_PYTHON_BINDINGS OR OpenRAVE_USE_PYBIND11_PYTHON3_BINDI
 else()
   find_package(Boost ${OpenRAVE_Boost_VERSION} REQUIRED COMPONENTS python)
 endif()
-set_and_check(OpenRAVE_PYTHON_DIR "${OpenRAVE_PYTHON_DIR}")
 
 # Backward compatibility only.
 get_target_property(libopenrave_LOCATION OpenRAVE::libopenrave LOCATION)
 get_target_property(libopenrave-core_LOCATION OpenRAVE::libopenrave-core LOCATION)
+set(OpenRAVE_LIBRARIES "${libopenrave_LOCATION}")
 set(OpenRAVE_CORE_LIBRARIES "${libopenrave_LOCATION};${libopenrave-core_LOCATION}")
-
-add_library(libopenrave ALIAS OpenRAVE::libopenrave)
-add_library(libopenrave-core ALIAS OpenRAVE::libopenrave-core)
 
 find_package(Eigen3 3.3.7 REQUIRED)
 

--- a/openrave-config.cmake.in
+++ b/openrave-config.cmake.in
@@ -93,7 +93,7 @@ endif()
 # Backward compatibility only.
 get_target_property(libopenrave_LOCATION OpenRAVE::libopenrave LOCATION)
 get_target_property(libopenrave-core_LOCATION OpenRAVE::libopenrave-core LOCATION)
-set(OpenRAVE_LIBRARIES "${libopenrave_LOCATION}")
+set(OpenRAVE_LIBRARIES OpenRAVE::libopenrave)
 set(OpenRAVE_CORE_LIBRARIES "${libopenrave_LOCATION};${libopenrave-core_LOCATION}")
 
 find_package(Eigen3 3.3.7 REQUIRED)

--- a/openrave-config.cmake.in
+++ b/openrave-config.cmake.in
@@ -94,7 +94,7 @@ endif()
 get_target_property(libopenrave_LOCATION OpenRAVE::libopenrave LOCATION)
 get_target_property(libopenrave-core_LOCATION OpenRAVE::libopenrave-core LOCATION)
 set(OpenRAVE_LIBRARIES OpenRAVE::libopenrave)
-set(OpenRAVE_CORE_LIBRARIES "${libopenrave_LOCATION};${libopenrave-core_LOCATION}")
+set(OpenRAVE_CORE_LIBRARIES OpenRAVE::libopenrave;OpenRAVE::libopenrave-core)
 
 find_package(Eigen3 3.3.7 REQUIRED)
 


### PR DESCRIPTION
PR https://github.com/rdiankov/openrave/pull/1224 introduced a few regressions in the CMake config file for exports:

- A `set_and_check(OpenRAVE_PYTHON_DIR)` macro call that breaks for configurations that have Python bindings disabled. I suggest to remove this check since the exported variable is set within the preceding if clauses anyway.
- A pair of `add_library(libopenrave ALIAS ...)` instructions that issue an "add_library cannot create ALIAS target "libopenrave" because target "OpenRAVE::libopenrave" is imported but not globally visible." fatal error on CMake 3.16 (i.e. Ubuntu 20.04; it might not break at later releases, see [this thread](https://discourse.cmake.org/t/alias-and-not-globally-visible-targets/6305)). It is customary to prepend the namespace prefix to the target name in downstream projects, hence the alias would render redundant. If the intention was to allow parts of OpenRAVE itself to conditionally consume local and imported targets, then the alias should be created within OpenRAVE; for instance in [src/libopenrave/](https://github.com/rdiankov/openrave/blob/01e7c01a359d418d237a72cc1562491dc0649812/src/libopenrave/CMakeLists.txt#L57):
  ```cmake
  add_library(libopenrave SHARED ${openrave_lib_SOURCES})
  add_library(OpenRAVE::libopenrave ALIAS libopenrave) # add this if needed
  ```
- The `set( OpenRAVE_LIBRARIES libopenrave )` instruction adds a faulty link target without the library suffix. I suggest to move this to the "Backward compatibility only" section next to `OpenRAVE_CORE_LIBRARIES`, and query the proper binary location from the modern target in a similar fashion.

I would also suggest (not in the scope of this PR) using [`find_dependency`](https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html) instead of `find_package`.

cc @undisputed-seraphim