### PR TITLE
Fix crop margin visualization for cages

### DIFF
--- a/plugins/qtosgrave/osgrenderitem.cpp
+++ b/plugins/qtosgrave/osgrenderitem.cpp
@@ -474,16 +474,23 @@ void KinBodyItem::Load()
                     geode->addDrawable(geom);
                     pgeometrydata->addChild(geode);
 
-                    if(orgeom->GetType() == GT_TriMesh || orgeom->GetType() == GT_Axial){
+                    if(orgeom->GetType() == GT_TriMesh || orgeom->GetType() == GT_Axial || orgeom->GetType() == GT_ConicalFrustum){
                         // CropContainerMargins and CropContainerEmptyMargins only exists in GT_Cage and GT_Container
                         break;
                     }
 
+                    float zOffset = 0;
+                    // For container and cage, compute the height of the base as zOffset
+                    if (orgeom->GetType() == GT_Container) {
+                        zOffset = orgeom->GetContainerOuterExtents().z - orgeom->GetContainerInnerExtents().z;
+                    } else if (orgeom->GetType() == GT_Cage) {
+                        zOffset = orgeom->GetCageBaseExtents().z * 2;
+                    }
                     std::pair<std::string, std::string> linkGeometryNames(porlink->GetName(), orgeom->GetName());
                     if (_visibleCropContainerMargins.count(linkGeometryNames) != 0) {
                         DrawCropContainerMargins(
                             pgeometrydata,
-                            orgeom->GetContainerOuterExtents(),
+                            zOffset,
                             orgeom->GetContainerInnerExtents(),
                             orgeom->GetNegativeCropContainerMargins(),
                             orgeom->GetPositiveCropContainerMargins(),
@@ -496,7 +503,7 @@ void KinBodyItem::Load()
                             RaveVector<float>(
                                 (orgeom->GetContainerInnerExtents().x - orgeom->GetNegativeCropContainerMargins().x - orgeom->GetPositiveCropContainerMargins().x) * 0.5,
                                 (orgeom->GetContainerInnerExtents().y - orgeom->GetNegativeCropContainerMargins().y - orgeom->GetPositiveCropContainerMargins().y) * 0.5,
-                                orgeom->GetContainerInnerExtents().z - orgeom->GetNegativeCropContainerMargins().z - orgeom->GetPositiveCropContainerMargins().z
+                                orgeom->GetContainerInnerExtents().z - orgeom->GetNegativeCropContainerMargins().z - orgeom->GetPositiveCropContainerMargins().z + zOffset
                             ) +
                             // adjust for length of the label
                             RaveVector<float>(-0.025, -0.28, 0),
@@ -508,7 +515,7 @@ void KinBodyItem::Load()
                     if (_visibleCropContainerEmptyMargins.count(linkGeometryNames) != 0) {
                         DrawCropContainerMargins(
                             pgeometrydata,
-                            orgeom->GetContainerOuterExtents(),
+                            zOffset,
                             orgeom->GetContainerInnerExtents(),
                             orgeom->GetNegativeCropContainerEmptyMargins(),
                             orgeom->GetPositiveCropContainerEmptyMargins(),
@@ -521,7 +528,7 @@ void KinBodyItem::Load()
                             RaveVector<float>(
                                 -(orgeom->GetContainerInnerExtents().x - orgeom->GetNegativeCropContainerEmptyMargins().x - orgeom->GetPositiveCropContainerEmptyMargins().x) * 0.5,
                                 -(orgeom->GetContainerInnerExtents().y - orgeom->GetNegativeCropContainerEmptyMargins().y - orgeom->GetPositiveCropContainerEmptyMargins().y) * 0.5,
-                                orgeom->GetContainerInnerExtents().z - orgeom->GetNegativeCropContainerEmptyMargins().z - orgeom->GetPositiveCropContainerEmptyMargins().z
+                                orgeom->GetContainerInnerExtents().z - orgeom->GetNegativeCropContainerEmptyMargins().z - orgeom->GetPositiveCropContainerEmptyMargins().z + zOffset
                             ) +
                             // adjust for length of the label
                             RaveVector<float>(0.025, 0.35, 0),
@@ -1149,7 +1156,7 @@ bool RobotItem::UpdateFromModel(const vector<dReal>& vjointvalues, const vector<
     return true;
 }
 
-void DrawCropContainerMargins(OSGGroupPtr pgeometrydata, const Vector& outerExtents, const Vector& innerExtents, const Vector& negativeCropContainerMargins, const Vector& positiveCropContainerMargins, const RaveVector<float>& color, float transparency){
+void DrawCropContainerMargins(OSGGroupPtr pgeometrydata, const float zOffset, const Vector& innerExtents, const Vector& negativeCropContainerMargins, const Vector& positiveCropContainerMargins, const RaveVector<float>& color, float transparency){
     if(negativeCropContainerMargins == Vector(0, 0, 0) && positiveCropContainerMargins == Vector(0, 0, 0)){
         // do nothing if CropContainerMargins are all zeros
         return;
@@ -1160,10 +1167,9 @@ void DrawCropContainerMargins(OSGGroupPtr pgeometrydata, const Vector& outerExte
         (negativeCropContainerMargins.x - positiveCropContainerMargins.x) * 0.5,
         (negativeCropContainerMargins.y - positiveCropContainerMargins.y) * 0.5,
         // The z = 0 plane sits at the bottom of the outer extent.
-        // First, move up by (outerExtents.z - innerExtents.z) to reach the bottom of inner extent.
+        // First, move up by zOffset to reach the bottom of inner extent.
         // Then move up by (innerExtents.z / 2) to reach the center of the box.
-        // Thus the center of the inner extent box is (0, 0, (outerExtents.z - innerExtents.z / 2))
-        (negativeCropContainerMargins.z - positiveCropContainerMargins.z) * 0.5 + (outerExtents.z - innerExtents.z * 0.5)
+        (negativeCropContainerMargins.z - positiveCropContainerMargins.z) * 0.5 + innerExtents.z * 0.5 + zOffset
     ));
     box->setHalfLengths(osg::Vec3f(
         (innerExtents.x - negativeCropContainerMargins.x - positiveCropContainerMargins.x) * 0.5,

--- a/plugins/qtosgrave/osgrenderitem.h
+++ b/plugins/qtosgrave/osgrenderitem.h
@@ -272,7 +272,7 @@ private:
     RobotBasePtr _probot;
 };
 
-void DrawCropContainerMargins(OSGGroupPtr pgeometrydata, const Vector& outerExtents, const Vector& innerExtents, const Vector& negativeCropContainerMargins, const Vector& positiveCropContainerMargins, const RaveVector<float>& color, float transparency);
+void DrawCropContainerMargins(OSGGroupPtr pgeometrydata, const float zOffset, const Vector& innerExtents, const Vector& negativeCropContainerMargins, const Vector& positiveCropContainerMargins, const RaveVector<float>& color, float transparency);
 
 #ifdef RAVE_REGISTER_BOOST
 #include BOOST_TYPEOF_INCREMENT_REGISTRATION_GROUP()


### PR DESCRIPTION
In https://github.com/rdiankov/openrave/pull/1295, the crop margin visualization is adjusted in the z direction using the geometry's outer extents. However, when the geometry is a cage, the same logic does not apply, and the visualization was still wrong. 

This PR fixes the issue by handling both cases explicitly. 