### PR TITLE
Correct the typo: tan(self.tvar) -> tan(self.var) in the "subsinv" list

### DIFF
--- a/python/ikfast.py
+++ b/python/ikfast.py
@@ -1343,7 +1343,7 @@ class IKFastSolver(AutoReloader):
             self.htvar = Symbol("ht%s"%var.name)
             self.vars = [self.var,self.svar,self.cvar,self.tvar,self.htvar]
             self.subs = [(cos(self.var),self.cvar),(sin(self.var),self.svar),(tan(self.var),self.tvar),(tan(self.var/2),self.htvar)]
-            self.subsinv = [(self.cvar,cos(self.var)),(self.svar, sin(self.var)),(self.tvar,tan(self.tvar))]
+            self.subsinv = [(self.cvar,cos(self.var)),(self.svar, sin(self.var)),(self.tvar,tan(self.var))]
         def getsubs(self,value):
             return [(self.var,value)]+[(s,v.subs(self.var,value).evalf()) for v,s in self.subs]
 

--- a/python/ikfast_sympy0_6.py
+++ b/python/ikfast_sympy0_6.py
@@ -1036,7 +1036,7 @@ class IKFastSolver(AutoReloader):
             self.htvar = Symbol("ht%s"%var.name)
             self.vars = [self.var,self.svar,self.cvar,self.tvar,self.htvar]
             self.subs = [(cos(self.var),self.cvar),(sin(self.var),self.svar),(tan(self.var),self.tvar),(tan(self.var/2),self.htvar)]
-            self.subsinv = [(self.cvar,cos(self.var)),(self.svar, sin(self.var)),(self.tvar,tan(self.tvar))]
+            self.subsinv = [(self.cvar,cos(self.var)),(self.svar, sin(self.var)),(self.tvar,tan(self.var))]
         def getsubs(self,value):
             return [(self.var,value)]+[(s,v.subs(self.var,value).evalf()) for v,s in self.subs]
 


### PR DESCRIPTION
A typo has been spotted in the member list "subsinv" of the class "Variable"

Not sure if that affected pair in the "subsinv" list is ever used for symbol substitution when solving equations, and I do not have any particular problems of which I can put my finger on that typo and say it is the cause; but I think it might be a good idea to have it corrected before it leads to any possible future issues.