### PR TITLE
Stock Pybind11 (2.9.2) compatibility issue

### DIFF
--- a/python/bindings/include/openravepy/openravepy_jointinfo.h
+++ b/python/bindings/include/openravepy/openravepy_jointinfo.h
@@ -71,8 +71,8 @@ public:
     void SetCageBaseHalfExtents(object oHalfExtents);
     void SetContainerOuterExtents(object oOuterExtents);
     void SetContainerInnerExtents(object oInnerExtents);
-    object GetCylinderRadius();
-    object GetCylinderHeight();
+    object GetCylinderRadius() const;
+    object GetCylinderHeight() const;
     object GetConicalFrustumTopRadius() const;
     object GetConicalFrustumBottomRadius() const;
     object GetConicalFrustumHeight() const;

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -519,11 +519,11 @@ object PyGeometryInfo::GetCylinderRadius() const
 
 object PyGeometryInfo::GetCylinderHeight() const
 {
-    return _vGeomData[1];
+    return _vGeomData[py::to_object(1)];
 }
 
 object PyGeometryInfo::GetConicalFrustumTopRadius() const {
-    return _vGeomData["0"];
+    return _vGeomData[py::to_object(0)];
 }
 
 object PyGeometryInfo::GetConicalFrustumBottomRadius() const {
@@ -531,7 +531,7 @@ object PyGeometryInfo::GetConicalFrustumBottomRadius() const {
 }
 
 object PyGeometryInfo::GetConicalFrustumHeight() const {
-    return _vGeomData["2"];
+    return _vGeomData[py::to_object(2)];
 }
 
 object PyGeometryInfo::GetCollisionMesh()

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -512,26 +512,26 @@ void PyGeometryInfo::SetContainerInnerExtents(object oInnerExtents)
     _vGeomData2 = oInnerExtents;
 }
 
-object PyGeometryInfo::GetCylinderRadius()
+object PyGeometryInfo::GetCylinderRadius() const
 {
-    return _vGeomData[0];
+    return _vGeomData[py::to_object(0)];
 }
 
-object PyGeometryInfo::GetCylinderHeight()
+object PyGeometryInfo::GetCylinderHeight() const
 {
     return _vGeomData[1];
 }
 
 object PyGeometryInfo::GetConicalFrustumTopRadius() const {
-    return _vGeomData[0];
+    return _vGeomData["0"];
 }
 
 object PyGeometryInfo::GetConicalFrustumBottomRadius() const {
-    return _vGeomData[1];
+    return _vGeomData[py::to_object(1)];
 }
 
 object PyGeometryInfo::GetConicalFrustumHeight() const {
-    return _vGeomData[2];
+    return _vGeomData["2"];
 }
 
 object PyGeometryInfo::GetCollisionMesh()


### PR DESCRIPTION
Got this error when building with stock pybind11:
```
openrave/python/bindings/openravepy_kinbody.cpp:522:23: error: invalid conversion from ‘int’ to ‘const char*’ [-fpermissive]
  522 |     return _vGeomData[1];
      |                       ^
      |                       |
      |                       int
```
we should use `py::to_object(0)` instead of the `int` when trying to access the elements using subscription.