### PR TITLE
WIP: allow void value (-1) in SetDOFValues indices

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -2160,7 +2160,9 @@ void KinBody::SetDOFValues(const dReal* pJointValues, int dof, uint32_t checklim
             // and then overwrite with the user set values
             GetDOFValues(_vTempJoints);
             for(size_t i = 0; i < dofindices.size(); ++i) {
-                _vTempJoints.at(dofindices[i]) = pJointValues[i];
+                if( dofindices[i] >= 0 ) {
+                    _vTempJoints.at(dofindices[i]) = pJointValues[i];
+                }
             }
             pJointValues = &_vTempJoints[0];
         }


### PR DESCRIPTION
So that we can call `SetDOFValues([1.0, 1.0, 1.0, 1.0, 0, 0, 2.0], [0, 1, 2, 3, 4, -1, -1, 7])`

/cc @ntohge