### PR TITLE
restore transform when EIO_SkipDOFValues and not added to env

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -6072,6 +6072,12 @@ void KinBody::ExtractInfo(KinBodyInfo& info, ExtractInfoOptions options)
 
     // in order for link transform comparision to make sense
     KinBody::KinBodyStateSaver stateSaver(shared_kinbody(), Save_LinkTransformation);
+    boost::shared_ptr<void> restoreTransformEvenWhenBodyIsNotAddedToEnv = nullptr;
+    if( (options & EIO_SkipDOFValues) && GetEnvironmentBodyIndex() == 0 ) {
+        RAVELOG_WARN("resetting DOF to zeros");
+        restoreTransformEvenWhenBodyIsNotAddedToEnv = boost::shared_ptr<void>((void*) 0, std::bind(&KinBody::SetTransform, this, std::cref(info._transform)));
+    }
+
     SetTransform(Transform()); // so that base link is at exactly _baseLinkInBodyTransform
     vector<dReal> vZeros(GetDOF(), 0);
     SetDOFValues(vZeros, KinBody::CLA_Nothing);


### PR DESCRIPTION
@rdiankov cc @yoshikikanemoto @kanbouchou @ziyan Since d841c7633ec34cbd95c6486811eb2d5401b198ad commit, users can call `KinBody::ExtractInfo()` whenever body is not added to environment. This has a side effect that the transform is reset to identity because

1. `KinBody::KinBodyStateSaver::~KinBodyStateSaver()` does not do anything when body is not added to environment
2. `KinBody::ExtractInfo()` interanally set tranform to identity and DOFs to zeros in order to collect `KinBodyInfo` relying on `KinBodyStateSaver`

As a result, just calling `KinBody::ExtractInfo()` to a body which is not added to env resets its transform.

```
body = RaveCreateKinBody(env, '')
body.InitFromBoxes([[0,0,0,1,1,1]])
body.SetTransform([1,0,0,0,1,2,3])
print('before: %r' % body.GetTransformPose())
body.ExtractInfo(ExtractInfoOptions.SkipDOFValues)
print('after: %r' % body.GetTransformPose())
```

```
before: array([1., 0., 0., 0., 1., 2., 3.])
after: array([1., 0., 0., 0., 0., 0., 0.])
```

With this PR, we can restore at least transform and warn about DOF resetting.


related discussion
- https://github.com/rdiankov/openrave/pull/1316#issuecomment-1749914852