### PR TITLE
Fix colladawriter overload, fixing skipwrite physics

### DIFF
--- a/src/libopenrave-core/environment-core.h
+++ b/src/libopenrave-core/environment-core.h
@@ -800,7 +800,12 @@ public:
             RaveWriteEncryptedMsgPackFile(listbodies,filename,atts,*_prLoadEnvAlloc);
         }
         else {
-            RaveWriteColladaFile(listbodies,filename,atts);
+            if( listbodies.size() == 1 ) {
+                RaveWriteColladaFile(listbodies.front(),filename,atts);
+            }
+            else {
+                RaveWriteColladaFile(listbodies,filename,atts);
+            }
         }
     }
 
@@ -938,7 +943,12 @@ public:
         }
 
         if (filetype == "collada") {
-            RaveWriteColladaMemory(listbodies, output, atts);
+            if( listbodies.size() == 1 ) {
+                RaveWriteColladaMemory(listbodies.front(), output, atts);
+            }
+            else {
+                RaveWriteColladaMemory(listbodies, output, atts);
+            }
         }
         else if (filetype == "json") {
             _ClearRapidJsonBuffer();


### PR DESCRIPTION
https://github.com/rdiankov/openrave/pull/1262 had one regression, where `if( listbodies.size() == 1 )RaveWriteColladaFile(listbodies.front(),filename,atts);`. colladawriter has very special meaning in `RaveWriteColladaFile(KinBodyPtr pbody)` overload. So this must not be removed.

This caused SEGV, but now fixed.

```
openrave.py -i src/robots/pr2-beta-static.zae
env.Save('1.mujin.dae', Environment.SelectionOptions.Body, {'target': robot.GetName(), 'skipwrite': 'visual geometry readable sensors physics'})
```

controllercommon CI will not pass until this is merged. Sorry for the inconvenience.

/cc @felixvd @ntohge