### PR TITLE
Re: Make the unit standard value functions constexpr

### DIFF
--- a/include/openrave/units.h
+++ b/include/openrave/units.h
@@ -156,7 +156,7 @@ inline T GetLengthUnitStandardValue(const std::string& s) {
 
 // \brief how many units in a meter
 template <typename T>
-inline T GetLengthUnitStandardValue(const LengthUnit unit)
+constexpr inline T GetLengthUnitStandardValue(const LengthUnit unit)
 {
     if( unit == OpenRAVE::LU_Meter ) {
         return T(1.0);
@@ -187,6 +187,7 @@ inline T GetLengthUnitStandardValue(const LengthUnit unit)
     }
 
     throw OPENRAVE_EXCEPTION_FORMAT("Unsupported length unit '%s'", GetLengthUnitString(unit), ORE_LengthUnitInvalid);
+    return T{};
 }
 
 template <typename T>
@@ -239,7 +240,7 @@ inline T GetMassUnitStandardValue(const std::string& s) {
 
 // \brief how many units in a gram
 template <typename T>
-inline T GetMassUnitStandardValue(const MassUnit unit)
+constexpr inline T GetMassUnitStandardValue(const MassUnit unit)
 {
     if( unit == OpenRAVE::MU_Gram ) {
         return T(1.0);
@@ -255,6 +256,7 @@ inline T GetMassUnitStandardValue(const MassUnit unit)
     }
 
     throw OPENRAVE_EXCEPTION_FORMAT("Unsupported mass unit '%s'", GetMassUnitString(unit), ORE_LengthUnitInvalid);
+    return T{};
 }
 
 template <typename T>
@@ -310,7 +312,7 @@ inline T GetTimeUnitStandardValue(const std::string& s) {
 
 // \brief how many units in a second
 template <typename T>
-inline T GetTimeUnitStandardValue(const TimeUnit unit)
+constexpr inline T GetTimeUnitStandardValue(const TimeUnit unit)
 {
     if( unit == OpenRAVE::TU_Second ) {
         return T(1.0);
@@ -329,6 +331,7 @@ inline T GetTimeUnitStandardValue(const TimeUnit unit)
     }
 
     throw OPENRAVE_EXCEPTION_FORMAT("Unsupported time unit '%s'", GetTimeUnitString(unit), ORE_LengthUnitInvalid);
+    return T{};
 }
 
 template <typename T>
@@ -376,7 +379,7 @@ inline T GetAngleUnitStandardValue(const std::string& s) {
 
 // \brief how many units in a radian
 template <typename T>
-inline T GetAngleUnitStandardValue(const AngleUnit unit)
+constexpr inline T GetAngleUnitStandardValue(const AngleUnit unit)
 {
     if( unit == OpenRAVE::AU_Radian ) {
         return T(1.0);
@@ -386,6 +389,7 @@ inline T GetAngleUnitStandardValue(const AngleUnit unit)
     }
 
     throw OPENRAVE_EXCEPTION_FORMAT("Unsupported angle unit '%s'", GetAngleUnitString(unit), ORE_LengthUnitInvalid);
+    return T{};
 }
 
 template <typename T>


### PR DESCRIPTION
Revert "revert constexpr change until it can be tested more"
This reverts commit 3bc6152ed7a26925c0bfc34d5bf40ac751617925.

redoing https://github.com/rdiankov/openrave/pull/1293

/cc @florisatmujin

----

Now all my cmake MRs are merged, it is time to take a look at this again.