### PR TITLE
fix test_planwithcollision for #1322

### DIFF
--- a/test/test_planning.py
+++ b/test/test_planning.py
@@ -364,7 +364,7 @@ class RunPlanning(EnvironmentSetup):
             assert(ret==None)
 
             robot.SetDOFValues([ 1.34046301, -0.52360053,  0.03541482, -2.32130534,  0, 0,  0], robot.GetManipulator('leftarm').GetArmIndices())
-            assert(robot.CheckSelfCollision())
+            assert(not robot.CheckSelfCollision())
             ret = basemanip.MoveToHandPosition([Tnew],jitter=0.08,execute=False)
             assert(ret is not None)
 


### PR DESCRIPTION
after #1322 , test_planning.py needs to be fixed. I'm not sure about this logic, so I'd like to have this reviewed (note: I clarify that this fix content is suggested by Yoshiki, not by me).

usually I don't touch test/ but this is tied to controllercommon/testopenrave this time.

after this is approved, I will update testopenrave (Note that controllercommon CI will not pass until this is approved).

/cc @ntohge

tested:

```
OPENRAVE_DATA=$PWD/src python -m nose -v test/test_planning.py:test_ode.test_planwithcollision
```