### PR TITLE
Fix en- and decrypt functions when not building with gpgme

### DIFF
--- a/src/libopenrave-core/jsonparser/gpgutils.cpp
+++ b/src/libopenrave-core/jsonparser/gpgutils.cpp
@@ -210,11 +210,11 @@ bool GpgEncrypt(std::istream& inputStream, std::ostream& outputStream, const std
 #else
 
 bool GpgDecrypt(std::istream&, std::ostream&) {
-    throw OPENRAVE_EXCEPTION_FORMAT("Encryption not enabled in OpenRAVE, but decryption was requested.");
+    throw OPENRAVE_EXCEPTION_FORMAT0("Encryption not enabled in OpenRAVE, but decryption was requested.", ORE_NotImplemented);
 }
 
-bool GpgEncrypt(std::istream&, std::ostream&, const std::string&) {
-    throw OPENRAVE_EXCEPTION_FORMAT("Encryption not enabled in OpenRAVE, but encryption was requested.");
+bool GpgEncrypt(std::istream&, std::ostream&, const std::unordered_set<std::string>&) {
+    throw OPENRAVE_EXCEPTION_FORMAT0("Encryption not enabled in OpenRAVE, but encryption was requested.", ORE_NotImplemented);
 }
 
 #endif


### PR DESCRIPTION
This fixes a compilation issue when building OpenRAVE with `-DOPT_ENCRYPTION=OFF`. Regarding the error code for `OPENRAVE_EXCEPTION_FORMAT`, I have picked `ORE_NotImplemented` similarly to:

https://github.com/rdiankov/openrave/blob/012d3488334befa3a6dffd0b4847bb5fda1afe46/src/libopenrave/openravemsgpack.cpp#L359-L362