### PR TITLE
Fix usage of CompareFirst/SecondBodyName return value

### DIFF
--- a/plugins/grasper/graspermodule.cpp
+++ b/plugins/grasper/graspermodule.cpp
@@ -1016,7 +1016,7 @@ public:
                         RAVELOG_VERBOSE(str(boost::format("contact %s\n")%report->__str__()));
                         for(int icollision = 0; icollision < report->nNumValidCollisions; ++icollision) {
                             const CollisionPairInfo& cpinfo = report->vCollisionInfos[icollision];
-                            bool bFirstMatchesRobot = cpinfo.CompareFirstBodyName(probot->GetName());
+                            bool bFirstMatchesRobot = cpinfo.CompareFirstBodyName(probot->GetName()) == 0;
                             for(const CONTACT& c : cpinfo.contacts) {
                                 if( bFirstMatchesRobot ) {
                                     grasp_params->contacts.emplace_back(c, (*itlink)->GetIndex());

--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -570,7 +570,7 @@ protected:
             if( !bIndependentLink2 && !bChildLink2 && !cpinfo.bodyLinkGeom2Name.empty() ) {
                 FOREACH(it,_listGrabbedSavedStates) {
                     const KinBodyPtr& pbody = it->GetBody();
-                    if( !!pbody && cpinfo.CompareSecondBodyName(pbody->GetName()) ) {
+                    if( !!pbody && cpinfo.CompareSecondBodyName(pbody->GetName()) == 0 /*compares equal*/ ) {
                         if( !_bCheckEndEffectorEnvCollision ) {
                             // if bodyLinkGeom1Name is not part of the robot, then ignore.
                             if( cpinfo.bodyLinkGeom1Name.empty() || cpinfo.CompareFirstBodyName(_probot->GetName()) != 0 ) {
@@ -587,7 +587,7 @@ protected:
             if( !bIndependentLink1 && !bChildLink1 && !cpinfo.bodyLinkGeom1Name.empty() ) {
                 FOREACH(it,_listGrabbedSavedStates) {
                     const KinBodyPtr& pbody = it->GetBody();
-                    if( !!pbody && cpinfo.CompareFirstBodyName(pbody->GetName()) ) {
+                    if( !!pbody && cpinfo.CompareFirstBodyName(pbody->GetName()) == 0 /*compares equal*/ ) {
                         if( !_bCheckEndEffectorEnvCollision ) {
                             // if plink2 is not part of the robot, then ignore. otherwise it needs to be counted as self-collision
                             if( cpinfo.bodyLinkGeom2Name.empty() || cpinfo.CompareSecondBodyName(_probot->GetName()) != 0 ) {

--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -570,7 +570,7 @@ protected:
             if( !bIndependentLink2 && !bChildLink2 && !cpinfo.bodyLinkGeom2Name.empty() ) {
                 FOREACH(it,_listGrabbedSavedStates) {
                     const KinBodyPtr& pbody = it->GetBody();
-                    if( !!pbody && cpinfo.CompareSecondBodyName(pbody->GetName()) == 0 /*compares equal*/ ) {
+                    if( !!pbody && cpinfo.CompareSecondBodyName(pbody->GetName()) == 0 /*equal*/ ) {
                         if( !_bCheckEndEffectorEnvCollision ) {
                             // if bodyLinkGeom1Name is not part of the robot, then ignore.
                             if( cpinfo.bodyLinkGeom1Name.empty() || cpinfo.CompareFirstBodyName(_probot->GetName()) != 0 ) {
@@ -587,7 +587,7 @@ protected:
             if( !bIndependentLink1 && !bChildLink1 && !cpinfo.bodyLinkGeom1Name.empty() ) {
                 FOREACH(it,_listGrabbedSavedStates) {
                     const KinBodyPtr& pbody = it->GetBody();
-                    if( !!pbody && cpinfo.CompareFirstBodyName(pbody->GetName()) == 0 /*compares equal*/ ) {
+                    if( !!pbody && cpinfo.CompareFirstBodyName(pbody->GetName()) == 0 /*equal*/ ) {
                         if( !_bCheckEndEffectorEnvCollision ) {
                             // if plink2 is not part of the robot, then ignore. otherwise it needs to be counted as self-collision
                             if( cpinfo.bodyLinkGeom2Name.empty() || cpinfo.CompareSecondBodyName(_probot->GetName()) != 0 ) {


### PR DESCRIPTION
### Summary

The recently added `CompareFirstBodyName` and `CompareSecondBodyName` functions in `CollisionPairInfo` return `0` when the given string compares _equal_ to the first and second body names, respectively.

There are some places that expect to test for equality but are missing the test `== 0`.

For example, in `StateCheckEndEffector::_CheckCollisionPair`, the condition reads
```c++
if( !!pbody && cpinfo.CompareSecondBodyName(pbody->GetName()) ) {
```
while the [original code](https://github.com/rdiankov/openrave/blob/6bbddfbe67e983bfde2e2903dce852f34bb4a788/plugins/ikfastsolvers/ikfastsolver.cpp#L574) reads
```c++
if( it->GetBody() == pcolliding ) {
```