### PR TITLE
Fix body-link transform update

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -2107,7 +2107,14 @@ void KinBody::SetDOFValues(const std::vector<dReal>& vJointValues, const Transfo
     if( _veclinks.size() == 0 ) {
         return;
     }
-    SetTransform(bodyTransform);
+    Transform baseLinkTransform = bodyTransform * _baseLinkInBodyTransform;
+    Transform tbase = baseLinkTransform*_veclinks.at(0)->GetTransform().inverse();
+    _veclinks.at(0)->SetTransform(baseLinkTransform);
+
+    // apply the relative transformation to all links!! (needed for passive joints)
+    for(size_t i = 1; i < _veclinks.size(); ++i) {
+        _veclinks[i]->SetTransform(tbase*_veclinks[i]->GetTransform());
+    }
     SetDOFValues(vJointValues,checklimits);
 }
 

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -6364,6 +6364,15 @@ UpdateFromInfoResult KinBody::UpdateFromKinBodyInfo(const KinBodyInfo& info)
         }
     }
 
+    // update the base link transform after all links have been updated
+    if( info._vLinkInfos.empty() ) {
+        _baseLinkInBodyTransform = _invBaseLinkInBodyTransform = Transform();
+    }
+    else {
+        _baseLinkInBodyTransform = info._vLinkInfos.front()->GetTransform();
+        _invBaseLinkInBodyTransform = _baseLinkInBodyTransform.inverse();
+    }
+
     // joints
     if (!UpdateChildrenFromInfo(info._vJointInfos, vJoints, updateFromInfoResult)) {
         return updateFromInfoResult;

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -1398,18 +1398,9 @@ void KinBody::SetTransform(const Transform& bodyTransform)
     if( _veclinks.size() == 0 ) {
         return;
     }
-    /*
-     * B (body transform), L_i (link i transform)
-     * BL_i (link i related to body transform, unchanged)
-     * B' (new body transform), L'_i (new link i transform)
-     *
-     * L_i = B x BL_i    => BL_i = B^-1 x L_i
-     * B = L_1 x BL_1^-1 => B^-1 = BL_1 x L_1^-1
-     * L'_i = B' x BL_i
-     *      = B' x B^-1 x L_i
-     *      = (B' x BL_1 x L_1^-1) x L_i
-     */
-    const Transform tapply = bodyTransform * _baseLinkInBodyTransform * _veclinks.front()->GetTransform().inverse();
+    Transform baseLinkTransform = bodyTransform * _baseLinkInBodyTransform;
+    Transform tbaseinv = _veclinks.front()->GetTransform().inverse();
+    Transform tapply = baseLinkTransform * tbaseinv;
     FOREACH(itlink, _veclinks) {
         (*itlink)->SetTransform(tapply * (*itlink)->GetTransform());
     }


### PR DESCRIPTION
Currently the body transform is incorrectly updated inside `KinBody::UpdateFromKinBodyInfo` due to an early change to   `_baseLinkInBodyTransform`, which resulted in a wrong link-body transformation state. This resulted in body transform changed in an unexpected way. This MR fixes this issue.