### PR TITLE
Use convex hull as a fallback

### DIFF
--- a/python/databases/convexdecomposition.py
+++ b/python/databases/convexdecomposition.py
@@ -285,19 +285,19 @@ class ConvexDecompositionModel(DatabaseGenerator):
         self.linkgeometry = []
         with self.env:
             links = self.robot.GetLinks()
-            for il,link in enumerate(links):
+            for il, link in enumerate(links):
                 geomhulls = []
                 geometries = link.GetGeometries()
-                for ig,geom in enumerate(geometries):
+                for ig, geom in enumerate(geometries):
                     trimesh = geom.GetCollisionMesh()
                     if len(trimesh.indices) == 0:
                         geom.InitCollisionMesh()
                         trimesh = geom.GetCollisionMesh()
                     if link.GetName() in convexHullLinks or (minTriangleConvexHullThresh is not None and len(trimesh.indices) > minTriangleConvexHullThresh):
-                        log.info(u'computing hull for link %d/%d geom %d/%d: vertices=%d, indices=%d',il,len(links), ig, len(geometries), len(trimesh.vertices), len(trimesh.indices))
+                        log.info(u'computing hull for link %d/%d geom %d/%d (%s:%s): vertices=%d, indices=%d', il, len(links), ig, len(geometries), link.GetName(), geom.GetName(), len(trimesh.vertices), len(trimesh.indices))
                         orghulls = [self.ComputePaddedConvexHullFromTriMesh(trimesh,padding)]
                     else:
-                        log.info(u'computing decomposition for link %d/%d geom %d/%d type %s',il,len(links), ig, len(geometries), geom.GetType())
+                        log.info(u'computing decomposition for link %d/%d geom %d/%d (%s:%s): type %s', il, len(links), ig, len(geometries), link.GetName(), geom.GetName(), geom.GetType())
                         orghulls = self.ComputePaddedConvexDecompositionFromTriMesh(trimesh,padding)
                     cdhulls = []
                     for hull in orghulls:
@@ -312,6 +312,9 @@ class ConvexDecompositionModel(DatabaseGenerator):
     def ComputePaddedConvexDecompositionFromTriMesh(self, trimesh, padding=0.0):
         if len(trimesh.indices) > 0:
             orghulls = convexdecompositionpy.computeConvexDecomposition(trimesh.vertices,trimesh.indices,**self.convexparams)
+            if not self._ValidateConvexDecomposition(orghulls, trimesh):
+                log.warn('Some original vertices are not inside the convex decomposition. Using ConvexHull instead.')
+                return [self.ComputePaddedConvexHullFromTriMesh(trimesh, padding)]
         else:
             orghulls = []
         if len(orghulls) > 0:
@@ -457,6 +460,34 @@ class ConvexDecompositionModel(DatabaseGenerator):
         for i in range(len(normalizedplanes)-1):
             uniqueplanes[i+1:] &= dot(normalizedplanes[i+1:,:],normalizedplanes[i])<thresh
         return planes[uniqueplanes]
+
+    def _ValidateConvexDecomposition(self, hullList, trimesh, tol=1e-8):
+        """Checks if the convex hulls specified in hullList conver all the vertices in the given trimesh.
+        
+        Args:
+            hullList (list of (vertices, indices)): list of tuples (vertices, indices), where each tuple contains vertices and indices for one convex hull.
+            trimesh (OpenRAVE.TriMesh):
+            tol (float): tolerance for when checking whether a point is inside a convex hull or not.
+        
+        Return:
+            allInside (bool): whether all the original vertices (in trimesh) are fully contained in the given hulls.
+        
+        """
+        inside = zeros(len(trimesh.vertices), bool)
+        leftIndices = arange(len(trimesh.vertices))
+        leftPoints = array(trimesh.vertices) # make a copy
+        for ihull, hull in enumerate(hullList):
+            hullPlanes = self.ComputeHullPlanes(hull)
+            insideIndices = numpy.all(dot(leftPoints, transpose(hullPlanes[:, 0:3])) + tile(hullPlanes[:, 3], (len(leftPoints), 1)) <= tol, axis=1)
+            inside[leftIndices[flatnonzero(insideIndices)]] = True
+            outsideIndices = flatnonzero(insideIndices == 0)
+            leftPoints = leftPoints[outsideIndices]
+            leftIndices = leftIndices[outsideIndices]
+            if len(leftIndices) == 0:
+                break
+        if len(leftIndices) > 0:
+            log.info('There are %d vertices not inside the given hulls', len(leftIndices))
+        return len(leftIndices) == 0
     
     def testPointsInside(self,points):
         """tests if a point is inside the convex mesh of the robot.

--- a/python/databases/convexdecomposition.py
+++ b/python/databases/convexdecomposition.py
@@ -134,7 +134,7 @@ class ConvexDecompositionModel(DatabaseGenerator):
         return self.linkgeometry is not None and len(self.linkgeometry)==len(self.robot.GetLinks())
     
     def getversion(self):
-        return 4
+        return 5
     
     def save(self):
         try:
@@ -462,7 +462,7 @@ class ConvexDecompositionModel(DatabaseGenerator):
         return planes[uniqueplanes]
 
     def _ValidateConvexDecomposition(self, hullList, trimesh, tol=1e-8):
-        """Checks if the convex hulls specified in hullList conver all the vertices in the given trimesh.
+        """Checks if the convex hulls specified in hullList cover all the vertices in the given trimesh.
         
         Args:
             hullList (list of (vertices, indices)): list of tuples (vertices, indices), where each tuple contains vertices and indices for one convex hull.

--- a/python/databases/convexdecomposition.py
+++ b/python/databases/convexdecomposition.py
@@ -461,7 +461,7 @@ class ConvexDecompositionModel(DatabaseGenerator):
             uniqueplanes[i+1:] &= dot(normalizedplanes[i+1:,:],normalizedplanes[i])<thresh
         return planes[uniqueplanes]
 
-    def _ValidateConvexDecomposition(self, hullList, trimesh, tol=1e-8):
+    def _ValidateConvexDecomposition(self, hullList, trimesh, tol=5e-4):
         """Checks if the convex hulls specified in hullList cover all the vertices in the given trimesh.
         
         Args:


### PR DESCRIPTION
### Summary

This pull request adds a new safety measure to make sure that the padded mesh is safe to use.

The current library OpenRAVE uses for convex decomposition computation may, in some corner cases, output a list of convex hulls that do not entirely cover the original mesh vertices. To ensure safety, a check is added and if it turns out that the output hulls do not completely cover the original vertices, convex hull computation will be used instead.

The reason convex hull is not always used is that in many cases, the hull will be too big that when used for collision checking, it will give out too many false positives.