### PR TITLE
Clamp camera distance when zooming, handle all scroll events with Zoom()

### DIFF
--- a/plugins/qtosgrave/osgviewerwidget.cpp
+++ b/plugins/qtosgrave/osgviewerwidget.cpp
@@ -72,12 +72,11 @@ public:
         switch( ea.getEventType() )
         {
         case osgGA::GUIEventAdapter::SCROLL:
-            if(_posgviewerwidget->IsInOrthoMode()) {
+            {
                 double factor = ea.getScrollingMotion() == osgGA::GUIEventAdapter::SCROLL_DOWN ? 1.1 : 0.9;
                 _posgviewerwidget->Zoom(factor);
                 return true;
             }
-            break;
 
         default:
             break;
@@ -333,12 +332,11 @@ public:
             return handleMouseDoubleClick( ea, us );
 
         case osgGA::GUIEventAdapter::SCROLL:
-            if(_posgviewerwidget->IsInOrthoMode()) {
+            {
                 double factor = ea.getScrollingMotion() == osgGA::GUIEventAdapter::SCROLL_DOWN ? 1.1 : 0.9;
                 _posgviewerwidget->Zoom(factor);
                 return true;
             }
-            break;
 
         default:
             break;
@@ -1355,10 +1353,10 @@ void QOSGViewerWidget::Zoom(float factor)
     if (IsInOrthoMode()) {
         // if we increase _currentOrthoFrustumSize, we zoom out since a bigger frustum maps object to smaller part of screen
         _currentOrthoFrustumSize = _currentOrthoFrustumSize / factor;
-        _SetCameraViewOrthoProjectionPlaneSize(_currentOrthoFrustumSize);
+        _SetCameraViewOrthoProjectionPlaneSize(ClampDistance(_currentOrthoFrustumSize));
         return;
     }
-    SetCameraDistanceToFocus(GetCameraDistanceToFocus() / factor);
+    SetCameraDistanceToFocus(ClampDistance(GetCameraDistanceToFocus() / factor));
 }
 
 

--- a/plugins/qtosgrave/osgviewerwidget.h
+++ b/plugins/qtosgrave/osgviewerwidget.h
@@ -40,6 +40,12 @@ using namespace OpenRAVE;
 class OpenRAVETracker;
 class OpenRAVETrackball;
 
+const float MAX_CAMERA_DISTANCE = 1e10;
+
+inline float ClampDistance(float distance) {
+    return (distance > MAX_CAMERA_DISTANCE) ? MAX_CAMERA_DISTANCE : distance;
+}
+
 /// \brief  Class of the openscene graph 3d viewer
 class QOSGViewerWidget : public QOpenGLWidget
 {


### PR DESCRIPTION
This PR clamps camera distance to a maximum of 10^10 when zooming. This prevents the viewer published state from breaking the json parser due to large values. 

To override the osg default zoom behavior, this PR also lets the `Zoom` function handle all scroll events. 