### PR TITLE
Fix log; pinfo->_pviewer cannot be used here

### DIFF
--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -761,7 +761,7 @@ void ViewerManager::_RunViewerThread()
                         pinfo->_pviewer = RaveCreateViewer(pinfo->_penv, pinfo->_viewername);
                     }
                     catch(const std::exception& ex) {
-                        RAVELOG_WARN_FORMAT("env=%s, failed to create viewer '%s': %s", pinfo->_pviewer->GetEnv()->GetNameId()%pinfo->_viewername%ex.what());
+                        RAVELOG_WARN_FORMAT("env=%s, failed to create viewer '%s': %s", pinfo->_penv->GetNameId()%pinfo->_viewername%ex.what());
                         pinfo->_bFailed = true;
                     }
 


### PR DESCRIPTION
This issue was found while I was testing 13523c3d7c870648297fad4f0bf13d061a3e775e.

This fixes nullpointer exception on LOG_WARN.

However this was shown:

```
2024-04-30 09:40:53,355 openrave [DEBUG] [qtosgviewer.cpp:210 QtOSGViewer::~QtO
SGViewer] env=1, destroying qtosg viewer
2024-04-30 09:40:53,360 openrave [WARN] [openravepy_int.cpp:758 ViewerManager::
_RunViewerThread] env=1, failed to create viewer 'qtosg ': openrave (Assert): [
/usr/include/boost/smart_ptr/shared_ptr.hpp:728] -> typename boost::detail::sp_
member_access<T>::type boost::shared_ptr<T>::operator->() const [with T = RaveP
lugin; typename boost::detail::sp_member_access<T>::type = RavePlugin*], expr: 
px != 0
```

( full slave log and command: [log.gpg.gz](https://github.com/rdiankov/openrave/files/15156959/log.gpg.gz) (decompress by `gzip -d | mugpg -d | tar x`) )

I don't know how the RavePlugin was destructed and https://github.com/rdiankov/openrave/blob/master/src/libopenrave/plugindatabase_virtual.cpp#L126 `plugin->GetPluginPath();` failed though.