### PR TITLE
Implement `env.drawarrow` for the qtosg viewer

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,16 @@
 ChangeLog
 #########
 
+Version 0.144.2
+===============
+
+- Implement `env.drawarrow` for the qtosg viewer.
+
+Version 0.144.1
+===============
+
+- bug fix in `VectorBackedMap::Insert`.
+
 Version 0.144.0
 ===============
 

--- a/plugins/qtosgrave/qtosgviewer.h
+++ b/plugins/qtosgrave/qtosgviewer.h
@@ -340,6 +340,7 @@ public:
     virtual void _DrawBox(OSGSwitchPtr handle, const RaveVector<float>& vextents, const RaveTransform<float>& pose, const RaveVector<float>& color, float transparency);
     virtual void _DrawBoxArray(OSGSwitchPtr handle, const std::vector<RaveVector<float> >& vpos, const RaveVector<float>& vextents, bool bUsingTransparency);
     virtual void _DrawPlane(OSGSwitchPtr handle, const RaveTransform<float>& tplane, const RaveVector<float>& vextents, const boost::multi_array<float,3>& vtexture);
+    virtual void _DrawArrow(OSGSwitchPtr handle, const RaveVector<float>& p1, const RaveVector<float>& p2, float fwidth, const RaveVector<float>& color);
 
     virtual void _SetCamera(RaveTransform<float> trans, float focalDistance);
     virtual void _SetCameraTransform(const RaveTransform<float>& transform);


### PR DESCRIPTION
![image](https://github.com/rdiankov/openrave/assets/43060294/ae2b275f-f414-4567-b564-f3eaae2b03ba)
