### PR TITLE
Update ikfast for newer sympy

### DIFF
--- a/python/ikfast.py
+++ b/python/ikfast.py
@@ -285,6 +285,45 @@ try:
 except ImportError:
     using_swiginac = False
 
+# from sympy/core/core.py
+ordering_of_classes = [
+    # singleton numbers
+    'Zero', 'One', 'Half', 'Infinity', 'NaN', 'NegativeOne', 'NegativeInfinity',
+    # numbers
+    'Integer', 'Rational', 'Float',
+    # singleton symbols
+    'Exp1', 'Pi', 'ImaginaryUnit',
+    # symbols
+    'Symbol', 'Wild', 'Temporary',
+    # arithmetic operations
+    'Pow', 'Mul', 'Add',
+    # function values
+    'Derivative', 'Integral',
+    # defined singleton functions
+    'Abs', 'Sign', 'Sqrt',
+    'Floor', 'Ceiling',
+    'Re', 'Im', 'Arg',
+    'Conjugate',
+    'Exp', 'Log',
+    'Sin', 'Cos', 'Tan', 'Cot', 'ASin', 'ACos', 'ATan', 'ACot',
+    'Sinh', 'Cosh', 'Tanh', 'Coth', 'ASinh', 'ACosh', 'ATanh', 'ACoth',
+    'RisingFactorial', 'FallingFactorial',
+    'factorial', 'binomial',
+    'Gamma', 'LowerGamma', 'UpperGamma', 'PolyGamma',
+    'Erf',
+    # special polynomials
+    'Chebyshev', 'Chebyshev2',
+    # undefined functions
+    'Function', 'WildFunction',
+    # anonymous functions__l
+    'Lambda',
+    # Landau O symbol
+    'Order',
+    # relational operations
+    'Equality', 'Unequality', 'StrictGreaterThan', 'StrictLessThan',
+    'GreaterThan', 'LessThan',
+]
+
 CodeGenerators = {}
 # try:
 #     import ikfast_generator_vb
@@ -8250,14 +8289,8 @@ class IKFastSolver(AutoReloader):
                     break
                 coeffs.append(value)
                 # since coeffs[0] is normalized with the LC constant, can compare for precision
-                #from IPython import embed;embed()
                 if len(coeffs) == 1:
-                    def cmp(a,b):
-                        return (a > b) - (a < b)
-                    cmpValue = cmp(type(Abs(coeffs[0])), Float)
-                    #if not isinstance(coeffs[0], (Float, Integer)):
-                    #    from IPython import embed;embed()
-                    if cmpValue != 1 and Abs(coeffs[0]) < 2*(10.0**-self.precision):
+                    if ordering_of_classes.index(type(coeffs[0]).__name__) <= ordering_of_classes.index('Float') and Abs(coeffs[0]) < 2*(10.0**-self.precision):
                         coeffs = None
                         break
             if coeffs is None:

--- a/python/ikfast.py
+++ b/python/ikfast.py
@@ -203,6 +203,7 @@ except:
 
 import numpy # required for fast eigenvalue computation
 from sympy import *
+#from sympy.simplify import cse_main
 if sympy_version > '0.7.1':
     _zeros, _ones = zeros, ones
     zeros = lambda args: _zeros(*args)
@@ -8245,9 +8246,16 @@ class IKFastSolver(AutoReloader):
                     break
                 coeffs.append(value)
                 # since coeffs[0] is normalized with the LC constant, can compare for precision
-                if len(coeffs) == 1 and Abs(coeffs[0]) < 2*(10.0**-self.precision):
-                    coeffs = None
-                    break
+                #from IPython import embed;embed()
+                if len(coeffs) == 1:
+                    def cmp(a,b):
+                        return (a > b) - (a < b)
+                    cmpValue = cmp(type(Abs(coeffs[0])), Float)
+                    #if not isinstance(coeffs[0], (Float, Integer)):
+                    #    from IPython import embed;embed()
+                    if cmpValue != 1 and Abs(coeffs[0]) < 2*(10.0**-self.precision):
+                        coeffs = None
+                        break
             if coeffs is None:
                 continue
             if not all([c.is_number for c in coeffs]):

--- a/python/ikfast.py
+++ b/python/ikfast.py
@@ -181,10 +181,19 @@ if sympy_version < '0.7.0':
     raise ImportError('ikfast needs sympy 0.7.x or greater')
 sympy_smaller_073 = sympy_version < '0.7.3'
 
+from sympy import *
+from sympy.simplify import cse_main
+if sympy_version > '0.7.1':
+    _zeros, _ones = zeros, ones
+    zeros = lambda args: _zeros(*args)
+    ones = lambda args: _ones(*args)
+
 __author__ = 'Rosen Diankov'
 __copyright__ = 'Copyright (C) 2009-2012 Rosen Diankov <rosen.diankov@gmail.com>'
 __license__ = 'Lesser GPL, Version 3'
 __version__ = '0x1000004c' # hex of the version, has to be prefixed with 0x. also in ikfast.h
+
+# has to specify __version__ after importing as sympy as it will be overwritten by sympy.__version__
 
 import sys, copy, time, math, datetime
 if sys.version_info[0]<3:
@@ -202,12 +211,7 @@ except:
         pass
 
 import numpy # required for fast eigenvalue computation
-from sympy import *
-#from sympy.simplify import cse_main
-if sympy_version > '0.7.1':
-    _zeros, _ones = zeros, ones
-    zeros = lambda args: _zeros(*args)
-    ones = lambda args: _ones(*args)
+
 try:
     import mpmath # on some distributions, sympy does not have mpmath in its scope
 except ImportError:

--- a/python/ikfast_generator_cpp.py
+++ b/python/ikfast_generator_cpp.py
@@ -634,12 +634,12 @@ int main(int argc, char** argv)
         
         usedvars = []
         for var in node.solvejointvars:
-            usedvars += [var[0].name,'c'+var[0].name,'s'+var[0].name,'ht'+var[0].name]
+            usedvars += [var[0].name,'c'+var[0].name,'s'+var[0].name,'ht'+var[0].name,'t'+var[0].name]
             # if the variable becomes free need the multiplier
             usedvars.append('%smul'%var[0].name)
         for i in range(len(node.freejointvars)):
             name = node.freejointvars[i][0].name
-            usedvars += [name,'c'+name,'s'+name,'ht'+name]
+            usedvars += [name,'c'+name,'s'+name,'ht'+name,'t'+name]
 
         for i in range(3):
             if userotation & (1<<i):
@@ -710,7 +710,7 @@ int main(int argc, char** argv)
         fcode = ''
         for i in range(len(node.freejointvars)):
             name = node.freejointvars[i][0].name
-            fcode += '%s=pfree[%d]; c%s=cos(pfree[%d]); s%s=sin(pfree[%d]), ht%s=tan(pfree[%d]*0.5);\n'%(name,i,name,i,name,i,name,i)
+            fcode += '%s=pfree[%d]; c%s=cos(pfree[%d]); s%s=sin(pfree[%d]), ht%s=tan(pfree[%d]*0.5), t%s=tan(pfree[%d]);\n'%(name,i,name,i,name,i,name,i,name,i)
         for i in range(3):
             for j in range(3):
                 fcode += "r%d%d = eerot[%d*3+%d];\n"%(i,j,i,j)
@@ -1252,6 +1252,7 @@ IkReal r00 = 0, r11 = 0, r22 = 0;
         code.write('if( %svalid[ii%s] && IKabs(c%sarray[i%s]-c%sarray[ii%s]) < IKFAST_SOLUTION_THRESH && IKabs(s%sarray[i%s]-s%sarray[ii%s]) < IKFAST_SOLUTION_THRESH )\n{\n    %svalid[ii%s]=false; _i%s[1] = ii%s; break; \n}\n'%(name,name,name,name,name,name,name,name,name,name,name,name,name,name))
         code.write('}\n')
         code.write('%s = %sarray[i%s]; c%s = c%sarray[i%s]; s%s = s%sarray[i%s];\n'%(name,name,name,name,name,name,name,name,name))
+        code.write('t%s = IKtan(%s);\n'%(name,name))
         if node.AddHalfTanValue:
             code.write('ht%s = IKtan(%s/2);\n'%(name,name))
         if node.getEquationsUsed() is not None and len(node.getEquationsUsed()) > 0:
@@ -1331,6 +1332,7 @@ IkReal r00 = 0, r11 = 0, r22 = 0;
         code += 'if( %svalid[ii%s] && IKabs(c%sarray[i%s]-c%sarray[ii%s]) < IKFAST_SOLUTION_THRESH && IKabs(s%sarray[i%s]-s%sarray[ii%s]) < IKFAST_SOLUTION_THRESH )\n{\n    %svalid[ii%s]=false; _i%s[1] = ii%s; break; \n}\n'%(name,name,name,name,name,name,name,name,name,name,name,name,name,name)
         code += '}\n'
         code += '%s = %sarray[i%s]; c%s = c%sarray[i%s]; s%s = s%sarray[i%s];\n\n'%(name,name,name,name,name,name,name,name,name)
+        code += 't%s = IKtan(%s);\n'%(name,name)
         if AddHalfTanValue:
             code += 'ht%s = IKtan(%s/2);\n'%(name,name)
         self.dictequations = origequations
@@ -1392,6 +1394,7 @@ IkReal r00 = 0, r11 = 0, r22 = 0;
         code += 'for(int i%s = 0; i%s < numsolutions; ++i%s)\n    {\n'%(name,name,name)
         code += 'if( !%svalid[i%s] )\n{\n    continue;\n}\n'%(name,name)
         code += '    %s = %sarray[i%s]; c%s = c%sarray[i%s]; s%s = s%sarray[i%s];\n'%(name,name,name,name,name,name,name,name,name)
+        code += 't%s = IKtan(%s);\n'%(name,name)
         if node.AddHalfTanValue:
             code += 'ht%s = IKtan(%s/2);\n'%(name,name)
         code += '\n'

--- a/python/ikfast_generator_cpp.py
+++ b/python/ikfast_generator_cpp.py
@@ -61,21 +61,12 @@ except:
         TranslationZAxisAngleYNorm4D=0x44000010
 
 from sympy import *
+from sympy.simplify import cse_main
 
 try:
     import re # for indenting
 except ImportError:
     pass
-
-try:
-    from itertools import izip, combinations
-except ImportError:
-    def combinations(items,n):
-        if n == 0: yield[]
-        else:
-            for  i in xrange(len(items)):
-                for cc in combinations(items[i+1:],n-1):
-                    yield [items[i]]+cc
 
 try:
     # not necessary, just used for testing


### PR DESCRIPTION
This pull request enabled iksolver generation with new version of sympy.

I tested 0.7.1 / 0.7.6.1 / 1.12.1.

This is required to upgrade our obsolete version of sympy dependency.

----

On 0.7.6.1 and 1.12.1, somehow, `tj0` appears in the generated code. I forcibly fixed the issue by adding tangent declaration to the generated code, but I don't know the side effect at all.

cc @ntohge @wkentaro @jerasman