### PR TITLE
Relax mpmath eps

### DIFF
--- a/python/ikfast.py
+++ b/python/ikfast.py
@@ -214,6 +214,7 @@ import numpy # required for fast eigenvalue computation
 
 try:
     import mpmath # on some distributions, sympy does not have mpmath in its scope
+    mpmath.mp.eps = 1e-11  # sometimes mpmath.polyroots does not converge well, relax the threshold
 except ImportError:
     pass
 


### PR DESCRIPTION
sometimes mpmath.polyroots does not converge well, so I relax the threshold.

```
lib/python3.9/site-packages/mpmath/calculus/polynomials.py in polyroots(ctx, coeffs, maxsteps, cleanup, extraprec, error)
    185                 err[i] = abs(x)
    186         if abs(max(err)) >= tol:
--> 187             raise ctx.NoConvergence("Didn't converge in maxsteps=%d steps." \
    188                     % maxsteps)
    189         # Remove small real or imaginary parts

NoConvergence: Didn't converge in maxsteps=50 steps.
```

with this patch, I locally confirm that m____c50h iksolver can be generated with sympy 1.11.1. Also I checked some ikparams can be solved.

cc @ntohge

----

as side-effect, https://github.com/roboticsleeds/ur5controller/issues/7 and https://github.com/andyzeng/ikfastpy/issues/2 will be solved positively (if threshold is alright).