### PR TITLE
Cast arguments for PyArray APIs

### DIFF
--- a/python/bindings/openravepy_global.cpp
+++ b/python/bindings/openravepy_global.cpp
@@ -431,10 +431,10 @@ public:
 
         PyObject *pPyVertices = vertices.ptr();
         if (PyArray_Check(pPyVertices)) {
-            if (PyArray_NDIM(pPyVertices) != 2) {
+            if (PyArray_NDIM((PyArrayObject*)pPyVertices) != 2) {
                 throw openrave_exception(_("vertices must be a 2D array"), ORE_InvalidArguments);
             }
-            if (!PyArray_ISFLOAT(pPyVertices)) {
+            if (!PyArray_ISFLOAT((PyArrayObject*)pPyVertices)) {
                 throw openrave_exception(_("vertices must be in float"), ORE_InvalidArguments);
             }
             PyArrayObject* pPyVerticesContiguous = PyArray_GETCONTIGUOUS(reinterpret_cast<PyArrayObject*>(pPyVertices));
@@ -477,7 +477,7 @@ public:
         mesh.indices.resize(3*numtris);
         PyObject *pPyIndices = indices.ptr();
         if (PyArray_Check(pPyIndices)) {
-            if (PyArray_NDIM(pPyIndices) != 2 || PyArray_DIM(pPyIndices, 1) != 3 || !PyArray_ISINTEGER(pPyIndices)) {
+            if (PyArray_NDIM((PyArrayObject*)pPyIndices) != 2 || PyArray_DIM((PyArrayObject*)pPyIndices, 1) != 3 || !PyArray_ISINTEGER((PyArrayObject*)pPyIndices)) {
                 throw openrave_exception(_("indices must be a Nx3 int array"), ORE_InvalidArguments);
             }
             PyArrayObject* pPyIndiciesContiguous = PyArray_GETCONTIGUOUS(reinterpret_cast<PyArrayObject*>(pPyIndices));


### PR DESCRIPTION
we were passing PyObject* to PyAray_NDIM, but it was wrongly accepted (should be PyArrayObject*) as it was implemented as macro with type-casting

that means passing PyArrayObject* directly casted from PyObject* (after PyCheck_Array of course) to PyAray_NDIM is ok (and actually it is mandated in numpy2)

```
[ 82%] Building CXX object python/bindings/CMakeFiles/openravepy3_int.dir/openravepy_global.cpp.o
In file included from /home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1909,
                 from /home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarrayobject.h:12,
                 from /home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/arrayobject.h:5,
                 from /home/mujin/mujin/checkoutroot/openrave/python/bindings/include/openravepy/openravepy_int.h:53,
                 from /home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_global.cpp:18:
/home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
   17 | #warning "Using deprecated NumPy API, disable it with " \
      |  ^~~~~~~
In file included from /home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1909,
                 from /home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarrayobject.h:12,
                 from /home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/arrayobject.h:5,
                 from /home/mujin/mujin/checkoutroot/openrave/python/bindings/include/openravepy/openravepy_int.h:53,
                 from /home/mujin/mujin/checkoutroot/openrave/python/bindings/include/openravepy/openravepy_environmentbase.h:21,
                 from /home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_module.cpp:18:
/home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
   17 | #warning "Using deprecated NumPy API, disable it with " \
      |  ^~~~~~~
/home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_global.cpp: In member function ‘void openravepy::PyTriMesh::GetTriMesh(OpenRAVE::TriMesh&) const’:
/home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_global.cpp:480:30: error: cannot convert ‘PyObject*’ {aka ‘_object*’} to ‘const PyArrayObject*’ {aka ‘const tagPyArrayObject_fields*’}
  480 |             if (PyArray_NDIM(pPyIndices) != 2 || PyArray_DIM(pPyIndices, 1) != 3 || !PyArray_ISINTEGER(pPyIndices)) {
      |                              ^~~~~~~~~~
      |                              |
      |                              PyObject* {aka _object*}
/home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1502:35: note:   initializing argument 1 of ‘int PyArray_NDIM(const PyArrayObject*)’
 1502 | PyArray_NDIM(const PyArrayObject *arr)
      |              ~~~~~~~~~~~~~~~~~~~~~^~~
/home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_global.cpp:480:62: error: cannot convert ‘PyObject*’ {aka ‘_object*’} to ‘const PyArrayObject*’ {aka ‘const tagPyArrayObject_fields*’}
  480 |             if (PyArray_NDIM(pPyIndices) != 2 || PyArray_DIM(pPyIndices, 1) != 3 || !PyArray_ISINTEGER(pPyIndices)) {
      |                                                              ^~~~~~~~~~
      |                                                              |
      |                                                              PyObject* {aka _object*}
/home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1532:34: note:   initializing argument 1 of ‘npy_intp PyArray_DIM(const PyArrayObject*, int)’
 1532 | PyArray_DIM(const PyArrayObject *arr, int idim)
      |             ~~~~~~~~~~~~~~~~~~~~~^~~
/home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_global.cpp:480:104: error: cannot convert ‘PyObject*’ {aka ‘_object*’} to ‘const PyArrayObject*’ {aka ‘const tagPyArrayObject_fields*’}
  480 |             if (PyArray_NDIM(pPyIndices) != 2 || PyArray_DIM(pPyIndices, 1) != 3 || !PyArray_ISINTEGER(pPyIndices)) {
      |                                                                                                        ^~~~~~~~~~
      |                                                                                                        |
      |                                                                                                        PyObject* {aka _object*}
/home/mujin/mujin/jhbuildappcontroller/install/lib/python3.11/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1563:35: note:   initializing argument 1 of ‘int PyArray_TYPE(const PyArrayObject*)’
 1563 | PyArray_TYPE(const PyArrayObject *arr)
      |              ~~~~~~~~~~~~~~~~~~~~~^~~
/home/mujin/mujin/checkoutroot/openrave/python/bindings/openravepy_global.cpp:480:104: error: cannot convert ‘PyObject*’ {aka ‘_object*’} to ‘const PyArrayObject*’ {aka ‘const tagPyArrayObject_fields*’}
  480 |             if (PyArray_NDIM(pPyIndices) != 2 || PyArray_DIM(pPyIndices, 1) != 3 || !PyArray_ISINTEGER(pPyIndices)) {
      |                                                                                                        ^~~~~~~~~~
      |                                                                                                        |
      |                                                                                                        PyObject* {aka _object*}
```