### PR TITLE
Include missing Boost.ContainerHash header

### DIFF
--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -58,6 +58,7 @@
 #if  __cplusplus >= 201703L
 #include <string_view>
 #else
+#include <boost/container_hash/hash.hpp>
 #include <boost/utility/string_view.hpp>
 namespace std{
     // make boost::string_view handlable by std::unordered_set/map


### PR DESCRIPTION
Regression caused by the last merge from production to master.

```
In file included from /home/bartek/git/openrave/src/libopenrave/libopenrave.h:24,
                 from /home/bartek/git/openrave/src/libopenrave/environment.cpp:17:
/home/bartek/git/openrave/include/openrave/openrave.h:65:75: error: expected template-name before ‘<’ token
   65 |     class hash<boost::basic_string_view<CharT,Traits>>: public boost::hash<boost::basic_string_view<CharT,Traits>>
      |                                                                           ^
/home/bartek/git/openrave/include/openrave/openrave.h:65:75: error: expected ‘{’ before ‘<’ token
```

See also https://stackoverflow.com/a/60366571.