### PR TITLE
Add "override" to allow other modules that include header files from OpenRave to compile

### DIFF
--- a/include/openrave/collisionchecker.h
+++ b/include/openrave/collisionchecker.h
@@ -352,7 +352,7 @@ protected:
     }
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_COLLISIONCHECKER_HASH;
     }
 

--- a/include/openrave/controller.h
+++ b/include/openrave/controller.h
@@ -107,7 +107,7 @@ public:
     //    virtual void SetControlTorques(const std::vector<dReal>& pTorques);
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_CONTROLLER_HASH;
     }
 };

--- a/include/openrave/iksolver.h
+++ b/include/openrave/iksolver.h
@@ -386,7 +386,7 @@ protected:
     virtual void _CallFinishCallbacks(IkReturnPtr, RobotBase::ManipulatorConstPtr, const IkParameterization &);
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_IKSOLVER_HASH;
     }
 

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -3340,7 +3340,7 @@ private:
         _nUpdateStampId += inc;
     }
 
-    virtual void Clone(InterfaceBaseConstPtr preference, int cloningoptions);
+    virtual void Clone(InterfaceBaseConstPtr preference, int cloningoptions) override;
 
     /// \brief Register a callback with the interface.
     ///
@@ -3351,7 +3351,7 @@ private:
     /// \param properties a mask of the \ref KinBodyProperty values that the callback should be called for when they change
     virtual UserDataPtr RegisterChangeCallback(uint32_t properties, const boost::function<void()>& callback) const;
 
-    void Serialize(BaseXMLWriterPtr writer, int options=0) const;
+    void Serialize(BaseXMLWriterPtr writer, int options=0) const override;
 
     /// \brief A md5 hash unique to the particular kinematic and geometric structure of a KinBody.
     ///
@@ -3751,7 +3751,7 @@ protected:
 
 private:
     mutable std::vector<dReal> _vTempJoints;
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_KINBODY_HASH;
     }
 

--- a/include/openrave/module.h
+++ b/include/openrave/module.h
@@ -61,9 +61,9 @@ public:
 
     /// \brief sets the ik failure accumulator to use when running functions
     virtual void SetIkFailureAccumulator(IkFailureAccumulatorBasePtr& pIkFailureAccumulator);
-    
+
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_MODULE_HASH;
     }
 };

--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -754,9 +754,9 @@ public:
     {
 public:
         Reader(ConfigurationSpecification& spec);
-        virtual ProcessElement startElement(const std::string& name, const AttributesList& atts);
-        virtual bool endElement(const std::string& name);
-        virtual void characters(const std::string& ch);
+        virtual ProcessElement startElement(const std::string& name, const AttributesList& atts) override;
+        virtual bool endElement(const std::string& name) override;
+        virtual void characters(const std::string& ch) override;
 protected:
         ConfigurationSpecification& _spec;
         std::stringstream _ss;

--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -444,9 +444,9 @@ class OPENRAVE_API DummyXMLReader : public BaseXMLReader
 {
 public:
     DummyXMLReader(const std::string& fieldname, const std::string& parentname, boost::shared_ptr<std::ostream> osrecord = boost::shared_ptr<std::ostream>());
-    virtual ProcessElement startElement(const std::string& name, const AttributesList& atts);
-    virtual bool endElement(const std::string& name);
-    virtual void characters(const std::string& ch);
+    virtual ProcessElement startElement(const std::string& name, const AttributesList& atts) override;
+    virtual bool endElement(const std::string& name) override;
+    virtual void characters(const std::string& ch) override;
     const std::string& GetFieldName() const {
         return _fieldname;
     }

--- a/include/openrave/openraveexception.h
+++ b/include/openrave/openraveexception.h
@@ -70,7 +70,7 @@ public:
     OpenRAVEException(const std::string& s, OpenRAVEErrorCode error=ORE_Failed);
     virtual ~OpenRAVEException() throw() {
     }
-    char const* what() const throw();
+    char const* what() const throw() override;
     const std::string& message() const;
     OpenRAVEErrorCode GetCode() const;
 private:

--- a/include/openrave/physicsengine.h
+++ b/include/openrave/physicsengine.h
@@ -154,7 +154,7 @@ protected:
     }
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_PHYSICSENGINE_HASH;
     }
 };

--- a/include/openrave/planner.h
+++ b/include/openrave/planner.h
@@ -715,7 +715,7 @@ protected:
     virtual PlannerAction _CallCallbacks(const PlannerProgress& progress);
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_PLANNER_HASH;
     }
 

--- a/include/openrave/robot.h
+++ b/include/openrave/robot.h
@@ -927,7 +927,7 @@ public:
         /// \brief release the body state. _pbody will not get restored on destruction
         ///
         /// After this call, it will still be possible to use \ref Restore.
-        virtual void Release();
+        virtual void Release() override;
 
 protected:
         RobotBasePtr _probot;

--- a/include/openrave/sensor.h
+++ b/include/openrave/sensor.h
@@ -95,7 +95,7 @@ public:
     class OPENRAVE_API JointEncoderSensorData : public SensorData
     {
 public:
-        virtual SensorType GetType() {
+        virtual SensorType GetType() override {
             return ST_JointEncoder;
         }
         std::vector<dReal> encoderValues;         ///< measured joint angles in radians

--- a/include/openrave/sensor.h
+++ b/include/openrave/sensor.h
@@ -66,7 +66,7 @@ public:
     class OPENRAVE_API LaserSensorData : public SensorData
     {
 public:
-        virtual SensorType GetType() {
+        virtual SensorType GetType() override {
             return ST_Laser;
         }
 
@@ -79,16 +79,16 @@ public:
         std::vector<RaveVector<dReal> > ranges;         ///< Range and direction readings in the form of direction*distance. The direction is in world coordinates. The values should be returned in the order laser detected them in.
         std::vector<dReal> intensity;         ///< Intensity readings.
 
-        virtual bool serialize(std::ostream& O) const;
+        virtual bool serialize(std::ostream& O) const override;
     };
     class OPENRAVE_API CameraSensorData : public SensorData
     {
 public:
-        virtual SensorType GetType() {
+        virtual SensorType GetType() override {
             return ST_Camera;
         }
         std::vector<uint8_t> vimagedata;         ///< rgb image data, if camera only outputs in grayscale, fill each channel with the same value
-        virtual bool serialize(std::ostream& O) const;
+        virtual bool serialize(std::ostream& O) const override;
     };
 
     /// \brief Stores joint angles and EE position.
@@ -106,7 +106,7 @@ public:
     class OPENRAVE_API Force6DSensorData : public SensorData
     {
 public:
-        virtual SensorType GetType() {
+        virtual SensorType GetType() override {
             return ST_Force6D;
         }
         Vector force;         ///< Force in X Y Z, in newtons
@@ -117,7 +117,7 @@ public:
     class OPENRAVE_API IMUSensorData : public SensorData
     {
 public:
-        virtual SensorType GetType() {
+        virtual SensorType GetType() override {
             return ST_IMU;
         }
         Vector rotation;         ///< quaternion
@@ -132,7 +132,7 @@ public:
     class OPENRAVE_API OdometrySensorData : public SensorData
     {
 public:
-        virtual SensorType GetType() {
+        virtual SensorType GetType() override {
             return ST_Odometry;
         }
         Transform pose;         ///< measured pose
@@ -145,7 +145,7 @@ public:
     class OPENRAVE_API TactileSensorData : public SensorData
     {
 public:
-        virtual SensorType GetType() {
+        virtual SensorType GetType() override {
             return ST_Tactile;
         }
         std::vector<Vector> forces;         /// xyz force of each individual element
@@ -167,7 +167,7 @@ public:
 
         ActuatorSensorData() : state(AS_Undefined), measuredcurrent(0), measuredtemperature(0), appliedcurrent(0) {
         }
-        virtual SensorType GetType() {
+        virtual SensorType GetType() override {
             return ST_Actuator;
         }
 

--- a/include/openrave/sensorsystem.h
+++ b/include/openrave/sensorsystem.h
@@ -69,7 +69,7 @@ protected:
     }
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_SENSORSYSTEM_HASH;
     }
 };
@@ -130,23 +130,23 @@ public:
             SetBody(pbody);
         }
 
-        virtual ReadableConstPtr GetData() const {
+        virtual ReadableConstPtr GetData() const override {
             return _initdata;
         }
-        virtual KinBody::LinkPtr GetOffsetLink() const {
+        virtual KinBody::LinkPtr GetOffsetLink() const override {
             return KinBody::LinkPtr(_plink);
         }
 
-        virtual bool IsPresent() const {
+        virtual bool IsPresent() const override {
             return bPresent;
         }
-        virtual bool IsEnabled() const {
+        virtual bool IsEnabled() const override {
             return bEnabled;
         }
-        virtual bool IsLocked() const {
+        virtual bool IsLocked() const override {
             return bLock;
         }
-        virtual bool Lock(bool bDoLock) {
+        virtual bool Lock(bool bDoLock) override {
             bLock = bDoLock; return true;
         }
 
@@ -187,12 +187,12 @@ protected:
     {
 public:
         SimpleXMLReader(boost::shared_ptr<XMLData>);
-        virtual ReadablePtr GetReadable() {
+        virtual ReadablePtr GetReadable() override {
             return _pdata;
         }
-        virtual ProcessElement startElement(const std::string& name, const AttributesList& atts);
-        virtual bool endElement(const std::string& name);
-        virtual void characters(const std::string& ch);
+        virtual ProcessElement startElement(const std::string& name, const AttributesList& atts) override;
+        virtual bool endElement(const std::string& name) override;
+        virtual void characters(const std::string& ch) override;
 
 protected:
         boost::shared_ptr<XMLData> _pdata;
@@ -205,15 +205,15 @@ protected:
     SimpleSensorSystem(const std::string& xmlid, EnvironmentBasePtr penv);
     virtual ~SimpleSensorSystem();
 
-    virtual void Reset();
+    virtual void Reset() override;
 
-    virtual void AddRegisteredBodies(const std::vector<KinBodyPtr>& vbodies);
-    virtual KinBody::ManageDataPtr AddKinBody(KinBodyPtr pbody, ReadableConstPtr pdata);
+    virtual void AddRegisteredBodies(const std::vector<KinBodyPtr>& vbodies) override;
+    virtual KinBody::ManageDataPtr AddKinBody(KinBodyPtr pbody, ReadableConstPtr pdata) override;
 
-    virtual bool RemoveKinBody(KinBodyPtr pbody);
-    virtual bool IsBodyPresent(KinBodyPtr pbody);
-    virtual bool EnableBody(KinBodyPtr pbody, bool bEnable);
-    virtual bool SwitchBody(KinBodyPtr pbody1, KinBodyPtr pbody2);
+    virtual bool RemoveKinBody(KinBodyPtr pbody) override;
+    virtual bool IsBodyPresent(KinBodyPtr pbody) override;
+    virtual bool EnableBody(KinBodyPtr pbody, bool bEnable) override;
+    virtual bool SwitchBody(KinBodyPtr pbody1, KinBodyPtr pbody2) override;
 
 protected:
     typedef std::pair<boost::shared_ptr<BodyData>, Transform > SNAPSHOT;

--- a/include/openrave/spacesampler.h
+++ b/include/openrave/spacesampler.h
@@ -178,7 +178,7 @@ protected:
     virtual int _CallStatusFunctions(int sampleiteration);
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_SPACESAMPLER_HASH;
     }
 

--- a/include/openrave/trajectory.h
+++ b/include/openrave/trajectory.h
@@ -245,7 +245,7 @@ public:
     /// \brief Clone the contents of the given trajectory to the current trajectory.
     /// \param preference the interface whose information to clone
     /// \param cloningoptions mask of CloningOptions
-    virtual void Clone(InterfaceBaseConstPtr preference, int cloningoptions);
+    virtual void Clone(InterfaceBaseConstPtr preference, int cloningoptions) override;
 
     /// \brief swap the contents of the data between the two trajectories.
     ///
@@ -277,7 +277,7 @@ protected:
     void _SamplePointsInRange(std::vector<dReal>& data, RangeGenerator<T>& timeRange, const ConfigurationSpecification& spec) const;
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_TRAJECTORY_HASH;
     }
 };

--- a/include/openrave/viewer.h
+++ b/include/openrave/viewer.h
@@ -230,7 +230,7 @@ protected:
     }
 
 private:
-    virtual const char* GetHash() const {
+    virtual const char* GetHash() const override {
         return OPENRAVE_VIEWER_HASH;
     }
 

--- a/python/bindings/include/openravepy/openravepy_int.h
+++ b/python/bindings/include/openravepy/openravepy_int.h
@@ -533,11 +533,11 @@ public:
         StringSerializableData(const std::string& data) : _data(data) {
         }
 
-        virtual void Serialize(std::ostream& O, int options=0) const {
+        virtual void Serialize(std::ostream& O, int options=0) const override {
             O << _data;
         }
 
-        virtual void Deserialize(std::istream& I) {
+        virtual void Deserialize(std::istream& I) override {
             // need to read the entire input
             stringbuf buf;
             I.get(buf, 0);
@@ -554,7 +554,7 @@ public:
     }
     PySerializableData(SerializableDataPtr handle) : _handle(handle) {
     }
-    void Close() {
+    void Close() override {
         _handle.reset();
     }
     py::object Serialize(int options) {


### PR DESCRIPTION
While working on enabling "-Werror=suggest-override" to strictly follow the Mujin C++ coding standard, a few header files ought to be modified to prevent compiler errors brought up by enabling that warning.

Checked in the pipeline #947098

![image](https://github.com/user-attachments/assets/80311e93-b3c3-4921-b75f-f1a347b09e03)
