### PR TITLE
pybind11 converts C++ exception to Python exception after returning from the function, so the exception has to be rethrown

### DIFF
--- a/python/bindings/include/openravepy/bindings.h
+++ b/python/bindings/include/openravepy/bindings.h
@@ -253,6 +253,9 @@ inline std::vector<int8_t> ExtractArrayInt8(const py::object& o)
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for int");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return v;
 }
@@ -273,6 +276,10 @@ inline std::vector<T> ExtractArray(const py::object& o)
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for " + std::string(typeid(T).name()));
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        // pybind11 converts C++ exception to Python exception after returning from the function, so the exception has to be rethrown
+        throw;
+#endif
     }
     return v;
 }

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -1104,6 +1104,9 @@ static std::vector<KinBody::KinBodyInfoPtr> _ExtractBodyInfoArray(object vBodyIn
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for BodyInfos");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return vBodyInfos;
 }

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -125,6 +125,9 @@ std::vector<KinBody::JointInfoPtr> ExtractJointInfoArray(object pyJointInfoList)
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for JointInfos");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return vJointInfos;
 }
@@ -161,6 +164,9 @@ std::vector<KinBody::GrabbedInfoPtr> ExtractGrabbedInfoArray(object pyGrabbedInf
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for GrabbedInfos");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return vGrabbedInfos;
 }
@@ -183,6 +189,9 @@ std::vector<std::pair<std::pair<std::string, int>, dReal> > ExtractDOFValuesArra
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for DOFValues");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return vDOFValues;
 }

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -482,6 +482,9 @@ std::vector<RobotBase::ManipulatorInfoPtr> ExtractManipulatorInfoArray(object py
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for ManipulatorInfo");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return vManipulatorInfos;
 }
@@ -508,6 +511,9 @@ std::vector<RobotBase::AttachedSensorInfoPtr> ExtractAttachedSensorInfoArray(obj
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for AttachedSensorInfo");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return vAttachedSensorInfos;
 }
@@ -534,6 +540,9 @@ std::vector<RobotBase::ConnectedBodyInfoPtr> ExtractConnectedBodyInfoArray(objec
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for ConnectedBodyInfo");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return vConnectedBodyInfos;
 }
@@ -559,6 +568,9 @@ std::vector<RobotBase::GripperInfoPtr> ExtractGripperInfoArray(object pyGripperI
     }
     catch(...) {
         RAVELOG_WARN("Cannot do ExtractArray for GripperInfo");
+#ifdef USE_PYBIND11_PYTHON_BINDINGS
+        throw;
+#endif
     }
     return vGripperInfos;
 }

--- a/test/test_collada.py
+++ b/test/test_collada.py
@@ -491,7 +491,7 @@ class TestCOLLADA(EnvironmentSetup):
             minfo._tLocalTool[0:3,3] = [0.1,0.2,0.3]
             minfo._vdirection = [-1,0,0]
             minfo._vGripperJointNames = ['j6']
-            minfo._vClosingDirection = [-1.0]
+            minfo._vClosingDirection = [-1]
             robot.AddManipulator(minfo)
             #robot.SetDOFLimits(-linspace(0.4,0.8,robot.GetDOF()),linspace(1.4,1.8,robot.GetDOF()))
             #robot.SetDOFVelocityLimits(linspace(1,10,robot.GetDOF()))

--- a/test/test_kinematics.py
+++ b/test/test_kinematics.py
@@ -1084,7 +1084,7 @@ class TestKinematics(EnvironmentSetup):
             link0._vgeometryinfos = [infobox0, infobox1]
             link0._name = 'link0'
             link0._mapFloatParameters = {'param0':[1,2.3]}
-            link0._mapIntParameters = {'param0':[4,5.6]}
+            link0._mapIntParameters = {'param0':[4,5,6]}
             link0._mapStringParameters = {'jp':u'日本語', 'test':'has spaces'}
             link1 = KinBody.LinkInfo()
             link1._vgeometryinfos = [infobox2]

--- a/test/test_kinematics.py
+++ b/test/test_kinematics.py
@@ -1090,7 +1090,7 @@ class TestKinematics(EnvironmentSetup):
             link1._vgeometryinfos = [infobox2]
             link1._name = 'link1'
             link1._mapFloatParameters = {'param0':[1,2.3]}
-            link1._mapIntParameters = {'param0':[4,5.6]}
+            link1._mapIntParameters = {'param0':[4,5,6]}
             link1._t[0,3] = 0.5
 
             joint0 = KinBody.JointInfo()

--- a/test/test_robot.py
+++ b/test/test_robot.py
@@ -525,7 +525,7 @@ class RunRobot(EnvironmentSetup):
         manipinfo._tLocalTool[2,3] = 1.0
         manipinfo._vGripperJointNames = ['l_gripper_l_finger_joint']
         manipinfo._vdirection = [0,1,0]
-        manipinfo._vClosingDirection = [1.0]
+        manipinfo._vClosingDirection = [1]
         newmanip = robot.AddManipulator(manipinfo)
         assert(newmanip.GetBase().GetName() == manip.GetBase().GetName())
         assert(newmanip.GetEndEffector().GetName() == manip.GetEndEffector().GetName())


### PR DESCRIPTION
some try-catch had RAVELOG_WARN. Pybind11 needs rethrow due to handling timing.

without patch

```
robot.SetActiveDOFs([1.0,[]])
robot.GetActiveDOFIndices()

array([0, 0], dtype=int32)
```

```
kbi = openravepy.KinBodyInfo()
kbi._dofValues = [('foo', None, [])]
kbi.SerializeJSON()

{'transform': [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
 'isRobot': False,
 'dofValues': [{'jointName': 'foo', 'value': 0.0}],
 '__isPartial__': True}
```

with patch

```
robot.SetActiveDOFs([1.0,[]])

RuntimeError: Unable to cast Python instance to C++ type (compile in debug mode for details)
```

```
kbi = openravepy.KinBodyInfo()
kbi._dofValues = [('foo', None, [])]
kbi.SerializeJSON()

RuntimeError: Unable to cast Python instance to C++ type (compile in debug mode for details)
```