### PR TITLE
Update changelog for grabbed api update

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,8 @@ Version 0.156.0
 
 - Speed up environment loading for big scenes with lots of static links.
 - Deprecate restoring of grabbed bodies by `KinBodyStateSaver` from one env to another env since it's hard to restore any kind of bodies into different env. Instead, use the dedicated private API in `Environment::_Clone`.
+- Remove unnecessary APIs about `CheckGrabbedInfo` and `InvalidateListNonCollidingLinks`.
+- Add python enum for `GICR_UserDataNotMatch`
 
 Version 0.155.0
 ===============


### PR DESCRIPTION
Really sorry, forgot to add changelog for https://github.com/rdiankov/openrave/pull/1432.

The version is already bumped and no need to update version itself.