### PR TITLE
Minimize null_deleter usage

### DIFF
--- a/plugins/configurationcache/openravepy_configurationcache.cpp
+++ b/plugins/configurationcache/openravepy_configurationcache.cpp
@@ -78,31 +78,29 @@ public:
 
     int InsertConfigurationDist(object ovalues, object opyreport, dReal dist)
     {
-        CollisionReport report;
         CollisionReportPtr preport;
         if( openravepy::IsCollisionReport(opyreport) ) {
-            preport = CollisionReportPtr(&report,utils::null_deleter());
+            preport = CollisionReportPtr(new CollisionReport);
         }
 
         bool bCollision = _cache->InsertConfiguration(openravepy::ExtractArray<dReal>(ovalues), preport, dist);
 
         if( !!preport ) {
-            openravepy::UpdateCollisionReport(opyreport, report);
+            openravepy::UpdateCollisionReport(opyreport, *preport);
         }
         return bCollision;
     }
 
     int InsertConfiguration(object ovalues, object opyreport)
     {
-        CollisionReport report;
         CollisionReportPtr preport;
         if( openravepy::IsCollisionReport(opyreport) ) {
-            preport = CollisionReportPtr(&report,utils::null_deleter());
+            preport = CollisionReportPtr(new CollisionReport);
         }
 
         bool bCollision = _cache->InsertConfiguration(openravepy::ExtractArray<dReal>(ovalues), preport);
         if( !!preport ) {
-            openravepy::UpdateCollisionReport(opyreport, report);
+            openravepy::UpdateCollisionReport(opyreport, *preport);
         }
         return bCollision;
     }

--- a/plugins/ikfastsolvers/ikfastsolver.cpp
+++ b/plugins/ikfastsolvers/ikfastsolver.cpp
@@ -638,13 +638,12 @@ protected:
         if( !!result ) {
             result->resize(0);
         }
-        IkReturn ikreturn(IKRA_Success);
-        IkReturnPtr pikreturn(&ikreturn,utils::null_deleter());
+        IkReturnPtr pikreturn(new IkReturn(IKRA_Success));
         if( !Solve(rawparam,q0local,filteroptions,pikreturn) ) {
             return false;
         }
         if( !!result ) {
-            *result = ikreturn._vsolution;
+            *result = pikreturn->_vsolution;
         }
         return true;
     }
@@ -669,13 +668,12 @@ protected:
         if( !!result ) {
             result->resize(0);
         }
-        IkReturn ikreturn(IKRA_Success);
-        IkReturnPtr pikreturn(&ikreturn,utils::null_deleter());
+        IkReturnPtr pikreturn(new IkReturn(IKRA_Success));
         if( !Solve(param,q0local,vFreeParameters,filteroptions,pikreturn) ) {
             return false;
         }
         if( !!result ) {
-            *result = ikreturn._vsolution;
+            *result = pikreturn->_vsolution;
         }
         return true;
     }
@@ -1591,10 +1589,9 @@ protected:
             }
         }
 
-        CollisionReport report;
         CollisionReportPtr ptempreport;
         if( !(filteroptions&IKFO_IgnoreSelfCollisions) || IS_DEBUGLEVEL(Level_Verbose) || paramnewglobal.GetType() == IKP_TranslationDirection5D ) { // 5D is necessary for tracking end effector collisions
-            ptempreport = boost::shared_ptr<CollisionReport>(&report,utils::null_deleter());
+            ptempreport = CollisionReportPtr(new CollisionReport);
         }
         if( !(filteroptions&IKFO_IgnoreSelfCollisions) ) {
             // check for self collisions
@@ -1681,7 +1678,7 @@ protected:
                     if( pmanip->CheckEndEffectorCollision(pmanip->GetTransform(), ptempreport) ) {
                         if( !!ptempreport ) {
                             stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
-                            ss << "ikfast collision " << report.__str__() << " colvalues=[";
+                            ss << "ikfast collision " << ptempreport->__str__() << " colvalues=[";
                             std::vector<dReal> vallvalues;
                             probot->GetDOFValues(vallvalues);
                             for(size_t i = 0; i < vallvalues.size(); ++i ) {
@@ -1741,7 +1738,7 @@ protected:
 
                 if( !!ptempreport ) {
                     stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
-                    ss << "env=" << GetEnv()->GetId() << ", ikfast collision " << probot->GetName() << ":" << pmanip->GetName() << " " << report.__str__() << " colvalues=[";
+                    ss << "env=" << GetEnv()->GetId() << ", ikfast collision " << probot->GetName() << ":" << pmanip->GetName() << " " << ptempreport->__str__() << " colvalues=[";
                     std::vector<dReal> vallvalues;
                     probot->GetDOFValues(vallvalues);
                     for(size_t i = 0; i < vallvalues.size(); ++i ) {
@@ -2042,10 +2039,9 @@ protected:
             }
         }
 
-        CollisionReport report;
         CollisionReportPtr ptempreport;
         if( IS_DEBUGLEVEL(Level_Verbose) ) {
-            ptempreport = boost::shared_ptr<CollisionReport>(&report,utils::null_deleter());
+            ptempreport = CollisionReportPtr(new CollisionReport);
         }
         if( !(filteroptions&IKFO_IgnoreSelfCollisions) ) {
             stateCheck.SetSelfCollisionState();
@@ -2168,7 +2164,7 @@ protected:
             if( GetEnv()->CheckCollision(KinBodyConstPtr(probot), ptempreport) ) {
                 if( !!ptempreport ) {
                     stringstream ss; ss << std::setprecision(std::numeric_limits<OpenRAVE::dReal>::digits10+1);
-                    ss << "ikfast collision " << report.__str__() << " colvalues=[";
+                    ss << "ikfast collision " << ptempreport->__str__() << " colvalues=[";
                     std::vector<dReal> vallvalues;
                     probot->GetDOFValues(vallvalues);
                     for(size_t i = 0; i < vallvalues.size(); ++i ) {

--- a/python/bindings/openravepy_collisionchecker.cpp
+++ b/python/bindings/openravepy_collisionchecker.cpp
@@ -226,10 +226,9 @@ bool PyCollisionCheckerBase::CheckCollision(PyKinBodyPtr pbody1, PyCollisionRepo
     }
 
     CHECK_POINTER(pbody1);
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
     bool bCollision = _pCollisionChecker->CheckCollision(KinBodyConstPtr(openravepy::GetKinBody(pbody1)), preport);
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
@@ -248,10 +247,9 @@ bool PyCollisionCheckerBase::CheckCollision(PyKinBodyPtr pbody1, PyKinBodyPtr pb
 
     CHECK_POINTER(pbody1);
     CHECK_POINTER(pbody2);
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
     bool bCollision = _pCollisionChecker->CheckCollision(KinBodyConstPtr(openravepy::GetKinBody(pbody1)), KinBodyConstPtr(openravepy::GetKinBody(pbody2)), preport);
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
@@ -275,8 +273,7 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, PyCollisionReportPtr pyre
         return CheckCollision(o1);
     }
 
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
 
     CHECK_POINTER(o1);
     KinBody::LinkConstPtr plink = openravepy::GetKinBodyLinkConst(o1);
@@ -293,7 +290,7 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, PyCollisionReportPtr pyre
             throw OPENRAVE_EXCEPTION_FORMAT0(_("invalid argument"),ORE_InvalidArguments);
         }
     }
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
@@ -315,10 +312,9 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, object o2)
         if( !IS_PYTHONOBJECT_NONE(o2) ) {
             extract_<PyCollisionReportPtr> epyreport2(o2);
             if( epyreport2.check() ) {
-                CollisionReport report;
-                CollisionReportPtr preport(&report,utils::null_deleter());
+                CollisionReportPtr preport(new CollisionReport);
                 bool bCollision = _pCollisionChecker->CheckCollision(plink,preport);
-                ((PyCollisionReportPtr)epyreport2)->Init(report);
+                ((PyCollisionReportPtr)epyreport2)->Init(*preport);
                 return bCollision;
             }
         }
@@ -338,10 +334,9 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, object o2)
         if( !IS_PYTHONOBJECT_NONE(o2) ) {
             extract_<PyCollisionReportPtr> epyreport2(o2);
             if( epyreport2.check() ) {
-                CollisionReport report;
-                CollisionReportPtr preport(&report,utils::null_deleter());
+                CollisionReportPtr preport(new CollisionReport);
                 bool bCollision = _pCollisionChecker->CheckCollision(pbody,preport);
-                ((PyCollisionReportPtr)epyreport2)->Init(report);
+                ((PyCollisionReportPtr)epyreport2)->Init(*preport);
                 return bCollision;
             }
         }
@@ -358,8 +353,7 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, object o2, PyCollisionRep
     CHECK_POINTER(o1);
     CHECK_POINTER(o2);
 
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
 
     bool bCollision = false;
     KinBody::LinkConstPtr plink = openravepy::GetKinBodyLinkConst(o1);
@@ -399,7 +393,7 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, object o2, PyCollisionRep
             throw OPENRAVE_EXCEPTION_FORMAT0(_("invalid argument 1"),ORE_InvalidArguments);
         }
     }
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
@@ -425,8 +419,7 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, PyKinBodyPtr pybody2, PyC
         return CheckCollision(o1, pybody2);
     }
 
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
 
     CHECK_POINTER(o1);
     CHECK_POINTER(pybody2);
@@ -445,7 +438,7 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, PyKinBodyPtr pybody2, PyC
             throw OPENRAVE_EXCEPTION_FORMAT0(_("CheckCollision(object) invalid argument"),ORE_InvalidArguments);
         }
     }
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
@@ -497,8 +490,7 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, object bodyexcluded, obje
         return CheckCollision(o1, bodyexcluded, linkexcluded);
     }
 
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
 
     std::vector<KinBodyConstPtr> vbodyexcluded;
     KinBody::LinkConstPtr plink1 = openravepy::GetKinBodyLinkConst(o1);
@@ -535,7 +527,7 @@ bool PyCollisionCheckerBase::CheckCollision(object o1, object bodyexcluded, obje
         throw OPENRAVE_EXCEPTION_FORMAT0(_("invalid argument 1"),ORE_InvalidArguments);
     }
 
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
@@ -570,8 +562,7 @@ bool PyCollisionCheckerBase::CheckCollision(PyKinBodyPtr pbody, object bodyexclu
         return CheckCollision(pbody, bodyexcluded, linkexcluded);
     }
 
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
 
     std::vector<KinBodyConstPtr> vbodyexcluded;
     size_t numBodyExcluded = len(bodyexcluded);
@@ -596,7 +587,7 @@ bool PyCollisionCheckerBase::CheckCollision(PyKinBodyPtr pbody, object bodyexclu
     }
 
     bool bCollision = _pCollisionChecker->CheckCollision(KinBodyConstPtr(openravepy::GetKinBody(pbody)), vbodyexcluded, vlinkexcluded, preport);
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
@@ -611,10 +602,9 @@ bool PyCollisionCheckerBase::CheckCollision(OPENRAVE_SHARED_PTR<PyRay> pyray, Py
         return CheckCollision(pyray, pbody);
     }
 
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
     bool bCollision = _pCollisionChecker->CheckCollision(pyray->r, KinBodyConstPtr(openravepy::GetKinBody(pbody)), preport);
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
@@ -628,8 +618,7 @@ object PyCollisionCheckerBase::CheckCollisionRays(object rays, PyKinBodyPtr pbod
     if( extract<int>(shape[py::to_object(1)]) != 6 ) {
         throw openrave_exception(_("rays object needs to be a Nx6 vector\n"));
     }
-    CollisionReport report;
-    CollisionReportPtr preport(&report,null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
     bool bHasPreempt = !IS_PYTHONOBJECT_NONE(oCheckPreemptFn);
     RAY r;
 
@@ -696,8 +685,8 @@ object PyCollisionCheckerBase::CheckCollisionRays(object rays, PyKinBodyPtr pbod
             }
             pcollision[i] = false;
             ppos[0] = 0; ppos[1] = 0; ppos[2] = 0; ppos[3] = 0; ppos[4] = 0; ppos[5] = 0;
-            if( bCollision && report.IsValid() && report.vCollisionInfos.at(0).contacts.size() > 0 ) {
-                const OpenRAVE::CONTACT& contact = report.vCollisionInfos.at(0).contacts.at(0);
+            if( bCollision && preport->IsValid() && preport->vCollisionInfos.at(0).contacts.size() > 0 ) {
+                const OpenRAVE::CONTACT& contact = preport->vCollisionInfos.at(0).contacts.at(0);
                 if( !bFrontFacingOnly || contact.norm.dot3(r.dir)<0 ) {
                     pcollision[i] = true;
                     ppos[0] = contact.pos.x;
@@ -728,20 +717,18 @@ bool PyCollisionCheckerBase::CheckCollision(OPENRAVE_SHARED_PTR<PyRay> pyray, Py
         return CheckCollision(pyray);
     }
 
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
 
     bool bCollision = _pCollisionChecker->CheckCollision(pyray->r, preport);
-    pyreport->Init(report);
+    pyreport->Init(*preport);
     return bCollision;
 }
 
 bool PyCollisionCheckerBase::CheckCollisionTriMesh(object otrimesh, PyKinBodyPtr pybody, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     TriMesh trimesh;
@@ -751,17 +738,16 @@ bool PyCollisionCheckerBase::CheckCollisionTriMesh(object otrimesh, PyKinBodyPtr
     KinBodyConstPtr pbody(openravepy::GetKinBody(pybody));
     bool bCollision = _pCollisionChecker->CheckCollision(trimesh, pbody, preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
 
 bool PyCollisionCheckerBase::CheckCollisionTriMesh(object otrimesh, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     TriMesh trimesh;
@@ -770,34 +756,32 @@ bool PyCollisionCheckerBase::CheckCollisionTriMesh(object otrimesh, PyCollisionR
     }
     bool bCollision = _pCollisionChecker->CheckCollision(trimesh, preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
 
 bool PyCollisionCheckerBase::CheckCollisionOBB(object oaabb, object otransform, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     AABB aabb = ExtractAABB(oaabb);
     Transform t = ExtractTransform(otransform);
     bool bCollision = _pCollisionChecker->CheckCollision(aabb, t, preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
 
 bool PyCollisionCheckerBase::CheckCollisionOBB(object oaabb, object otransform, object bodiesincluded, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     const AABB aabb = ExtractAABB(oaabb);
@@ -814,17 +798,16 @@ bool PyCollisionCheckerBase::CheckCollisionOBB(object oaabb, object otransform, 
     }
     bool bCollision = _pCollisionChecker->CheckCollision(aabb, t, vbodiesincluded, preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
 
 bool PyCollisionCheckerBase::CheckSelfCollision(object o1, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     KinBody::LinkConstPtr plink1 = openravepy::GetKinBodyLinkConst(o1);
@@ -840,7 +823,7 @@ bool PyCollisionCheckerBase::CheckSelfCollision(object o1, PyCollisionReportPtr 
         throw OPENRAVE_EXCEPTION_FORMAT0(_("invalid parameters to CheckSelfCollision"), ORE_InvalidArguments);
     }
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }

--- a/python/bindings/openravepy_global.cpp
+++ b/python/bindings/openravepy_global.cpp
@@ -93,13 +93,13 @@ public:
             return py::none_();
         }
         std::string xmlid;
-        OpenRAVE::xmlreaders::StreamXMLWriter writer(xmlid);
-        if( !_readable->SerializeXML(OpenRAVE::xmlreaders::StreamXMLWriterPtr(&writer,utils::null_deleter()),options) ) {
+        OpenRAVE::xmlreaders::StreamXMLWriterPtr pwriter(new OpenRAVE::xmlreaders::StreamXMLWriter(xmlid));
+        if( !_readable->SerializeXML(pwriter, options) ) {
             return py::none_();
         }
 
         std::stringstream ss;
-        writer.Serialize(ss);
+        pwriter->Serialize(ss);
         return ConvertStringToUnicode(ss.str());
     }
 

--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -1351,15 +1351,14 @@ bool PyEnvironmentBase::CheckCollision(PyKinBodyPtr pbody1)
 bool PyEnvironmentBase::CheckCollision(PyKinBodyPtr pbody1, PyCollisionReportPtr pyreport)
 {
     CHECK_POINTER(pbody1);
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision = _penv->CheckCollision(KinBodyConstPtr(openravepy::GetKinBody(pbody1)), preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1375,15 +1374,14 @@ bool PyEnvironmentBase::CheckCollision(PyKinBodyPtr pbody1, PyKinBodyPtr pbody2,
 {
     CHECK_POINTER(pbody1);
     CHECK_POINTER(pbody2);
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision = _penv->CheckCollision(KinBodyConstPtr(openravepy::GetKinBody(pbody1)), KinBodyConstPtr(openravepy::GetKinBody(pbody2)), preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1405,10 +1403,9 @@ bool PyEnvironmentBase::CheckCollision(object o1)
 bool PyEnvironmentBase::CheckCollision(object o1, PyCollisionReportPtr pyreport)
 {
     CHECK_POINTER(o1);
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     KinBody::LinkConstPtr plink = openravepy::GetKinBodyLinkConst(o1);
@@ -1426,7 +1423,7 @@ bool PyEnvironmentBase::CheckCollision(object o1, PyCollisionReportPtr pyreport)
         }
     }
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1449,10 +1446,9 @@ bool PyEnvironmentBase::CheckCollision(object o1, object o2)
         if( !IS_PYTHONOBJECT_NONE(o2) ) {
             extract_<PyCollisionReportPtr> epyreport2(o2);
             if( epyreport2.check() ) {
-                CollisionReport report;
-                CollisionReportPtr preport(&report,utils::null_deleter());
+                CollisionReportPtr preport(new CollisionReport);
                 bool bCollision = _penv->CheckCollision(plink,preport);
-                ((PyCollisionReportPtr)epyreport2)->Init(report);
+                ((PyCollisionReportPtr)epyreport2)->Init(*preport);
                 return bCollision;
             }
         }
@@ -1473,10 +1469,9 @@ bool PyEnvironmentBase::CheckCollision(object o1, object o2)
         if( !IS_PYTHONOBJECT_NONE(o2) ) {
             extract_<PyCollisionReportPtr> epyreport2(o2);
             if( epyreport2.check() ) {
-                CollisionReport report;
-                CollisionReportPtr preport(&report,utils::null_deleter());
+                CollisionReportPtr preport(new CollisionReport);
                 bool bCollision = _penv->CheckCollision(pbody,preport);
-                ((PyCollisionReportPtr)epyreport2)->Init(report);
+                ((PyCollisionReportPtr)epyreport2)->Init(*preport);
                 return bCollision;
             }
         }
@@ -1490,10 +1485,9 @@ bool PyEnvironmentBase::CheckCollision(object o1, object o2, PyCollisionReportPt
 {
     CHECK_POINTER(o1);
     CHECK_POINTER(o2);
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision = false;
@@ -1535,7 +1529,7 @@ bool PyEnvironmentBase::CheckCollision(object o1, object o2, PyCollisionReportPt
     }
 
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1560,10 +1554,9 @@ bool PyEnvironmentBase::CheckCollision(object o1, PyKinBodyPtr pybody2, PyCollis
 {
     CHECK_POINTER(o1);
     CHECK_POINTER(pybody2);
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     KinBodyConstPtr pbody2 = openravepy::GetKinBody(pybody2);
@@ -1582,7 +1575,7 @@ bool PyEnvironmentBase::CheckCollision(object o1, PyKinBodyPtr pybody2, PyCollis
         }
     }
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1629,10 +1622,9 @@ bool PyEnvironmentBase::CheckCollision(object o1, object bodyexcluded, object li
 
 bool PyEnvironmentBase::CheckCollision(object o1, object bodyexcluded, object linkexcluded, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     std::vector<KinBodyConstPtr> vbodyexcluded;
@@ -1671,7 +1663,7 @@ bool PyEnvironmentBase::CheckCollision(object o1, object bodyexcluded, object li
     }
 
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1703,10 +1695,9 @@ bool PyEnvironmentBase::CheckCollision(PyKinBodyPtr pbody, object bodyexcluded, 
 
 bool PyEnvironmentBase::CheckCollision(PyKinBodyPtr pbody, object bodyexcluded, object linkexcluded, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     std::vector<KinBodyConstPtr> vbodyexcluded;
@@ -1732,7 +1723,7 @@ bool PyEnvironmentBase::CheckCollision(PyKinBodyPtr pbody, object bodyexcluded, 
 
     bool bCollision = _penv->CheckCollision(KinBodyConstPtr(openravepy::GetKinBody(pbody)), vbodyexcluded, vlinkexcluded, preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1744,15 +1735,14 @@ bool PyEnvironmentBase::CheckCollision(OPENRAVE_SHARED_PTR<PyRay> pyray, PyKinBo
 
 bool PyEnvironmentBase::CheckCollision(OPENRAVE_SHARED_PTR<PyRay> pyray, PyKinBodyPtr pbody, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision = _penv->CheckCollision(pyray->r, KinBodyConstPtr(openravepy::GetKinBody(pbody)), preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1767,8 +1757,7 @@ object PyEnvironmentBase::CheckCollisionRays(py::numeric::array rays, PyKinBodyP
     if( extract<int>(shape[py::to_object(1)]) != 6 ) {
         throw OpenRAVEException(_("rays object needs to be a Nx6 vector\n"));
     }
-    CollisionReport report;
-    CollisionReportPtr preport(&report,null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
 
     PyArrayObject *pPyRays = PyArray_GETCONTIGUOUS(reinterpret_cast<PyArrayObject*>(rays.ptr()));
     AutoPyArrayObjectDereferencer pyderef(pPyRays);
@@ -1829,8 +1818,8 @@ object PyEnvironmentBase::CheckCollisionRays(py::numeric::array rays, PyKinBodyP
 
             const bool bCollision = pbody ? _penv->CheckCollision(r, KinBodyConstPtr(openravepy::GetKinBody(pbody)), preport) : _penv->CheckCollision(r, preport);
 
-            if( bCollision && report.nNumValidCollisions > 0 ) {
-                const CollisionPairInfo& cpinfo = report.vCollisionInfos[0];
+            if( bCollision && preport->nNumValidCollisions > 0 ) {
+                const CollisionPairInfo& cpinfo = preport->vCollisionInfos[0];
                 if( cpinfo.contacts.size() > 0 ) {
                     if( !bFrontFacingOnly || cpinfo.contacts[0].norm.dot3(r.dir)<0 ) {
                         pcollision[i] = true;
@@ -1859,15 +1848,14 @@ bool PyEnvironmentBase::CheckCollision(OPENRAVE_SHARED_PTR<PyRay> pyray)
 
 bool PyEnvironmentBase::CheckCollision(OPENRAVE_SHARED_PTR<PyRay> pyray, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision = _penv->CheckCollision(pyray->r, preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }

--- a/python/bindings/openravepy_kinbody.cpp
+++ b/python/bindings/openravepy_kinbody.cpp
@@ -4032,15 +4032,14 @@ PyInterfaceBasePtr PyKinBody::GetSelfCollisionChecker()
 
 bool PyKinBody::CheckSelfCollision(PyCollisionReportPtr pyreport, PyCollisionCheckerBasePtr pycollisionchecker)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision = _pbody->CheckSelfCollision(preport, openravepy::GetCollisionChecker(pycollisionchecker));
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }

--- a/python/bindings/openravepy_robot.cpp
+++ b/python/bindings/openravepy_robot.cpp
@@ -1212,25 +1212,23 @@ object PyRobotBase::PyManipulator::GetIkConfigurationSpecification(IkParameteriz
 
 bool PyRobotBase::PyManipulator::CheckEndEffectorCollision(PyCollisionReportPtr pyreport) const
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bcollision = _pmanip->CheckEndEffectorCollision(preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bcollision;
 }
 
 bool PyRobotBase::PyManipulator::CheckEndEffectorCollision(object otrans, PyCollisionReportPtr pyreport, int numredundantsamples) const
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision;
@@ -1242,32 +1240,30 @@ bool PyRobotBase::PyManipulator::CheckEndEffectorCollision(object otrans, PyColl
         bCollision = _pmanip->CheckEndEffectorCollision(ExtractTransform(otrans),preport, numredundantsamples);
     }
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
 
 bool PyRobotBase::PyManipulator::CheckEndEffectorSelfCollision(PyCollisionReportPtr pyreport) const
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bcollision = _pmanip->CheckEndEffectorSelfCollision(preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bcollision;
 }
 
 bool PyRobotBase::PyManipulator::CheckEndEffectorSelfCollision(object otrans, PyCollisionReportPtr pyreport, int numredundantsamples, bool ignoreManipulatorLinks) const
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision;
@@ -1279,7 +1275,7 @@ bool PyRobotBase::PyManipulator::CheckEndEffectorSelfCollision(object otrans, Py
         bCollision = _pmanip->CheckEndEffectorSelfCollision(ExtractTransform(otrans), preport, numredundantsamples, ignoreManipulatorLinks);
     }
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -1290,15 +1286,14 @@ bool PyRobotBase::PyManipulator::CheckIndependentCollision() const
 }
 bool PyRobotBase::PyManipulator::CheckIndependentCollision(PyCollisionReportPtr pyreport) const
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision = _pmanip->CheckIndependentCollision(preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }
@@ -2221,15 +2216,14 @@ bool PyRobotBase::Grab(PyKinBodyPtr pbody, object pylink, object linkstoignore, 
 
 bool PyRobotBase::CheckLinkSelfCollision(int ilinkindex, object olinktrans, PyCollisionReportPtr pyreport)
 {
-    CollisionReport report;
     CollisionReportPtr preport;
     if( !!pyreport ) {
-        preport = CollisionReportPtr(&report,utils::null_deleter());
+        preport = CollisionReportPtr(new CollisionReport);
     }
 
     bool bCollision = _probot->CheckLinkSelfCollision(ilinkindex, ExtractTransform(olinktrans), preport);
     if( !!pyreport ) {
-        pyreport->Init(report);
+        pyreport->Init(*preport);
     }
     return bCollision;
 }

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -3536,9 +3536,8 @@ void KinBody::ComputeInverseDynamics(std::vector<dReal>& doftorques, const std::
     if( !bHasVelocity ) {
         vDOFVelocities.resize(0);
     }
-    AccelerationMap externalaccelerations;
-    externalaccelerations[0] = make_pair(-vgravity, Vector());
-    AccelerationMapPtr pexternalaccelerations(&externalaccelerations, utils::null_deleter());
+    AccelerationMapPtr pexternalaccelerations(new AccelerationMap);
+    (*pexternalaccelerations)[0] = make_pair(-vgravity, Vector());
     _ComputeLinkAccelerations(vDOFVelocities, vDOFAccelerations, vLinkVelocities, vLinkAccelerations, pexternalaccelerations);
 
     // all valuess are in the global coordinate system
@@ -3676,9 +3675,8 @@ void KinBody::ComputeInverseDynamics(boost::array< std::vector<dReal>, 3>& vDOFT
         vDOFVelocities.resize(0);
     }
 
-    AccelerationMap externalaccelerations;
-    externalaccelerations[0] = make_pair(-vgravity, Vector());
-    AccelerationMapPtr pexternalaccelerations(&externalaccelerations, utils::null_deleter());
+    AccelerationMapPtr pexternalaccelerations(new AccelerationMap);
+    (*pexternalaccelerations)[0] = make_pair(-vgravity, Vector());
 
     // all valuess are in the global coordinate system
     // try to compute as little as possible by checking what is non-zero

--- a/src/libopenrave/kinbodycollision.cpp
+++ b/src/libopenrave/kinbodycollision.cpp
@@ -64,10 +64,9 @@ bool KinBody::CheckSelfCollision(CollisionReportPtr report, CollisionCheckerBase
 
     // if collision checker is set to distance checking, have to compare reports for the minimum distance
     int coloptions = collisionchecker->GetCollisionOptions();
-    CollisionReport tempreport;
     CollisionReportPtr pusereport = report;
     if( !!report && (coloptions & CO_Distance) ) {
-        pusereport = boost::shared_ptr<CollisionReport>(&tempreport,utils::null_deleter());
+        pusereport = CollisionReportPtr(new CollisionReport);
     }
 
     // Flatten the grabbed bodies so that we can zip our iteration with the cache of locked pointers

--- a/src/libopenrave/planningutils.cpp
+++ b/src/libopenrave/planningutils.cpp
@@ -41,8 +41,7 @@ int JitterActiveDOF(RobotBasePtr robot,int nMaxIterations,dReal fRand,const Plan
     robot->GetActiveDOFValues(curdof);
     newdof.resize(curdof.size());
     deltadof.resize(curdof.size(),0);
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
     bool bCollision = false;
     bool bConstraint = !!neighstatefn;
 
@@ -68,12 +67,12 @@ int JitterActiveDOF(RobotBasePtr robot,int nMaxIterations,dReal fRand,const Plan
 
         if(robot->CheckSelfCollision(preport)) {
             bCollision = true;
-            RAVELOG_DEBUG(str(boost::format("JitterActiveDOFs: self collision: %s!\n")%report.__str__()));
+            RAVELOG_DEBUG(str(boost::format("JitterActiveDOFs: self collision: %s!\n")%preport->__str__()));
             break;
         }
         if( robot->GetEnv()->CheckCollision(KinBodyConstPtr(robot),preport) ) {
             bCollision = true;
-            RAVELOG_DEBUG(str(boost::format("JitterActiveDOFs: collision: %s!\n")%report.__str__()));
+            RAVELOG_DEBUG(str(boost::format("JitterActiveDOFs: collision: %s!\n")%preport->__str__()));
             break;
         }
     }
@@ -193,8 +192,7 @@ int JitterCurrentConfiguration(PlannerBase::PlannerParametersConstPtr parameters
     newdof.resize(curdof.size());
     deltadof.resize(curdof.size(),0);
     zerodof.resize(curdof.size(),0);
-    CollisionReport report;
-    CollisionReportPtr preport(&report,utils::null_deleter());
+    CollisionReportPtr preport(new CollisionReport);
     bool bCollision = false;
     bool bConstraint = !!parameters->_neighstatefn;
 

--- a/src/libopenrave/robotmanipulator.cpp
+++ b/src/libopenrave/robotmanipulator.cpp
@@ -1225,8 +1225,7 @@ bool RobotBase::Manipulator::_CheckEndEffectorCollision(const IkParameterization
     }
 
     // if IK can be solved, then there exists a solution for the end effector that is not in collision
-    IkReturn ikreturn(IKRA_Success);
-    IkReturnPtr pikreturn(&ikreturn,utils::null_deleter());
+    IkReturnPtr pikreturn(new IkReturn(IKRA_Success));
 
     // need to use free params here since sometimes IK can have 3+ free DOF and it would freeze searching for all of them
     std::vector<dReal> vFreeParameters;
@@ -1235,8 +1234,8 @@ bool RobotBase::Manipulator::_CheckEndEffectorCollision(const IkParameterization
         return false;
     }
     else {
-        if( (ikreturn._action&IKRA_RejectSelfCollision) != IKRA_RejectSelfCollision && (ikreturn._action&IKRA_RejectEnvCollision) != IKRA_RejectEnvCollision ) {
-            RAVELOG_VERBOSE_FORMAT("ik solution not found due to non-collision reasons (0x%x), returning true anway...", ikreturn._action);
+        if( (pikreturn->_action&IKRA_RejectSelfCollision) != IKRA_RejectSelfCollision && (pikreturn->_action&IKRA_RejectEnvCollision) != IKRA_RejectEnvCollision ) {
+            RAVELOG_VERBOSE_FORMAT("ik solution not found due to non-collision reasons (0x%x), returning true anway...", pikreturn->_action);
             // is this a good idea?
         }
         if( !!report ) {
@@ -1297,8 +1296,7 @@ bool RobotBase::Manipulator::CheckEndEffectorSelfCollision(const IkParameterizat
     }
 
     // if IK can be solved, then there exists a solution for the end effector that is not in collision
-    IkReturn ikreturn(IKRA_Success);
-    IkReturnPtr pikreturn(&ikreturn,utils::null_deleter());
+    IkReturnPtr pikreturn(new IkReturn(IKRA_Success));
 
     // need to use free params here since sometimes IK can have 3+ free DOF and it would freeze searching for all of them
     std::vector<dReal> vFreeParameters;
@@ -1307,8 +1305,8 @@ bool RobotBase::Manipulator::CheckEndEffectorSelfCollision(const IkParameterizat
         return false;
     }
     else {
-        if( (ikreturn._action&IKRA_RejectSelfCollision) != IKRA_RejectSelfCollision && (ikreturn._action&IKRA_RejectEnvCollision) != IKRA_RejectEnvCollision ) {
-            RAVELOG_VERBOSE_FORMAT("ik solution not found due to non-collision reasons (0x%x), returning true anway...", ikreturn._action);
+        if( (pikreturn->_action&IKRA_RejectSelfCollision) != IKRA_RejectSelfCollision && (pikreturn->_action&IKRA_RejectEnvCollision) != IKRA_RejectEnvCollision ) {
+            RAVELOG_VERBOSE_FORMAT("ik solution not found due to non-collision reasons (0x%x), returning true anway...", pikreturn->_action);
             // is this a good idea?
         }
         if( !!report ) {


### PR DESCRIPTION
null_deleter is against the raison d'etre of shared_ptr. Also it is confusing when we want to make custom factory (instantiater).

Hence it should not be used (unless we need to convert some reference to shared_ptr).

For the full background why I wanted this pull request, please see controllercommon!1108.