### PR TITLE
Extract isRobot flag from the reference body

### DIFF
--- a/src/libopenrave-core/jsonparser/jsonreader.cpp
+++ b/src/libopenrave-core/jsonparser/jsonreader.cpp
@@ -914,7 +914,6 @@ protected:
     bool _Extract(const rapidjson::Value& rBodyInfo, KinBodyPtr& pBodyOut, const rapidjson::Value& rEnvInfo, dReal fUnitScale, rapidjson::Document::AllocatorType& alloc, std::map<RobotBase::ConnectedBodyInfoPtr, std::string>& mapProcessedConnectedBodyUris)
     {
         // extract for robot
-        bool isRobot = orjson::GetJsonValueByKey<bool>(rBodyInfo, "isRobot");
         std::string bodyId = orjson::GetJsonValueByKey<std::string>(rBodyInfo, "id", "");
         std::string bodyName = orjson::GetJsonValueByKey<std::string>(rBodyInfo, "name", "");
         const char* pReferenceUri = orjson::GetCStringJsonValueByKey(rBodyInfo, "referenceUri", "");
@@ -952,11 +951,13 @@ protected:
         RobotBase::RobotBaseInfoPtr pRobotBaseInfo;
         if( insertIndex >= 0 ) {
             pKinBodyInfo = envInfo._vBodyInfos.at(insertIndex);
+            bool isRobot = orjson::GetJsonValueByKey<bool>(rBodyInfo, "isRobot", pKinBodyInfo->_isRobot); // fallback to extract isRobot flag from the reference body info
             if( isRobot ) {
                 pRobotBaseInfo = OPENRAVE_DYNAMIC_POINTER_CAST<RobotBase::RobotBaseInfo>(pKinBodyInfo);
             }
         }
         else {
+            bool isRobot = orjson::GetJsonValueByKey<bool>(rBodyInfo, "isRobot");
             if( isRobot ) {
                 pRobotBaseInfo.reset(new RobotBase::RobotBaseInfo());
                 pKinBodyInfo = pRobotBaseInfo;


### PR DESCRIPTION
Fixes an issue where `env.ReadRobotURI`  does not load `isRobot` flag from the reference body, eventually causing the loading of the robot body to fail.
```
2024-10-29 10:58:20,503 openrave [WARN] [plugindatabase_virtual.cpp:146 InterfaceBasePtr OpenRAVE::RaveDatabase::Create] env=1 failed to create name GenericRobot, interface kinbody
2024-10-29 10:58:20,503 openrave [WARN] [kinbody.cpp:853 KinBody::InitFromKinBodyInfo] body 'sc2_cameras' interfaceType does not match  != GenericRobot
```