### PR TITLE
clang19 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,9 @@ find_package(Boost REQUIRED COMPONENTS filesystem system thread iostreams)
 set(OPENRAVE_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
 set(OPENRAVE_BOOST_LIB_DIRS ${Boost_LIBRARY_DIRS})
 
+# prevents CLANG from "error: integer value -1 is outside the valid range of values [0, 3] for the enumeration type 'sign_mixture_enum' [-Wenum-constexpr-conversion]"
+include_directories(SYSTEM ${OPENRAVE_BOOST_INCLUDE_DIRS})
+
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG )
   set(NATIVE_COMPILE_FLAGS "" CACHE STRING "compilation flags to pass to tools that are executed at build-time. For example '-march=native -mtune=native'. By default this is empty.")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,9 +272,6 @@ find_package(Boost REQUIRED COMPONENTS filesystem system thread iostreams)
 set(OPENRAVE_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
 set(OPENRAVE_BOOST_LIB_DIRS ${Boost_LIBRARY_DIRS})
 
-# prevents CLANG from "error: integer value -1 is outside the valid range of values [0, 3] for the enumeration type 'sign_mixture_enum' [-Wenum-constexpr-conversion]"
-include_directories(SYSTEM ${OPENRAVE_BOOST_INCLUDE_DIRS})
-
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR COMPILER_IS_CLANG )
   set(NATIVE_COMPILE_FLAGS "" CACHE STRING "compilation flags to pass to tools that are executed at build-time. For example '-march=native -mtune=native'. By default this is empty.")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ elseif( COMPILER_IS_CLANG )
   add_definitions("-Werror=return-stack-address")
   # prevents CLANG from "error: integer value -1 is outside the valid range of values [0, 3]
   # for the enumeration type 'sign_mixture_enum' [-Wenum-constexpr-conversion]"
-  add_definitions("-Wno-enum-constexpr-conversion")
+  add_definitions("-Wno-error=enum-constexpr-conversion")
 endif()
 
 set(OPENRAVE_EXPORT_CXXFLAGS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,9 @@ if( CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX )
   add_definitions("-Werror=return-local-addr")
 elseif( COMPILER_IS_CLANG )
   add_definitions("-Werror=return-stack-address")
+  # prevents CLANG from "error: integer value -1 is outside the valid range of values [0, 3]
+  # for the enumeration type 'sign_mixture_enum' [-Wenum-constexpr-conversion]"
+  add_definitions("-Wno-enum-constexpr-conversion")
 endif()
 
 set(OPENRAVE_EXPORT_CXXFLAGS)
@@ -243,7 +246,7 @@ if( MSVC )
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/msvc_include/stdint.h DESTINATION include/openrave-${OPENRAVE_VERSION_MAJOR}.${OPENRAVE_VERSION_MINOR} COMPONENT ${COMPONENT_PREFIX}dev)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/msvc_include)
   endif()
-  
+
   # have to install dlls manually
   if( MSVC70 OR MSVC71 )
     set(MSVC_PREFIX "vc70")
@@ -255,7 +258,7 @@ if( MSVC )
     set(MSVC_PREFIX "vc100")
   endif()
   set(OPENRAVE_LIBRARY_SUFFIX "${OPENRAVE_SOVERSION}-${MSVC_PREFIX}-mt" CACHE STRING "Suffix to append to library names")
-  
+
   # force multi-threaded DLL boost
   set(Boost_USE_MULTITHREAD ON)
   set(Boost_USE_STATIC_LIBS OFF)


### PR DESCRIPTION
clang19 treats `-Wenum-constexpr-conversion` as an error by default, and gives the following message:
```
/usr/include/boost/mpl/aux_/integral_wrapper.hpp:73:31: error: integer value -1 is outside the valid range of values [0, 3] for the enumeration type 'sign_mixture_enum' [-Wenum-constexpr-conversion]
```

in case of a simple warning adding to the system includes should work with:
```
include_directories(SYSTEM ${OPENRAVE_BOOST_INCLUDE_DIRS})
```
but it does not in this case, hence the need of disabling this particular error directly.