### PR TITLE
Draft: Do not force CMAKE_CXX_STANDARD as g++ defaults gnu++14. Force C++14 on ann.

### DIFF
--- a/3rdparty/ann/CMakeLists.txt
+++ b/3rdparty/ann/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_CXX_STANDARD 14)
 file(GLOB ann_files ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 add_definitions(-DANN_STATIC_LIBRARY) # for windows compilation, just exports the symbols (even though library is being built statically)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,6 @@ cmake_policy(SET CMP0002 NEW)
 # http://www.cmake.org/cmake/help/cmake-2.6.html#policy:CMP0003
 cmake_policy(SET CMP0003 NEW)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14) # C++14 for std::shared_timed_mutex
-endif()
 # Use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)
 

--- a/include/openrave/interface.h
+++ b/include/openrave/interface.h
@@ -75,7 +75,9 @@ public:
     virtual void DeserializeJSON(const rapidjson::Value& value, dReal fUnitScale, int options) = 0;
 };
 
-struct OPENRAVE_API ReadablesContainer {
+class OPENRAVE_API ReadablesContainer
+{
+public:
     virtual ~ReadablesContainer() = default;
 
     typedef std::map<std::string, ReadablePtr, CaseInsensitiveCompare> READERSMAP;


### PR DESCRIPTION
Our builder already defaults to gnu++14, so there are no need to force CXX_STANDARD.

G++ 11.0 / Clang++ 16.0 defaults to gnu++17.

OpenRAVE built with C++14 cannot be linked to downstream libraries built with C++17, so forcing CXX_STANDARD can cause confusion.