### PR TITLE
Use ReadablesContainer public-class rather than struct, because former declaration is done as class

### DIFF
--- a/include/openrave/interface.h
+++ b/include/openrave/interface.h
@@ -75,7 +75,9 @@ public:
     virtual void DeserializeJSON(const rapidjson::Value& value, dReal fUnitScale, int options) = 0;
 };
 
-struct OPENRAVE_API ReadablesContainer {
+class OPENRAVE_API ReadablesContainer
+{
+public:
     virtual ~ReadablesContainer() = default;
 
     typedef std::map<std::string, ReadablePtr, CaseInsensitiveCompare> READERSMAP;


### PR DESCRIPTION
Otherwise clang will raise warnings and Werror will be affected.