### PR TITLE
Fix hash include

### DIFF
--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -63,6 +63,7 @@
 #if OPENRAVE_STD_STRING_VIEW
 #include <string_view>
 #else
+#include <boost/functional/hash.hpp>
 #include <boost/utility/string_view.hpp>
 namespace std{
     // make boost::string_view handlable by std::unordered_set/map


### PR DESCRIPTION
```
[ 38%] Building CXX object src/libopenrave/CMakeFiles/libopenrave.dir/collisionchecker.cpp.o
[ 38%] Building CXX object src/libopenrave/CMakeFiles/libopenrave.dir/configurationspecification.cpp.o
In file included from /home/mujin/mujin/checkoutroot/openrave/src/libopenrave/libopenrave.h:24,
                 from /home/mujin/mujin/checkoutroot/openrave/src/libopenrave/collisionchecker.cpp:17:
/home/mujin/mujin/checkoutroot/openrave/include/openrave/openrave.h:70:75: error: expected template-name before ‘<’ token
   70 |     class hash<boost::basic_string_view<CharT,Traits>>: public boost::hash<boost::basic_string_view<CharT,Traits>>
      |                                                                           ^
/home/mujin/mujin/checkoutroot/openrave/include/openrave/openrave.h:70:75: error: expected ‘{’ before ‘<’ token
In file included from /home/mujin/mujin/checkoutroot/openrave/src/libopenrave/libopenrave.h:24,
                 from /home/mujin/mujin/checkoutroot/openrave/src/libopenrave/configurationspecification.cpp:20:
/home/mujin/mujin/checkoutroot/openrave/include/openrave/openrave.h:70:75: error: expected template-name before ‘<’ token
   70 |     class hash<boost::basic_string_view<CharT,Traits>>: public boost::hash<boost::basic_string_view<CharT,Traits>>
      |                                                                           ^
/home/mujin/mujin/checkoutroot/openrave/include/openrave/openrave.h:70:75: error: expected ‘{’ before ‘<’ token
```