### PR TITLE
Use PyUnicode_GET_LENGTH

### DIFF
--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -256,7 +256,7 @@ void toRapidJSONValue(const object &obj, rapidjson::Value &value, rapidjson::Doc
 #if PY_MAJOR_VERSION >= 3
     else if (PyUnicode_Check(obj.ptr()))
     {
-        value.SetString(PyUnicode_AsUTF8(obj.ptr()), PyUnicode_GET_SIZE(obj.ptr()), allocator);
+        value.SetString(PyUnicode_AsUTF8(obj.ptr()), PyUnicode_GET_LENGTH(obj.ptr()), allocator);
     }
 #else
     else if (PyString_Check(obj.ptr()))


### PR DESCRIPTION
PyUnicode_GET_SIZE was removed in Python 3.13.