### PR TITLE
Add cstdint to ikfast.h

### DIFF
--- a/python/ikfast.h
+++ b/python/ikfast.h
@@ -36,6 +36,7 @@
 #include <list>
 #include <stdexcept>
 #include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 


### PR DESCRIPTION
On Debian 13, `pytest -v -s test_iksolver.py -k test_CustomFilter[lab1.env.xml]` raised this:

```
2025-01-30 01:12:16,814 openravepy.databases.inversekinematics [INFO] [inversekinematics.py:958 generate] successfully generated c++ ik in 85.855430s, file=/private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast0x1000004c.Transform6D.0_1_3_4_5_6_f2.cpp
2025-01-30 01:12:16,814 openravepy.databases.inversekinematics [INFO] [inversekinematics.py:964 generate] compiling ik file to /private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast0x1000004c.Transform6D.x86_64.0_1_3_4_5_6_f2.so
2025-01-30 01:12:16,814 root [INFO] [spawn.py:60 spawn] c++ -DIKFAST_CLIBRARY=1 -DIKFAST_NO_MAIN=1 -c /private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast0x1000004c.Transform6D.x86_64.0_1_3_4_5_6_f2.cpp -o ../../../../../../../../../private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast0x1000004c.Transform6D.x86_64.0_1_3_4_5_6_f2.o -O3 -fPIC -std=c++11
In file included from /private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast0x1000004c.Transform6D.x86_64.0_1_3_4_5_6_f2.cpp:22:
/private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast.h:197:35: error: ‘uint32_t’ has not been declared
  197 |     void SetSolution(const T v[], uint32_t nvars) {
      |                                   ^~~~~~~~
/private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast.h: In member function ‘void ikfast::IkSolution<T>::SetSolution(const T*, int)’:
/private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast.h:200:13: error: ‘uint32_t’ was not declared in this scope
  200 |         for(uint32_t i = 0; i < nvars; i++) {
      |             ^~~~~~~~
/private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast.h:41:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   40 | #include <iomanip>
  +++ |+#include <cstdint>
   41 | 
/private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast.h:200:29: error: ‘i’ was not declared in this scope
  200 |         for(uint32_t i = 0; i < nvars; i++) {
      |                             ^
                ^

E           subprocess.CalledProcessError: Command '['/usr/bin/c++', '-DIKFAST_CLIBRARY=1', '-DIKFAST_NO_MAIN=1', '-c', '/private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast0x1000004c.Transform6D.x86_64.0_1_3_4_5_6_f2.cpp', '-o', '../../../../../../../../../private/cache/openrave/kinematics.07d2f91176824501770bf9b1d22d00d3/ikfast0x1000004c.Transform6D.x86_64.0_1_3_4_5_6_f2.o', '-O3', '-fPIC', '-std=c++11']' returned non-zero exit status 1.
```