### PR TITLE
Add warning when self-collision checker does not exist

### DIFF
--- a/src/libopenrave/kinbodycollision.cpp
+++ b/src/libopenrave/kinbodycollision.cpp
@@ -53,6 +53,7 @@ bool KinBody::CheckSelfCollision(CollisionReportPtr report, CollisionCheckerBase
                 // no checker set
                 return false;
             }
+            RAVELOG_WARN_FORMAT("env=%s, self-collision checker is not set for '%s' so using env collision checker instead", GetEnv()->GetNameId() % GetName());
         }
         else {
             // have to set the same options as GetEnv()->GetCollisionChecker() since stuff like CO_ActiveDOFs is only set on the global checker


### PR DESCRIPTION
# Description

Generally, the environment-collision checker and the robot self-collision checker might be using different geometry groups for collision checking. Using the environment-collision checker as a substitute for the missing self-collision checker may not give desired results.

At least, when the self-collision checker is missing, prints some warning.