### PR TITLE
Include link transforms in geometry hash, maybe we should include readables?

### DIFF
--- a/include/openrave/hashcontext.h
+++ b/include/openrave/hashcontext.h
@@ -91,7 +91,8 @@ public:
     }
 
     // Allow directly updating with rapidjson values
-    HashContext& operator<<(const rapidjson::Value& rValue)
+    template <typename EncodingT, typename AllocatorT>
+    HashContext& operator<<(const rapidjson::GenericValue<EncodingT, AllocatorT>& rValue)
     {
         switch (rValue.GetType()) {
         // Don't count a null for anything

--- a/include/openrave/interface.h
+++ b/include/openrave/interface.h
@@ -24,6 +24,8 @@
 
 #include <rapidjson/document.h>
 
+#include "openrave/hashcontext.h"
+
 namespace OpenRAVE {
 
 /// \brief options to pass into UpdateFromInfo that control what gets updated
@@ -109,6 +111,10 @@ public:
 
     /// \brief updates the readable interfaces. returns true if there are any changes
     virtual bool UpdateReadableInterfaces(const std::map<std::string, ReadablePtr>& newReadableInterfaces);
+
+    /// \brief generate the hash digest of all readables in the container
+    /// Thread-safe.
+    void DigestHash(HashContext& hash) const;
 
     boost::shared_mutex& GetReadableInterfaceMutex() const
     {

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -3612,6 +3612,26 @@ public:
     /// \brief Generate a hash of this structure into the provided hash context
     virtual void DigestHash(HashContext& hash, int options) const;
 
+    /// \brief Set a new readable interface and return the previously set interface if it exists. <b>[multi-thread safe]</b>
+    /// Overridden here so that we can invalidate our hash on readable data change
+    ReadablePtr SetReadableInterface(const std::string& id, ReadablePtr readable) override;
+
+    /// \brief sets a set of readable interfaces all at once. The pointers are copied
+    ///
+    /// \param mapReadables the readable interfaces to ste
+    /// \param bClearAllExisting if true, then clears the existing readables, if false, just updates the readables that are specified in mapReadables
+    /// Overridden here so that we can invalidate our hash on readable data change
+    void SetReadableInterfaces(const READERSMAP& mapReadables, bool bClearAllExisting) override;
+
+    /// \brief clears the readable interfaces
+    /// Overridden here so that we can invalidate our hash on readable data change
+    void ClearReadableInterfaces() override;
+    void ClearReadableInterface(const std::string& id) override;
+
+    /// \brief updates the readable interfaces. returns true if there are any changes
+    /// Overridden here so that we can invalidate our hash on readable data change
+    bool UpdateReadableInterfaces(const std::map<std::string, ReadablePtr>& newReadableInterfaces) override;
+
     inline KinBodyPtr shared_kinbody() {
         return boost::static_pointer_cast<KinBody>(shared_from_this());
     }

--- a/include/openrave/openrave.h
+++ b/include/openrave/openrave.h
@@ -268,6 +268,7 @@ class IkReturn;
 class IkFailureInfo;
 class IkFailureAccumulatorBase;
 class Readable;
+class HashContext;
 
 typedef boost::shared_ptr<CollisionReport> CollisionReportPtr;
 typedef boost::shared_ptr<CollisionReport const> CollisionReportConstPtr;
@@ -389,6 +390,9 @@ public:
 
     /// \return return a cloned copy of this readable
     virtual ReadablePtr CloneSelf() const = 0;
+
+    /// \brief Generate a digest of the given readable
+    virtual void DigestHash(HashContext& hash) const;
 
 private:
     std::string __xmlid;

--- a/src/libopenrave/interface.cpp
+++ b/src/libopenrave/interface.cpp
@@ -315,6 +315,15 @@ void ReadablesContainer::ClearReadableInterface(const std::string& id) {
     __mapReadableInterfaces.erase(id);
 }
 
+void ReadablesContainer::DigestHash(HashContext& hash) const
+{
+    std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
+    for (const READERSMAP::value_type& it : __mapReadableInterfaces) {
+        hash << it.first;
+        it.second->DigestHash(hash);
+    }
+}
+
 bool ReadablesContainer::UpdateReadableInterfaces(const std::map<std::string, ReadablePtr>& newReadableInterfaces) {
     std::unique_lock<boost::shared_mutex> lock(_mutexInterface);
     bool bChanged = false;
@@ -368,6 +377,14 @@ bool ReadablesContainer::UpdateReadableInterfaces(const std::map<std::string, Re
         }
     }
     return bChanged;
+}
+
+void Readable::DigestHash(HashContext& hash) const
+{
+    hash << GetXMLId();
+    rapidjson::Document doc;
+    SerializeJSON(doc, doc.GetAllocator(), 1.0, 0);
+    hash << doc;
 }
 
 }

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -6147,6 +6147,38 @@ void KinBody::SetZeroConfiguration()
     }
 }
 
+ReadablePtr KinBody::SetReadableInterface(const std::string& id, ReadablePtr readable)
+{
+    ReadablePtr ret = ReadablesContainer::SetReadableInterface(id, readable);
+    __hashKinematicsGeometryDynamics.clear();
+    return ret;
+}
+
+void KinBody::SetReadableInterfaces(const READERSMAP& mapReadables, bool bClearAllExisting)
+{
+    ReadablesContainer::SetReadableInterfaces(mapReadables, bClearAllExisting);
+    __hashKinematicsGeometryDynamics.clear();
+}
+
+void KinBody::ClearReadableInterfaces()
+{
+    ReadablesContainer::ClearReadableInterfaces();
+    __hashKinematicsGeometryDynamics.clear();
+}
+
+void KinBody::ClearReadableInterface(const std::string& id)
+{
+    ReadablesContainer::ClearReadableInterface(id);
+    __hashKinematicsGeometryDynamics.clear();
+}
+
+bool KinBody::UpdateReadableInterfaces(const std::map<std::string, ReadablePtr>& newReadableInterfaces)
+{
+    const bool ret = ReadablesContainer::UpdateReadableInterfaces(newReadableInterfaces);
+    __hashKinematicsGeometryDynamics.clear();
+    return ret;
+}
+
 const std::string& KinBody::GetKinematicsGeometryHash() const
 {
     CHECK_INTERNAL_COMPUTATION;

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -6629,6 +6629,11 @@ UpdateFromInfoResult KinBody::UpdateFromKinBodyInfo(const KinBodyInfo& info)
         }
     }
 
+    // If we made changes, invalidate our cached geometry hash
+    if (updateFromInfoResult != UFIR_NoChange) {
+        __hashKinematicsGeometryDynamics.clear();
+    }
+
     return updateFromInfoResult;
 }
 

--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -6184,6 +6184,7 @@ const std::string& KinBody::GetKinematicsGeometryHash() const
     CHECK_INTERNAL_COMPUTATION;
     if( __hashKinematicsGeometryDynamics.size() == 0 ) {
         HashContext hash;
+        ReadablesContainer::DigestHash(hash);
         // should add dynamics since that affects a lot how part is treated.
         DigestHash(hash, SO_Kinematics|SO_Geometry|SO_Dynamics);
         __hashKinematicsGeometryDynamics = hash.HexDigest();

--- a/src/libopenrave/kinbodylink.cpp
+++ b/src/libopenrave/kinbodylink.cpp
@@ -675,6 +675,7 @@ AABB KinBody::Link::ComputeAABBForGeometryGroupFromTransform(const std::string& 
 void KinBody::Link::DigestHash(HashContext& hash, int options) const
 {
     hash << _index;
+    hash << _info._t;
     if (options & SO_Geometry) {
         hash << _vGeometries.size();
         FOREACHC(it, _vGeometries) {


### PR DESCRIPTION
See issue in mattermost re: map syncing. 