### PR TITLE
Add format_as for geometry type

### DIFF
--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -66,6 +66,10 @@ enum GeometryType : uint8_t
 
 OPENRAVE_API const char* GetGeometryTypeString(GeometryType geometryType);
 
+OPENRAVE_API inline std::string format_as(GeometryType geomtype){
+    return GetGeometryTypeString(geomtype);
+}
+
 enum DynamicsConstraintsType : int8_t
 {
     DC_Unknown = -1, ///< constraints type is not set.

--- a/include/openrave/kinbody.h
+++ b/include/openrave/kinbody.h
@@ -66,7 +66,7 @@ enum GeometryType : uint8_t
 
 OPENRAVE_API const char* GetGeometryTypeString(GeometryType geometryType);
 
-OPENRAVE_API inline std::string format_as(GeometryType geomtype){
+OPENRAVE_API inline const char* format_as(GeometryType geomtype){
     return GetGeometryTypeString(geomtype);
 }
 


### PR DESCRIPTION
@rschlaikjer 

This adds OpenRAVE::format_as(GeometryType) so that fmt9+ works.

Already tested in trixie autotester schedule.