### PR TITLE
Preserve base link in body transform on clone

### DIFF
--- a/src/libopenrave/kinbody.cpp
+++ b/src/libopenrave/kinbody.cpp
@@ -776,6 +776,11 @@ void KinBody::_InitWithInitialLinks(const std::vector<LinkInfoT>& linkInfos)
     CHECK_NO_INTERNAL_COMPUTATION;
     BOOST_ASSERT(_veclinks.empty()); // We assume we are the first call to initialize links
 
+    // If there are no links, nothing to init
+    if (linkInfos.empty()) {
+        return;
+    }
+
     // Keep track of link names as we go to deduplicate
     std::unordered_set<std::string> existingLinkNames;
     existingLinkNames.reserve(linkInfos.size());
@@ -797,6 +802,10 @@ void KinBody::_InitWithInitialLinks(const std::vector<LinkInfoT>& linkInfos)
         _InitLinkFromInfo(plink, info);
         _veclinks.push_back(std::move(plink));
     }
+
+    // If the first (base) link in the body has a non-zero transform, we need to make sure we latch it.
+    _baseLinkInBodyTransform = _ResolveLinkInfo(linkInfos[0]).GetTransform();
+    _invBaseLinkInBodyTransform = _baseLinkInBodyTransform.inverse();
 
     _vLinkTransformPointers.clear();
     __hashKinematicsGeometryDynamics.resize(0);
@@ -5806,6 +5815,8 @@ void KinBody::Clone(InterfaceBaseConstPtr preference, int cloningoptions)
     __hashKinematicsGeometryDynamics = r->__hashKinematicsGeometryDynamics;
     _vTempJoints = r->_vTempJoints;
 
+    _baseLinkInBodyTransform = r->_baseLinkInBodyTransform;
+    _invBaseLinkInBodyTransform = r->_invBaseLinkInBodyTransform;
     _vLinkTransformPointers.clear(); _vLinkTransformPointers.reserve(r->_veclinks.size());
     _veclinks.clear(); _veclinks.reserve(r->_veclinks.size());
     for (const LinkPtr& origLinkPtr : r->_veclinks) {


### PR DESCRIPTION
If a kinbody is created via `InitFromKinBodyInfo`, and the base link in that body has a non-zero transform, then openrave will correctly track that offset.

However, if you then _clone_ that body, the offset is currently lost, resulting in surprising behaviour in clone envs. Similarly, if you init a kinbody from a set of link infos, it doesn't respect base link offset.

Fix cloning and `InitWithInitialLinks` to preserve/initialize the base link offset for consistency.

Tests: 
https://tiny.mujin.co.jp/hra7d
https://tiny.mujin.co.jp/lx3jg