### PR TITLE
py::extract before releasing gil

### DIFF
--- a/python/bindings/openravepy_planningutils.cpp
+++ b/python/bindings/openravepy_planningutils.cpp
@@ -93,11 +93,12 @@ object pyGetReverseTrajectory(PyTrajectoryBasePtr pytraj)
 void pyVerifyTrajectory(object pyparameters, PyTrajectoryBasePtr pytraj, dReal samplingstep, bool releasegil=true)
 {
     PlannerBase::PlannerParametersConstPtr parameters = openravepy::GetPlannerParametersConst(pyparameters);
+    TrajectoryBasePtr traj = openravepy::GetTrajectory(pytraj);
     openravepy::PythonThreadSaverPtr statesaver;
     if( releasegil ) {
         statesaver.reset(new openravepy::PythonThreadSaver());
     }
-    OpenRAVE::planningutils::VerifyTrajectory(parameters, openravepy::GetTrajectory(pytraj),samplingstep);
+    OpenRAVE::planningutils::VerifyTrajectory(parameters, traj, samplingstep);
 }
 
 // GIL is assumed locked

--- a/python/bindings/openravepy_planningutils.cpp
+++ b/python/bindings/openravepy_planningutils.cpp
@@ -92,11 +92,12 @@ object pyGetReverseTrajectory(PyTrajectoryBasePtr pytraj)
 
 void pyVerifyTrajectory(object pyparameters, PyTrajectoryBasePtr pytraj, dReal samplingstep, bool releasegil=true)
 {
+    PlannerBase::PlannerParametersConstPtr parameters = openravepy::GetPlannerParametersConst(pyparameters);
     openravepy::PythonThreadSaverPtr statesaver;
     if( releasegil ) {
         statesaver.reset(new openravepy::PythonThreadSaver());
     }
-    OpenRAVE::planningutils::VerifyTrajectory(openravepy::GetPlannerParametersConst(pyparameters), openravepy::GetTrajectory(pytraj),samplingstep);
+    OpenRAVE::planningutils::VerifyTrajectory(parameters, openravepy::GetTrajectory(pytraj),samplingstep);
 }
 
 // GIL is assumed locked


### PR DESCRIPTION
py::extract after releasing gil is illegal and it must be done before releasing gil.

@yoshikikanemoto @rolandjitsu @pico737 