### PR TITLE
Return py::none_ outside statesaver

### DIFF
--- a/python/bindings/openravepy_int.cpp
+++ b/python/bindings/openravepy_int.cpp
@@ -991,6 +991,7 @@ object PyInterfaceBase::SendCommand(const string& in, bool releasegil, bool lock
 {
     std::stringstream sin(in);
     std::stringstream sout;
+    bool successSendCommand;
     {
         openravepy::PythonThreadSaverPtr statesaver;
         openravepy::PyEnvironmentLockSaverPtr envsaver;
@@ -1008,9 +1009,10 @@ object PyInterfaceBase::SendCommand(const string& in, bool releasegil, bool lock
             }
         }
         sout << std::setprecision(std::numeric_limits<dReal>::digits10+1);     /// have to do this or otherwise precision gets lost
-        if( !_pbase->SendCommand(sout,sin) ) {
-            return py::none_();
-        }
+        successSendCommand = _pbase->SendCommand(sout,sin);
+    }
+    if( !successSendCommand ) {
+        return py::none_();
     }
     return py::to_object(sout.str());
 }


### PR DESCRIPTION
py::none_ calls inc_ref, which must be outside statesaver