### PR TITLE
Skip semantic analysis of source files to prevent mypy from crashing

### DIFF
--- a/python/bindings/typestubs/CMakeLists.txt
+++ b/python/bindings/typestubs/CMakeLists.txt
@@ -48,31 +48,31 @@ if (PYBIND11_STUBGEN)
         COMMAND ${CMAKE_COMMAND} -E echo "from ._openravepy_.misc import *" > ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/misc.pyi
         COMMAND ${CMAKE_COMMAND} -E echo "from ._openravepy_.openrave_ext import *" > ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/openravepy_ext.pyi
         COMMAND ${CMAKE_COMMAND} -E echo "from ._openravepy_.openrave_int import *" > ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/openravepy_int.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.misc
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.misc
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/misc.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/misc/__init__.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.openravepy_ext
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.openravepy_ext
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/openravepy_ext.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/openravepy_ext/__init__.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.convexdecomposition
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.convexdecomposition
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/databases/convexdecomposition.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/databases/convexdecomposition/__init__.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.grasping
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.grasping
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/databases/grasping.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/databases/grasping/__init__.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.inversekinematics
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.inversekinematics
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/databases/inversekinematics.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/databases/inversekinematics/__init__.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.inversereachability
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.inversereachability
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/databases/inversereachability.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/databases/inversereachability/__init__.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.kinematicreachability
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.kinematicreachability
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/databases/kinematicreachability.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/databases/kinematicreachability/__init__.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.linkstatistics
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.linkstatistics
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/databases/linkstatistics.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/databases/linkstatistics/__init__.pyi
-        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.visibilitymodel
+        COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.databases.visibilitymodel
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/databases/visibilitymodel.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/databases/visibilitymodel/__init__.pyi
-        # COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.interfaces.BaseManipulation
+        # COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.interfaces.BaseManipulation
         # COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/interfaces/BaseManipulation.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/interfaces/BaseManipulation/__init__.pyi
-        # COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.interfaces.Grasper
+        # COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.interfaces.Grasper
         # COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/interfaces/Grasper.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/interfaces/Grasper/__init__.pyi
-        # COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.interfaces.TaskManipulation
+        # COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.interfaces.TaskManipulation
         # COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/interfaces/TaskManipulation.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/interfaces/TaskManipulation/__init__.pyi
-        # COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.interfaces.visualfeedback
+        # COMMAND ${Python3_EXECUTABLE} -c [=[from mypy.stubgen import main\; main\(\)]=] --no-analysis -o ${CMAKE_CURRENT_BINARY_DIR}/python -m openravepy.interfaces.visualfeedback
         # COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy/interfaces/visualfeedback.pyi ${CMAKE_CURRENT_BINARY_DIR}/python/openravepy-stubs/_openravepy_/interfaces/visualfeedback/__init__.pyi
         DEPENDS ${OPENRAVEPY_INT_SO_FILE}
     )


### PR DESCRIPTION
This MR provides a workaround for mypy crashing while building https://github.com/rdiankov/openrave/pull/1539

Definition of the `--no-analysis` flag:

> Don’t perform semantic analysis of source files. This may generate worse stubs – in particular, some module, class, and function aliases may be represented as variables with the Any type. This is generally only useful if semantic analysis causes a critical mypy error.

https://mypy.readthedocs.io/en/stable/stubgen.html#cmdoption-stubgen-no-analysis