### PR TITLE
Fix builds under Boost 1.90.0 (Ubuntu 26.04)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,7 +265,7 @@ else()
   set(OPENRAVE_LIBRARY_SUFFIX "${OPENRAVE_SOVERSION}" CACHE STRING "Suffix to append to library names")
 endif()
 
-find_package(Boost REQUIRED COMPONENTS filesystem system thread iostreams)
+find_package(Boost REQUIRED COMPONENTS filesystem thread iostreams)
 set(OPENRAVE_BOOST_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})
 set(OPENRAVE_BOOST_LIB_DIRS ${Boost_LIBRARY_DIRS})
 
@@ -668,7 +668,7 @@ else()
 endif()
 set(CONVEXDECOMPOSITION_FOUND 1)
 
-if( Boost_FILESYSTEM_FOUND AND Boost_SYSTEM_FOUND )
+if( Boost_FILESYSTEM_FOUND )
   add_definitions(-DHAVE_BOOST_FILESYSTEM)
 endif()
 

--- a/src/libopenrave/libopenrave.cpp
+++ b/src/libopenrave/libopenrave.cpp
@@ -813,7 +813,7 @@ protected:
         boost::filesystem::path fullfilename;
         boost::filesystem::path filename(_filename);
 
-        if( filename.is_complete() ) {
+        if( filename.is_absolute() ) {
             fullfilename = filename;
         }
         else if( curdir.size() > 0 ) {
@@ -1003,9 +1003,6 @@ protected:
 
     void _CustomNormalizePath(boost::filesystem::path& p)
     {
-#ifndef BOOST_FILESYSTEM_NO_DEPRECATED
-        p.normalize();
-#else
         boost::filesystem::path result;
         for(boost::filesystem::path::iterator it=p.begin(); it!=p.end(); ++it)
         {
@@ -1033,7 +1030,6 @@ protected:
             }
         }
         p = result;
-#endif
     }
 
     bool _ValidateFilename(const boost::filesystem::path& filename, const boost::filesystem::path& curdir)


### PR DESCRIPTION
- Boost.System no longer exists as a standalone CMake package since 1.89 (https://www.boost.org/releases/1.89.0/):
  > - The stub compiled library has been removed; System has been header-only since release 1.69.
  > - This may affect `CMakeLists.txt` files containing `find_package(Boost COMPONENTS system ...)`. The easiest fix is to just remove `system` from the list of components as it's no longer required. If compatibility with Boost releases earlier than 1.69 is to be preserved, one can use `find_package(Boost COMPONENTS ... OPTIONAL_COMPONENTS system)`. 
- `boost::filesystem::is_complete` was replaced by `is_absolute` at least since 1.69, i.e. 2018 (https://www.boost.org/doc/libs/1_90_0/libs/filesystem/doc/v3.html)
- `boost::filesystem::path::normalize` was long deprecated and ceased to exist; the replacement code was already there, I have just activated the enclosing #if-branch (https://stackoverflow.com/a/1750710)