### PR TITLE
perf(fclrave): visit only changed bodies in Synchronize and EnsureBodies

### DIFF
--- a/plugins/fclrave/fclmanagercache.cpp
+++ b/plugins/fclrave/fclmanagercache.cpp
@@ -140,6 +140,7 @@ void FCLCollisionManagerInstance::InitBodyManager(KinBodyConstPtr pbody, bool bT
         bodyCache.Invalidate();
     }
     _nLastSyncRevision = 0; // every cache entry was just invalidated, so the next Synchronize has to revisit all bodies
+    _nLastEnsureBodiesRevision = 0; // likewise for the next EnsureBodies
     const EnvironmentBase& env = *pbody->GetEnv();
     int maxBodyIndex = env.GetMaxEnvironmentBodyIndex();
     EnsureVectorSize(_vecCachedBodies, maxBodyIndex + 1);
@@ -231,6 +232,7 @@ void FCLCollisionManagerInstance::InitEnvironment(const std::vector<int8_t>& exc
         bodyCache.Invalidate();
     }
     _nLastSyncRevision = 0; // every cache entry was just invalidated, so the next Synchronize has to revisit all bodies
+    _nLastEnsureBodiesRevision = 0; // likewise for the next EnsureBodies
 
     _vecExcludeBodyIndices = excludedEnvBodyIndices;
     pmanager->setup();
@@ -246,33 +248,46 @@ void FCLCollisionManagerInstance::EnsureBodies(const std::vector<KinBodyConstPtr
     // Clear our scratch buffer
     _tmpSortedBuffer.resize(0);
 
-    // We need to make sure we resize _vecCachedBodies to allow direct lookup by body index, which we can do the first time we encounter a non-null body.
-    bool ensuredVecCachedBodies = false;
+    // Visit only the bodies FCLSpace recorded as changed since this function last ran, instead of every
+    // body in the environment: a body can only need adding here if something changed it, and every path
+    // that fills its info marks it (InitKinBody in particular). vbodies is FCLSpace::GetEnvBodies(),
+    // which is indexed by environment body index.
+    // This cursor is separate from _nLastSyncRevision on purpose: Synchronize runs right after this from
+    // _GetEnvManager and has to see the same marks, so the two must not consume from one cursor.
+    const uint64_t currentSpaceRevision = _fclspace.GetCurrentRevision();
+    _fclspace.CollectBodyIndicesChangedAfter(_nLastEnsureBodiesRevision, _vecChangedBodyIndicesCache);
 
-    // For each tracked body, ensure that we have all necessary collision info
-    for (const KinBodyConstPtr& pbody : vbodies) {
+    // resize for direct lookup by body index. vbodies covers every index this loop can touch
+    EnsureVectorSize(_vecCachedBodies, vbodies.size());
+
+    // For each changed body, ensure that we have all necessary collision info
+    for (const int bodyIndex : _vecChangedBodyIndicesCache) {
+        if (bodyIndex < 1 || bodyIndex >= (int)vbodies.size()) {
+            // stale mark for an index the space no longer has a body at; nothing to add
+            continue;
+        }
+        const KinBodyConstPtr& pbody = vbodies[bodyIndex];
         // Null bodies can be ignored
         if (!pbody) {
             continue;
         }
         const KinBody& body = *pbody;
 
-        // If this is our first real body, use it to get the max body index from the env and resize our body cache
-        if (!ensuredVecCachedBodies) {
-            EnsureVectorSize(_vecCachedBodies, body.GetEnv()->GetMaxEnvironmentBodyIndex() + 1);
-            ensuredVecCachedBodies = true;
-        }
-
         // If this body index is excluded, skip it.
-        const int bodyIndex = body.GetEnvironmentBodyIndex();
-        if (bodyIndex < _vecExcludeBodyIndices.size() && _vecExcludeBodyIndices[bodyIndex]) {
+        if (bodyIndex < (int)_vecExcludeBodyIndices.size() && _vecExcludeBodyIndices[bodyIndex]) {
             continue;
         }
 
         // If our cache of this body is still valid, then we don't need to recompute.
-        const bool bIsValid = _vecCachedBodies.at(bodyIndex).IsValid();
-        if (bIsValid) {
-            continue;
+        KinBodyCache& existingCache = _vecCachedBodies.at(bodyIndex);
+        if (existingCache.IsValid()) {
+            if (existingCache.pwbody.lock() == pbody) {
+                // already cached; Synchronize picks up whatever changed on it
+                continue;
+            }
+            // the index was reused by a new body while the previously cached one is still alive. The mark
+            // is consumed now, so dropping the stale entry here is the only chance to add the new body
+            _UnregisterCachedCollisionObjects(existingCache);
         }
 
         // Calculate the collision objects for this body.
@@ -280,15 +295,15 @@ void FCLCollisionManagerInstance::EnsureBodies(const std::vector<KinBodyConstPtr
         // We still want to cache the _absence_ of collision data however, to avoid expensive recomputes on non-colliding bodies, so cache the returned data even if it's empty.
         const FCLSpace::FCLKinBodyInfoPtr& pinfo = _fclspace.GetInfo(body);
         if (!pinfo) {
-            // not initialized in this checker, and _AddBody and SetBodyData would both dereference it
+            // not initialized in this checker, and _AddBody and SetBodyData would both dereference it.
+            // consuming the mark is fine: every path that later fills the info records a new one
             RAVELOG_VERBOSE_FORMAT(
                 "env=%s, body %s is not initialized in this checker, ignoring for now", body.GetEnv()->GetNameId() % body.GetName());
             continue;
         }
         _AddBody(body, pinfo, _ensureBodiesCollisionObjectsCache, _linkEnableStatesBitmasks, false);
-        KinBodyCache& cache = _vecCachedBodies.at(bodyIndex);
-        cache.SetBodyData(pbody, pinfo, _linkEnableStatesBitmasks);
-        cache.vcolobjs.swap(_ensureBodiesCollisionObjectsCache);
+        existingCache.SetBodyData(pbody, pinfo, _linkEnableStatesBitmasks);
+        existingCache.vcolobjs.swap(_ensureBodiesCollisionObjectsCache);
     }
 
     if (_tmpSortedBuffer.size() > 0) {
@@ -300,6 +315,10 @@ void FCLCollisionManagerInstance::EnsureBodies(const std::vector<KinBodyConstPtr
 
     // Clear our cached collision body vector to ensure we don't prolong the lifetime of any collision objects
     _ensureBodiesCollisionObjectsCache.clear();
+
+    // only advance once the loop and the bulk register finished, for the same reason Synchronize advances
+    // its cursor last: a throw part way through must leave the unprocessed marks for the next call
+    _nLastEnsureBodiesRevision = currentSpaceRevision;
 }
 
 bool FCLCollisionManagerInstance::RemoveBody(const KinBody& body) {
@@ -489,7 +508,8 @@ void FCLCollisionManagerInstance::Synchronize() {
             // DestroyEnvironment leaves behind. The LinkInfos backing our collision objects are gone, so drop them.
             // a body manager has no other way back: it only revisits its attached bodies when
             // nAttachedBodiesUpdateStamp changes, and re-initializing the body in the space does not change it.
-            // an environment manager needs nothing here, EnsureBodies already re-adds the body on every call
+            // an environment manager needs nothing here: re-initializing the body in the space records a new
+            // mark (InitKinBody), which EnsureBodies' own cursor picks up and re-adds the body from
             if (!!ptrackingbody) {
                 _bRetryAttachedBodies = true;
             }

--- a/plugins/fclrave/fclmanagercache.cpp
+++ b/plugins/fclrave/fclmanagercache.cpp
@@ -155,7 +155,9 @@ void FCLCollisionManagerInstance::InitBodyManager(KinBodyConstPtr pbody, bool bT
         const KinBody& attachedBody = *pAttachedBody;
         const FCLSpace::FCLKinBodyInfoPtr& pinfo = _fclspace.GetInfo(attachedBody);
         if (!pinfo) {
-            // don't init something that isn't initialized in this checker.
+            // don't init something that isn't initialized in this checker. Come back on the next Synchronize,
+            // since nothing else revisits the attached bodies until nAttachedBodiesUpdateStamp changes
+            _bRetryAttachedBodies = true;
             RAVELOG_VERBOSE_FORMAT(
                 "body %s has attached body %s which is not initialized in this checker, ignoring for now", pbody->GetName() % attachedBody.GetName());
             continue;
@@ -481,6 +483,12 @@ void FCLCollisionManagerInstance::Synchronize() {
         if (!pnewinfo) {
             // the space no longer tracks this body even though it is still in the environment, which is what
             // DestroyEnvironment leaves behind. The LinkInfos backing our collision objects are gone, so drop them.
+            // a body manager has no other way back: it only revisits its attached bodies when
+            // nAttachedBodiesUpdateStamp changes, and re-initializing the body in the space does not change it.
+            // an environment manager needs nothing here, EnsureBodies already re-adds the body on every call
+            if (!!ptrackingbody) {
+                _bRetryAttachedBodies = true;
+            }
             RAVELOG_VERBOSE_FORMAT(
                 "env=%s, %u body %s is no longer tracked by the fcl space, dropping its cached collision objects",
                 body.GetEnv()->GetNameId() % _lastSyncTimeStamp % body.GetName());
@@ -715,12 +723,12 @@ void FCLCollisionManagerInstance::Synchronize() {
             cache.nAttachedBodiesUpdateStamp = kinBodyInfo.nAttachedBodiesUpdateStamp;
         }
     }
-    // only advance once every collected body was processed: the loop above can throw part way through
-    // (GetLinkBV and _AddBody both index with at(), and registering objects allocates), and advancing up
-    // front would drop the bodies after the throwing one from every future call
-    _nLastSyncRevision = currentSpaceRevision;
-
-    if (bAttachedBodiesChanged && !!ptrackingbody) {
+    if ((bAttachedBodiesChanged || _bRetryAttachedBodies) && !!ptrackingbody) {
+        // latch the retry for the whole block: cache.nAttachedBodiesUpdateStamp was already advanced in the
+        // loop above, so if _AddBody throws part way through, nothing else would bring the rest of the
+        // attached bodies back and they would stay out of the manager
+        _bRetryAttachedBodies = true;
+        bool bSkippedUninitializedAttachedBody = false;
         // since tracking have to update all the bodies
         std::vector<KinBodyPtr>& vecAttachedEnvBodies = _vecAttachedEnvBodiesCache;
         std::vector<int>& vecAttachedEnvBodyIndices = _vecAttachedEnvBodyIndicesCache;
@@ -747,7 +755,9 @@ void FCLCollisionManagerInstance::Synchronize() {
 
             const FCLSpace::FCLKinBodyInfoPtr& pInfo = _fclspace.GetInfo(attached);
             if (!pInfo) {
-                // not initialized in this checker, same as the skip in InitBodyManager
+                // not initialized in this checker, same as the skip in InitBodyManager. Come back on the next
+                // Synchronize, since nAttachedBodiesUpdateStamp was already consumed and will not change again
+                bSkippedUninitializedAttachedBody = true;
                 RAVELOG_VERBOSE_FORMAT(
                     "env=%s, attached body %s is not initialized in this checker, ignoring for now",
                     attached.GetEnv()->GetNameId() % attached.GetName());
@@ -792,8 +802,10 @@ void FCLCollisionManagerInstance::Synchronize() {
                 _UnregisterCachedCollisionObjects(cache);
             }
         }
+        // the block finished, so keep retrying only if it skipped an attached body the space had not
+        // initialized yet
+        _bRetryAttachedBodies = bSkippedUninitializedAttachedBody;
     }
-
     if (_tmpSortedBuffer.size() > 0) {
 #ifdef FCLRAVE_DEBUG_COLLISION_OBJECTS
         SaveCollisionObjectDebugInfos();
@@ -803,6 +815,10 @@ void FCLCollisionManagerInstance::Synchronize() {
     if (bcallsetup) {
         pmanager->setup();
     }
+    // only advance once everything above succeeded: the loops index with at(), and _AddBody, registerObjects
+    // and setup all allocate, so any of them can throw. Advancing earlier would drop every body after the
+    // throwing one from all future calls, leaving their collision objects out of the manager for good
+    _nLastSyncRevision = currentSpaceRevision;
 }
 
 bool FCLCollisionManagerInstance::_AddBody(

--- a/plugins/fclrave/fclmanagercache.cpp
+++ b/plugins/fclrave/fclmanagercache.cpp
@@ -418,12 +418,16 @@ void FCLCollisionManagerInstance::Synchronize() {
                                         pmanager->registerObject(pColObjRaw);
 #endif
                                         bcallsetup = true;
+                                        trackingCache.vcolobjs.at(ilink) = pcolobj;
                                     } else {
                                         if (!!trackingCache.vcolobjs.at(ilink)) {
                                             pmanager->unregisterObject(trackingCache.vcolobjs.at(ilink).get());
                                         }
+                                        // a non-null vcolobjs entry means the object is registered in pmanager,
+                                        // so an object this branch did not register must not be stored here,
+                                        // otherwise the next unregister of this entry has nothing to remove
+                                        trackingCache.vcolobjs.at(ilink).reset();
                                     }
-                                    trackingCache.vcolobjs.at(ilink) = pcolobj;
                                 } else {
                                     if (!bIsActiveLinkEnabled && !!trackingCache.vcolobjs.at(ilink)) {
                                         // RAVELOG_VERBOSE_FORMAT("env=%d %x resetting cached colobj %s %d",

--- a/plugins/fclrave/fclmanagercache.cpp
+++ b/plugins/fclrave/fclmanagercache.cpp
@@ -139,6 +139,7 @@ void FCLCollisionManagerInstance::InitBodyManager(KinBodyConstPtr pbody, bool bT
     for (KinBodyCache& bodyCache : _vecCachedBodies) {
         bodyCache.Invalidate();
     }
+    _nLastSyncRevision = 0; // every cache entry was just invalidated, so the next Synchronize has to revisit all bodies
     const EnvironmentBase& env = *pbody->GetEnv();
     int maxBodyIndex = env.GetMaxEnvironmentBodyIndex();
     EnsureVectorSize(_vecCachedBodies, maxBodyIndex + 1);
@@ -227,6 +228,7 @@ void FCLCollisionManagerInstance::InitEnvironment(const std::vector<int8_t>& exc
     for (KinBodyCache& bodyCache : _vecCachedBodies) {
         bodyCache.Invalidate();
     }
+    _nLastSyncRevision = 0; // every cache entry was just invalidated, so the next Synchronize has to revisit all bodies
 
     _vecExcludeBodyIndices = excludedEnvBodyIndices;
     pmanager->setup();
@@ -275,6 +277,12 @@ void FCLCollisionManagerInstance::EnsureBodies(const std::vector<KinBodyConstPtr
         // Note that if there are no collision volumes for an entity, _AddBody will return false.
         // We still want to cache the _absence_ of collision data however, to avoid expensive recomputes on non-colliding bodies, so cache the returned data even if it's empty.
         const FCLSpace::FCLKinBodyInfoPtr& pinfo = _fclspace.GetInfo(body);
+        if (!pinfo) {
+            // not initialized in this checker, and _AddBody and SetBodyData would both dereference it
+            RAVELOG_VERBOSE_FORMAT(
+                "env=%s, body %s is not initialized in this checker, ignoring for now", body.GetEnv()->GetNameId() % body.GetName());
+            continue;
+        }
         _AddBody(body, pinfo, _ensureBodiesCollisionObjectsCache, _linkEnableStatesBitmasks, false);
         KinBodyCache& cache = _vecCachedBodies.at(bodyIndex);
         cache.SetBodyData(pbody, pinfo, _linkEnableStatesBitmasks);
@@ -299,13 +307,7 @@ bool FCLCollisionManagerInstance::RemoveBody(const KinBody& body) {
     if ((int)_vecCachedBodies.size() > bodyIndex && bodyIndex > 0) {
         KinBodyCache& cache = _vecCachedBodies.at(bodyIndex);
         if (cache.IsValid()) {
-            for (CollisionObjectPtr& col : cache.vcolobjs) {
-                if (!!col.get()) {
-                    pmanager->unregisterObject(col.get());
-                }
-            }
-            cache.vcolobjs.resize(0);
-            cache.Invalidate();
+            _UnregisterCachedCollisionObjects(cache);
 
             return true;
         } else {
@@ -357,10 +359,13 @@ void FCLCollisionManagerInstance::Synchronize() {
         } else {
             FCLSpace::FCLKinBodyInfoPtr pinfo = trackingCache.pwinfo.lock();
             const FCLSpace::FCLKinBodyInfoPtr& pnewinfo = _fclspace.GetInfo(trackingbody); // necessary in case pinfos were swapped!
+            // A null pnewinfo means the space stopped tracking the body while it is still in the environment,
+            // which is what DestroyEnvironment leaves behind. There is no active-DOF state left to refresh;
+            // the loop below drops the cache entry.
             // Also refresh when the tracked FCLKinBodyInfo object itself was swapped (e.g. a geometry-group
             // switch via SetBodyGeometryGroup): each per-group info has an independent nActiveDOFUpdateStamp
             // counter, so equal stamps across two different infos must not be read as "no active-DOF change".
-            if (trackingCache.nActiveDOFUpdateStamp != pnewinfo->nActiveDOFUpdateStamp || pinfo != pnewinfo) {
+            if (!!pnewinfo && (trackingCache.nActiveDOFUpdateStamp != pnewinfo->nActiveDOFUpdateStamp || pinfo != pnewinfo)) {
                 if (trackingbody.IsRobot()) {
                     RobotBaseConstPtr probot = OpenRAVE::RaveInterfaceConstCast<RobotBase>(ptrackingbody);
                     if (!!probot) {
@@ -438,20 +443,26 @@ void FCLCollisionManagerInstance::Synchronize() {
 
     FCLSpace::FCLKinBodyInfoPtr pinfo;
     KinBodyConstPtr pbody;
-    for (int bodyIndexCached = 1; bodyIndexCached < (int)_vecCachedBodies.size(); ++bodyIndexCached) {
+    // Visit only the bodies FCLSpace recorded as changed since this manager last synchronized, rather
+    // than every cached body. The first call after construction or after Init*Manager passes 0, which
+    // returns every index FCLSpace has ever recorded, so nothing is missed on a cold cache.
+    const uint64_t currentSpaceRevision = _fclspace.GetCurrentRevision();
+    _fclspace.CollectBodyIndicesChangedAfter(_nLastSyncRevision, _vecChangedBodyIndicesCache);
+    for (const int bodyIndexCached : _vecChangedBodyIndicesCache) {
+        if (bodyIndexCached < 1 || bodyIndexCached >= (int)_vecCachedBodies.size()) {
+            // dropping the mark for an out-of-range index is safe: growing _vecCachedBodies only appends
+            // invalid entries with no registered collision objects, and every place that fills a slot
+            // (EnsureBodies, InitBodyManager, the attached-bodies tail below) reads the stamps at that
+            // moment, so there is nothing left for this loop to catch up on
+            continue;
+        }
         KinBodyCache& cache = _vecCachedBodies[bodyIndexCached];
         pbody = cache.pwbody.lock();
         if (!pbody || pbody->GetEnvironmentBodyIndex() == 0) {
             // should happen when parts are removed
             // RAVELOG_VERBOSE_FORMAT("env=%d, %u manager contains invalid body %s, removing for now", _fclspace.GetEnvironmentId()%_lastSyncTimeStamp%(!pbody ?
             // std::string() : pbody->GetName()));
-            FOREACH(itcolobj, cache.vcolobjs) {
-                if (!!itcolobj->get()) {
-                    pmanager->unregisterObject(itcolobj->get());
-                }
-            }
-            cache.vcolobjs.resize(0);
-            cache.Invalidate();
+            _UnregisterCachedCollisionObjects(cache);
             continue;
         }
 
@@ -467,6 +478,15 @@ void FCLCollisionManagerInstance::Synchronize() {
 
         pinfo = cache.pwinfo.lock();
         const FCLSpace::FCLKinBodyInfoPtr& pnewinfo = _fclspace.GetInfo(body); // necessary in case pinfos were swapped!
+        if (!pnewinfo) {
+            // the space no longer tracks this body even though it is still in the environment, which is what
+            // DestroyEnvironment leaves behind. The LinkInfos backing our collision objects are gone, so drop them.
+            RAVELOG_VERBOSE_FORMAT(
+                "env=%s, %u body %s is no longer tracked by the fcl space, dropping its cached collision objects",
+                body.GetEnv()->GetNameId() % _lastSyncTimeStamp % body.GetName());
+            _UnregisterCachedCollisionObjects(cache);
+            continue;
+        }
         if (pinfo != pnewinfo) {
             // everything changed!
             RAVELOG_VERBOSE_FORMAT("%u body %s entire FCLKinBodyInfo changed", _lastSyncTimeStamp % pbody->GetName());
@@ -695,6 +715,10 @@ void FCLCollisionManagerInstance::Synchronize() {
             cache.nAttachedBodiesUpdateStamp = kinBodyInfo.nAttachedBodiesUpdateStamp;
         }
     }
+    // only advance once every collected body was processed: the loop above can throw part way through
+    // (GetLinkBV and _AddBody both index with at(), and registering objects allocates), and advancing up
+    // front would drop the bodies after the throwing one from every future call
+    _nLastSyncRevision = currentSpaceRevision;
 
     if (bAttachedBodiesChanged && !!ptrackingbody) {
         // since tracking have to update all the bodies
@@ -722,6 +746,13 @@ void FCLCollisionManagerInstance::Synchronize() {
             }
 
             const FCLSpace::FCLKinBodyInfoPtr& pInfo = _fclspace.GetInfo(attached);
+            if (!pInfo) {
+                // not initialized in this checker, same as the skip in InitBodyManager
+                RAVELOG_VERBOSE_FORMAT(
+                    "env=%s, attached body %s is not initialized in this checker, ignoring for now",
+                    attached.GetEnv()->GetNameId() % attached.GetName());
+                continue;
+            }
             if (_AddBody(attached, pInfo, cache.vcolobjs, _linkEnableStatesBitmasks, _bTrackActiveDOF && (pattached == ptrackingbody))) {
                 bcallsetup = true;
             }
@@ -758,13 +789,7 @@ void FCLCollisionManagerInstance::Synchronize() {
                     RAVELOG_VERBOSE_FORMAT("env=%s, %x, %u removing old cache %d", pBody->GetEnv()->GetNameId() % this % _lastSyncTimeStamp % cachedBodyIndex);
                 }
                 // not in attached bodies so should remove
-                FOREACH(itcol, cache.vcolobjs) {
-                    if (!!itcol->get()) {
-                        pmanager->unregisterObject(itcol->get());
-                    }
-                }
-                cache.vcolobjs.resize(0);
-                cache.Invalidate();
+                _UnregisterCachedCollisionObjects(cache);
             }
         }
     }
@@ -818,6 +843,16 @@ bool FCLCollisionManagerInstance::_AddBody(
         }
     }
     return bsetUpdateStamp;
+}
+
+void FCLCollisionManagerInstance::_UnregisterCachedCollisionObjects(KinBodyCache& cache) {
+    FOREACH(itcolobj, cache.vcolobjs) {
+        if (!!itcolobj->get()) {
+            pmanager->unregisterObject(itcolobj->get());
+        }
+    }
+    cache.vcolobjs.resize(0); // has to happen before Invalidate, which warns on a non-empty vcolobjs
+    cache.Invalidate();
 }
 
 void FCLCollisionManagerInstance::_UpdateActiveLinks(const RobotBase& robot) {

--- a/plugins/fclrave/fclmanagercache.h
+++ b/plugins/fclrave/fclmanagercache.h
@@ -206,6 +206,7 @@ private:
     uint32_t _lastSyncTimeStamp; ///< timestamp when last synchronized
     uint64_t _nLastSyncRevision = 0; ///< FCLSpace revision at the last Synchronize. 0 means the next Synchronize revisits every body
     std::vector<int> _vecChangedBodyIndicesCache; ///< cache, environment body indices changed since _nLastSyncRevision
+    bool _bRetryAttachedBodies = false; ///< true when Synchronize skipped an attached body that FCLSpace had not initialized yet. Nothing else brings it back, since the attached bodies are only revisited when nAttachedBodiesUpdateStamp changes again
 
     std::vector<int8_t> _vecExcludeBodyIndices; ///< any bodies that should not be considered inside the manager, used with environment mode. includes environment body index of of bodies who should be excluded.
     CollisionGroup _tmpSortedBuffer; ///< cache, sorted so that we can efficiently search

--- a/plugins/fclrave/fclmanagercache.h
+++ b/plugins/fclrave/fclmanagercache.h
@@ -168,6 +168,9 @@ private:
     /// should not add anything to _vecCachedBodies! insert to _tmpSortedBuffer
     bool _AddBody(const KinBody& body, const FCLSpace::FCLKinBodyInfoPtr& pinfo, std::vector<CollisionObjectPtr>& vcolobjs, std::vector<uint64_t>& linkEnableStatesBitmasks, bool bTrackActiveDOF);
 
+    /// \brief unregisters the collision objects this manager cached for a body and invalidates the cache entry
+    void _UnregisterCachedCollisionObjects(KinBodyCache& cache);
+
     void _UpdateActiveLinks(const RobotBase& robot);
 
 //    void CheckCount()
@@ -201,6 +204,8 @@ private:
     BroadPhaseCollisionManagerPtr pmanager;
     std::vector<KinBodyCache> _vecCachedBodies; ///< vector of KinBodyCache(weak body, updatestamp)) where index is KinBody::GetEnvironmentBodyIndex. Index 0 has invalid entry because valid env id starts from 1.
     uint32_t _lastSyncTimeStamp; ///< timestamp when last synchronized
+    uint64_t _nLastSyncRevision = 0; ///< FCLSpace revision at the last Synchronize. 0 means the next Synchronize revisits every body
+    std::vector<int> _vecChangedBodyIndicesCache; ///< cache, environment body indices changed since _nLastSyncRevision
 
     std::vector<int8_t> _vecExcludeBodyIndices; ///< any bodies that should not be considered inside the manager, used with environment mode. includes environment body index of of bodies who should be excluded.
     CollisionGroup _tmpSortedBuffer; ///< cache, sorted so that we can efficiently search

--- a/plugins/fclrave/fclmanagercache.h
+++ b/plugins/fclrave/fclmanagercache.h
@@ -205,6 +205,7 @@ private:
     std::vector<KinBodyCache> _vecCachedBodies; ///< vector of KinBodyCache(weak body, updatestamp)) where index is KinBody::GetEnvironmentBodyIndex. Index 0 has invalid entry because valid env id starts from 1.
     uint32_t _lastSyncTimeStamp; ///< timestamp when last synchronized
     uint64_t _nLastSyncRevision = 0; ///< FCLSpace revision at the last Synchronize. 0 means the next Synchronize revisits every body
+    uint64_t _nLastEnsureBodiesRevision = 0; ///< FCLSpace revision at the last EnsureBodies. Separate from _nLastSyncRevision because both run back to back on the same marks
     std::vector<int> _vecChangedBodyIndicesCache; ///< cache, environment body indices changed since _nLastSyncRevision
     bool _bRetryAttachedBodies = false; ///< true when Synchronize skipped an attached body that FCLSpace had not initialized yet. Nothing else brings it back, since the attached bodies are only revisited when nAttachedBodiesUpdateStamp changes again
 

--- a/plugins/fclrave/fclspace.cpp
+++ b/plugins/fclrave/fclspace.cpp
@@ -471,19 +471,46 @@ void FCLSpace::_MarkBodyChanged(int envBodyIndex)
     }
     EnsureVectorSize(_vecBodyRevisions, envBodyIndex + 1);
     uint64_t& bodyRevision = _vecBodyRevisions.at(envBodyIndex);
-    if( bodyRevision > 0 ) {
-        _mapChangedBodyIndices.erase(bodyRevision); // keep exactly one entry per body, at its latest revision
+    if( bodyRevision == 0 ) {
+        ++_numCurrentChangedBodyEntries; // first time this body is recorded
     }
     bodyRevision = ++_nCurrentRevision;
-    // the new revision is always the largest, so the entry always belongs at the end
-    _mapChangedBodyIndices.emplace_hint(_mapChangedBodyIndices.end(), bodyRevision, envBodyIndex);
+    // revisions only increase, so appending keeps _vecChangedBodyIndices sorted. The body's previous
+    // entry is left behind and skipped on read, which is cheaper than erasing from the middle.
+    _vecChangedBodyIndices.emplace_back(bodyRevision, envBodyIndex);
+
+    if( _vecChangedBodyIndices.size() > 2 * _numCurrentChangedBodyEntries + 16 ) {
+        _CompactChangedBodyIndices();
+    }
+}
+
+void FCLSpace::_CompactChangedBodyIndices()
+{
+    // drop the superseded entries, keeping only each body's latest. Scanning in order preserves the
+    // sort, and dropping a superseded entry is safe because the entry that replaced it has a higher
+    // revision, so any cursor that would have seen the old one also sees the new one.
+    size_t writeIndex = 0;
+    for (size_t readIndex = 0; readIndex < _vecChangedBodyIndices.size(); ++readIndex) {
+        const std::pair<uint64_t, int>& entry = _vecChangedBodyIndices[readIndex];
+        if( _IsCurrentChangedBodyEntry(entry) ) {
+            _vecChangedBodyIndices[writeIndex++] = entry;
+        }
+    }
+    _vecChangedBodyIndices.resize(writeIndex);
 }
 
 void FCLSpace::CollectBodyIndicesChangedAfter(uint64_t sinceRevision, std::vector<int>& envBodyIndicesOut) const
 {
     envBodyIndicesOut.resize(0);
-    for (std::map<uint64_t, int>::const_iterator it = _mapChangedBodyIndices.upper_bound(sinceRevision); it != _mapChangedBodyIndices.end(); ++it) {
-        envBodyIndicesOut.push_back(it->second);
+    const std::vector<std::pair<uint64_t, int> >::const_iterator itBegin = std::upper_bound(
+        _vecChangedBodyIndices.begin(), _vecChangedBodyIndices.end(), sinceRevision,
+        [](uint64_t revision, const std::pair<uint64_t, int>& entry) {
+        return revision < entry.first;
+    });
+    for (std::vector<std::pair<uint64_t, int> >::const_iterator it = itBegin; it != _vecChangedBodyIndices.end(); ++it) {
+        if( _IsCurrentChangedBodyEntry(*it) ) {
+            envBodyIndicesOut.push_back(it->second);
+        }
     }
 }
 

--- a/plugins/fclrave/fclspace.cpp
+++ b/plugins/fclrave/fclspace.cpp
@@ -21,6 +21,9 @@ void FCLSpace::FCLKinBodyInfo::Reset()
         (*itlink)->Reset();
     }
     vlinks.resize(0);
+    // _activeDOFsCallback and _bodyAttachedCallback stay registered here, so clear the cached index to stop
+    // them marking whichever body now holds it. InitKinBody re-fills it right after calling Reset
+    nEnvBodyIndex = 0;
     _geometrycallback.reset();
     _geometrygroupcallback.reset();
     _linkenablecallback.reset();
@@ -57,12 +60,17 @@ void FCLSpace::DestroyEnvironment()
             continue;
         }
         // managers outlive DestroyEnvironment and still hold collision objects from these infos, so mark
-        // before resetting to force them to revisit every body. The position in _vecInitializedBodies is
-        // the environment body index the managers cached this body under.
+        // before resetting to force them to revisit every body. The position in _vecInitializedBodies is the
+        // environment body index the body was initialized under, which is also the index the managers cached
+        // it under and the index it still has: Prop_BodyRemoved runs RemoveUserData before the environment
+        // unassigns the index, so a body whose index changed is no longer in _vecInitializedBodies at all.
+        // Index both the mark and the info off that position so the two cannot drift apart.
         _MarkBodyChanged(envBodyIndex);
-        FCLKinBodyInfoPtr& pinfo = GetInfo(*pbody);
-        if( !!pinfo ) {
-            pinfo->Reset();
+        if (envBodyIndex < (int)_currentpinfo.size()) {
+            FCLKinBodyInfoPtr& pinfo = _currentpinfo.at(envBodyIndex);
+            if( !!pinfo ) {
+                pinfo->Reset();
+            }
         }
     }
     // even after DestroyEnvironment is called, users of this class still try to access _currentpinfo
@@ -193,13 +201,15 @@ FCLSpace::FCLKinBodyInfoPtr FCLSpace::InitKinBody(KinBodyConstPtr pbody, FCLKinB
     _MarkBodyChanged(pbody->GetEnvironmentBodyIndex());
     pinfo->Reset();
     pinfo->_pbody = boost::const_pointer_cast<KinBody>(pbody);
+    // restore the index Reset cleared before ReloadKinBodyLinks can throw, otherwise the callbacks that
+    // survive Reset would keep marking index 0 and managers would stop seeing this body change
+    pinfo->nEnvBodyIndex = pbody->GetEnvironmentBodyIndex();
     // make sure that synchronization do occur !
     pinfo->nLastStamp = pbody->GetUpdateStamp() - 1;
     pinfo->nLastLinkReloadStamp = pbody->GetUpdateStamp() - 1;
 
     ReloadKinBodyLinks(pbody, pinfo);
 
-    pinfo->nEnvBodyIndex = pbody->GetEnvironmentBodyIndex();
     pinfo->_geometrycallback = pbody->RegisterChangeCallback(KinBody::Prop_LinkGeometry, boost::bind(&FCLSpace::_ResetCurrentGeometryCallback,boost::bind(&OpenRAVE::utils::sptr_from<FCLSpace>, weak_space()),boost::weak_ptr<FCLKinBodyInfo>(pinfo)));
     pinfo->_geometrygroupcallback = pbody->RegisterChangeCallback(KinBody::Prop_LinkGeometryGroup, boost::bind(&FCLSpace::_ResetGeometryGroupsCallback,boost::bind(&OpenRAVE::utils::sptr_from<FCLSpace>, weak_space()),boost::weak_ptr<FCLKinBodyInfo>(pinfo)));
     pinfo->_linkenablecallback = pbody->RegisterChangeCallback(KinBody::Prop_LinkEnable, boost::bind(&FCLSpace::_ResetLinkEnableCallback, boost::bind(&OpenRAVE::utils::sptr_from<FCLSpace>, weak_space()), boost::weak_ptr<FCLKinBodyInfo>(pinfo)));
@@ -518,25 +528,37 @@ void FCLSpace::RemoveUserData(KinBodyConstPtr pbody) {
     if( !!pbody ) {
         RAVELOG_VERBOSE(str(boost::format("FCL User data removed from env %d (userdatakey %s) : %s") % _penv->GetId() % _userdatakey % pbody->GetName()));
         const int envId = pbody->GetEnvironmentBodyIndex();
-        _MarkBodyChanged(envId); // consumers must drop their cached collision objects for this body
-        if (envId < (int) _vecInitializedBodies.size()) {
-            _vecInitializedBodies.at(envId).reset();
-        }
-        FCLKinBodyInfoPtr& pinfo = GetInfo(*pbody);
-        if( !!pinfo ) {
-            pinfo->Reset();
-        }
-
         if( envId == 0 ) {
             RAVELOG_WARN_FORMAT("env=%s, body '%s' has bodyIndex=0, so not adding to the environment!", _penv->GetNameId()%pbody->GetName());
         }
-
-        if (envId < (int) _currentpinfo.size()) {
-            _currentpinfo.at(envId).reset();
-            //RAVELOG_INFO_FORMAT("erased %d but didn't pop back, size is %d", envId%_currentpinfo.size());
+        // everything this body left behind is stored under the index it was initialized with, so when the body
+        // no longer has an index, find that one and tear down there. index 0 holds no body, so nothing to do
+        int initializedBodyIndex = envId;
+        if( initializedBodyIndex <= 0 ) {
+            for (int bodyIndex = 1; bodyIndex < (int)_vecInitializedBodies.size(); ++bodyIndex) {
+                if (_vecInitializedBodies[bodyIndex] == pbody) {
+                    initializedBodyIndex = bodyIndex;
+                    break;
+                }
+            }
         }
-        if (envId < (int) _cachedpinfo.size()) {
-            _cachedpinfo.at(envId).clear();
+        if( initializedBodyIndex <= 0 ) {
+            return;
+        }
+        _MarkBodyChanged(initializedBodyIndex); // consumers must drop their cached collision objects for this body
+        if (initializedBodyIndex < (int) _vecInitializedBodies.size()) {
+            _vecInitializedBodies.at(initializedBodyIndex).reset();
+        }
+        if (initializedBodyIndex < (int) _currentpinfo.size()) {
+            FCLKinBodyInfoPtr& pinfo = _currentpinfo.at(initializedBodyIndex);
+            if( !!pinfo ) {
+                pinfo->Reset();
+            }
+            pinfo.reset();
+            //RAVELOG_INFO_FORMAT("erased %d but didn't pop back, size is %d", initializedBodyIndex%_currentpinfo.size());
+        }
+        if (initializedBodyIndex < (int) _cachedpinfo.size()) {
+            _cachedpinfo.at(initializedBodyIndex).clear();
         }
     }
 }
@@ -731,10 +753,14 @@ void FCLSpace::_Synchronize(FCLKinBodyInfo& info, const KinBody& body)
 {
     //KinBodyPtr pbody = info.GetBody();
     if( info.nLastStamp != body.GetUpdateStamp()) {
-        info.nLastStamp = body.GetUpdateStamp();
         // the collision objects of this info are about to move, so any manager caching them has to revisit it.
+        // mark before mutating, like every other mark site.
         // the body is right here, so read the index off it rather than off info.nEnvBodyIndex
         _MarkBodyChanged(body.GetEnvironmentBodyIndex());
+        // advance the stamp before the check below, so a body with a stale vlinks throws once rather than on
+        // every call: Synchronize() has no per-body try/catch, so a repeating throw would stop every body
+        // after this one in _vecInitializedBodies from ever synchronizing again
+        info.nLastStamp = body.GetUpdateStamp();
         if( body.GetLinks().size() != info.vlinks.size() ) {
             throw OpenRAVE::OpenRAVEException(str(boost::format("env=%s, the current number of links in body '%s' are %d, and are not the same as the number cached links %d")%_penv->GetNameId()%body.GetName()%body.GetLinks().size()%info.vlinks.size()), OpenRAVE::ORE_InvalidState);
         }

--- a/plugins/fclrave/fclspace.cpp
+++ b/plugins/fclrave/fclspace.cpp
@@ -51,10 +51,15 @@ FCLSpace::FCLSpace(EnvironmentBasePtr penv, const std::string& userdatakey)
 void FCLSpace::DestroyEnvironment()
 {
     RAVELOG_VERBOSE_FORMAT("destroying fcl collision environment (env %d) (userdatakey %s)", _penv->GetId()%_userdatakey);
-    for (KinBodyConstPtr pbody : _vecInitializedBodies) {
+    for (int envBodyIndex = 0; envBodyIndex < (int)_vecInitializedBodies.size(); ++envBodyIndex) {
+        const KinBodyConstPtr& pbody = _vecInitializedBodies[envBodyIndex];
         if (!pbody) {
             continue;
         }
+        // managers outlive DestroyEnvironment and still hold collision objects from these infos, so mark
+        // before resetting to force them to revisit every body. The position in _vecInitializedBodies is
+        // the environment body index the managers cached this body under.
+        _MarkBodyChanged(envBodyIndex);
         FCLKinBodyInfoPtr& pinfo = GetInfo(*pbody);
         if( !!pinfo ) {
             pinfo->Reset();
@@ -183,6 +188,9 @@ FCLSpace::FCLKinBodyInfoPtr FCLSpace::InitKinBody(KinBodyConstPtr pbody, FCLKinB
     }
 
     RAVELOG_VERBOSE_FORMAT("env=%s, self=%d, init body %s (%d)", _penv->GetNameId()%_bIsSelfCollisionChecker%pbody->GetName()%pbody->GetEnvironmentBodyIndex());
+    // mark before mutating, like every other mark site: ReloadKinBodyLinks below can throw and would
+    // otherwise leave the info gutted with no revision recorded for it
+    _MarkBodyChanged(pbody->GetEnvironmentBodyIndex());
     pinfo->Reset();
     pinfo->_pbody = boost::const_pointer_cast<KinBody>(pbody);
     // make sure that synchronization do occur !
@@ -191,6 +199,7 @@ FCLSpace::FCLKinBodyInfoPtr FCLSpace::InitKinBody(KinBodyConstPtr pbody, FCLKinB
 
     ReloadKinBodyLinks(pbody, pinfo);
 
+    pinfo->nEnvBodyIndex = pbody->GetEnvironmentBodyIndex();
     pinfo->_geometrycallback = pbody->RegisterChangeCallback(KinBody::Prop_LinkGeometry, boost::bind(&FCLSpace::_ResetCurrentGeometryCallback,boost::bind(&OpenRAVE::utils::sptr_from<FCLSpace>, weak_space()),boost::weak_ptr<FCLKinBodyInfo>(pinfo)));
     pinfo->_geometrygroupcallback = pbody->RegisterChangeCallback(KinBody::Prop_LinkGeometryGroup, boost::bind(&FCLSpace::_ResetGeometryGroupsCallback,boost::bind(&OpenRAVE::utils::sptr_from<FCLSpace>, weak_space()),boost::weak_ptr<FCLKinBodyInfo>(pinfo)));
     pinfo->_linkenablecallback = pbody->RegisterChangeCallback(KinBody::Prop_LinkEnable, boost::bind(&FCLSpace::_ResetLinkEnableCallback, boost::bind(&OpenRAVE::utils::sptr_from<FCLSpace>, weak_space()), boost::weak_ptr<FCLKinBodyInfo>(pinfo)));
@@ -259,13 +268,13 @@ bool FCLSpace::SetBodyGeometryGroup(KinBodyConstPtr pbody, const std::string& gr
         return true;
     }
 
-    poldinfo->nGeometryUpdateStamp += 1;
-
     const int maxBodyIndex = _penv->GetMaxEnvironmentBodyIndex();
     EnsureVectorSize(_cachedpinfo, maxBodyIndex + 1);
 
     const int bodyIndex = body.GetEnvironmentBodyIndex();
     OPENRAVE_ASSERT_OP_FORMAT(bodyIndex, !=, 0, "env=%s, body %s", _penv->GetNameId()%body.GetName(), OpenRAVE::ORE_InvalidState);
+    _MarkBodyChanged(bodyIndex); // mark before mutating, so a throw below still leaves the body marked
+    poldinfo->nGeometryUpdateStamp += 1;
     std::map< std::string, FCLKinBodyInfoPtr >& cache = _cachedpinfo.at(bodyIndex);
     cache[poldinfo->_geometrygroup] = poldinfo;
 
@@ -281,6 +290,7 @@ bool FCLSpace::SetBodyGeometryGroup(KinBodyConstPtr pbody, const std::string& gr
         // Set the current info to use the FCLKinBodyInfoPtr associated to groupname
         EnsureVectorSize(_currentpinfo, maxBodyIndex + 1);
         _currentpinfo.at(bodyIndex) = pinfo;
+        _MarkBodyChanged(bodyIndex); // swapping pinfo does not go through any change callback
 
         // Revoke the information inside the cache so that a potentially outdated object does not survive
         cache.erase(groupname);
@@ -354,7 +364,15 @@ std::string const& FCLSpace::GetBVHRepresentation() const {
 
 void FCLSpace::Synchronize()
 {
-    // We synchronize only the initialized bodies, which differs from oderave
+    // We synchronize only the initialized bodies, which differs from oderave.
+    //
+    // This stays a full scan on purpose. Not every pose change reaches a change callback: several places
+    // bump the body update stamp by writing it directly, without going through
+    // _PostprocessChangedParameters (KinBody::Link::SetTransform and KinBody::IncrementUpdateStamp among
+    // them). Comparing the update stamp here is the only thing that catches those, and it is just an
+    // integer compare per body.
+    // _Synchronize records a revision for the bodies it actually refreshes, which is what lets the
+    // collision managers skip the far more expensive walk over their own caches.
     for (const KinBodyConstPtr& pbody : _vecInitializedBodies) {
         if (!pbody) {
             continue;
@@ -446,10 +464,34 @@ const FCLSpace::FCLKinBodyInfoPtr& FCLSpace::GetInfo(const KinBody &body) const
     return _currentpinfo.at(0);
 }
 
+void FCLSpace::_MarkBodyChanged(int envBodyIndex)
+{
+    if( envBodyIndex <= 0 ) {
+        return;
+    }
+    EnsureVectorSize(_vecBodyRevisions, envBodyIndex + 1);
+    uint64_t& bodyRevision = _vecBodyRevisions.at(envBodyIndex);
+    if( bodyRevision > 0 ) {
+        _mapChangedBodyIndices.erase(bodyRevision); // keep exactly one entry per body, at its latest revision
+    }
+    bodyRevision = ++_nCurrentRevision;
+    // the new revision is always the largest, so the entry always belongs at the end
+    _mapChangedBodyIndices.emplace_hint(_mapChangedBodyIndices.end(), bodyRevision, envBodyIndex);
+}
+
+void FCLSpace::CollectBodyIndicesChangedAfter(uint64_t sinceRevision, std::vector<int>& envBodyIndicesOut) const
+{
+    envBodyIndicesOut.resize(0);
+    for (std::map<uint64_t, int>::const_iterator it = _mapChangedBodyIndices.upper_bound(sinceRevision); it != _mapChangedBodyIndices.end(); ++it) {
+        envBodyIndicesOut.push_back(it->second);
+    }
+}
+
 void FCLSpace::RemoveUserData(KinBodyConstPtr pbody) {
     if( !!pbody ) {
         RAVELOG_VERBOSE(str(boost::format("FCL User data removed from env %d (userdatakey %s) : %s") % _penv->GetId() % _userdatakey % pbody->GetName()));
         const int envId = pbody->GetEnvironmentBodyIndex();
+        _MarkBodyChanged(envId); // consumers must drop their cached collision objects for this body
         if (envId < (int) _vecInitializedBodies.size()) {
             _vecInitializedBodies.at(envId).reset();
         }
@@ -663,6 +705,9 @@ void FCLSpace::_Synchronize(FCLKinBodyInfo& info, const KinBody& body)
     //KinBodyPtr pbody = info.GetBody();
     if( info.nLastStamp != body.GetUpdateStamp()) {
         info.nLastStamp = body.GetUpdateStamp();
+        // the collision objects of this info are about to move, so any manager caching them has to revisit it.
+        // the body is right here, so read the index off it rather than off info.nEnvBodyIndex
+        _MarkBodyChanged(body.GetEnvironmentBodyIndex());
         if( body.GetLinks().size() != info.vlinks.size() ) {
             throw OpenRAVE::OpenRAVEException(str(boost::format("env=%s, the current number of links in body '%s' are %d, and are not the same as the number cached links %d")%_penv->GetNameId()%body.GetName()%body.GetLinks().size()%info.vlinks.size()), OpenRAVE::ORE_InvalidState);
         }
@@ -704,12 +749,19 @@ private:
 void FCLSpace::_ResetCurrentGeometryCallback(boost::weak_ptr<FCLKinBodyInfo> _pinfo)
 {
     FCLKinBodyInfoPtr pinfo = _pinfo.lock();
+    if( !pinfo ) {
+        return;
+    }
     KinBodyPtr pbody = pinfo->GetBody();
+    if( !pbody ) {
+        return;
+    }
     const int bodyIndex = pbody->GetEnvironmentBodyIndex();
     if (0 < bodyIndex && bodyIndex < (int)_currentpinfo.size()) {
         const FCLKinBodyInfoPtr& pcurrentinfo = _currentpinfo.at(bodyIndex);
 
-        if (!!pinfo && pinfo == pcurrentinfo) { //pinfo->_geometrygroup.size() == 0 ) {
+        if (pinfo == pcurrentinfo) { //pinfo->_geometrygroup.size() == 0 ) {
+            _MarkBodyChanged(bodyIndex); // ahead of the mutation below, so a throwing reload still leaves a mark
             // pinfo is current set to the current one, so should InitKinBody into _currentpinfo
             //RAVELOG_VERBOSE_FORMAT("env=%d, resetting current geometry for kinbody %s nGeometryUpdateStamp=%d, (key %s, self=%d)", _penv->GetId()%pbody->GetName()%pinfo->nGeometryUpdateStamp%_userdatakey%_bIsSelfCollisionChecker);
             pinfo->nGeometryUpdateStamp++;
@@ -728,21 +780,26 @@ void FCLSpace::_ResetCurrentGeometryCallback(boost::weak_ptr<FCLKinBodyInfo> _pi
 void FCLSpace::_ResetGeometryGroupsCallback(boost::weak_ptr<FCLKinBodyInfo> _pinfo)
 {
     FCLKinBodyInfoPtr pinfo = _pinfo.lock();
+    if( !pinfo ) {
+        return;
+    }
     KinBodyPtr pbody = pinfo->GetBody();
+    if( !pbody ) {
+        return; // ReloadKinBodyLinks below dereferences pbody
+    }
+    _MarkBodyChanged(pbody->GetEnvironmentBodyIndex());
 
     //FCLKinBodyInfoPtr pcurrentinfo = _currentpinfo.at(pbody->GetEnvironmentBodyIndex());
 
-    if( !!pinfo ) {// && pinfo->_geometrygroup.size() > 0 ) {
-        //RAVELOG_VERBOSE_FORMAT("env=%d, resetting geometry groups for kinbody %s, nGeometryUpdateStamp=%d (key %s, self=%d)", _penv->GetId()%pbody->GetName()%pinfo->nGeometryUpdateStamp%_userdatakey%_bIsSelfCollisionChecker);
-        pinfo->nGeometryUpdateStamp++;
+    //RAVELOG_VERBOSE_FORMAT("env=%d, resetting geometry groups for kinbody %s, nGeometryUpdateStamp=%d (key %s, self=%d)", _penv->GetId()%pbody->GetName()%pinfo->nGeometryUpdateStamp%_userdatakey%_bIsSelfCollisionChecker);
+    pinfo->nGeometryUpdateStamp++;
 
-        // In order to ensure that the body is removed from the FCL space if something goes wrong during the reload process,
-        // create a scoped remover that will clear our user data for this body on scope exit. If the reload succeeds, we
-        // reset the scoped remover to prevent it clearing the data.
-        ScopedUserDataRemover userDataGuard{*this, pbody};
-        ReloadKinBodyLinks(pbody, pinfo);
-        userDataGuard.Reset();
-    }
+    // In order to ensure that the body is removed from the FCL space if something goes wrong during the reload process,
+    // create a scoped remover that will clear our user data for this body on scope exit. If the reload succeeds, we
+    // reset the scoped remover to prevent it clearing the data.
+    ScopedUserDataRemover userDataGuard{*this, pbody};
+    ReloadKinBodyLinks(pbody, pinfo);
+    userDataGuard.Reset();
 
 //   FCLKinBodyInfoPtr pinfoCurrentGeometry = _cachedpinfo[pbody->GetEnvironmentBodyIndex()][std::string()];
 //   _cachedpinfo.erase(pbody->GetEnvironmentBodyIndex());

--- a/plugins/fclrave/fclspace.h
+++ b/plugins/fclrave/fclspace.h
@@ -3,6 +3,7 @@
 #define OPENRAVE_FCL_SPACE
 
 #include <boost/shared_ptr.hpp>
+#include <map>
 #include <memory> // c++11
 #include <vector>
 
@@ -146,6 +147,7 @@ public:
         }
 
         KinBodyWeakPtr _pbody;
+        int nEnvBodyIndex = 0; ///< environment body index of _pbody, cached so change callbacks do not have to lock _pbody as well as the info
         int nLastStamp = 0; ///< KinBody::GetUpdateStamp() when last synchronized ("is transform up to date")
         int nLastLinkReloadStamp = 0; ///< KinBody::GetUpdateStamp() when we last ran ReloadKinBodyLinks
         int nLinkUpdateStamp = 0; ///< update stamp for link enable state (increases every time link enables change)
@@ -226,6 +228,23 @@ public:
         return _vecInitializedBodies;
     }
 
+    /// \brief revision of this space, incremented every time a body's FCLKinBodyInfo changes.
+    ///
+    /// Consumers that mirror FCLKinBodyInfo state in their own per-body caches record this value after
+    /// synchronizing, then pass it back to CollectBodyIndicesChangedAfter to revisit only what changed.
+    ///
+    /// Note this tracks changes to the *info*, not to the KinBody. Not every pose change reaches a change
+    /// callback (KinBody::Link::SetTransform bumps the body update stamp without firing one), so the mark
+    /// is set by _Synchronize when it actually refreshes an info, rather than at the point of mutation.
+    inline uint64_t GetCurrentRevision() const {
+        return _nCurrentRevision;
+    }
+
+    /// \brief replaces envBodyIndicesOut with the environment body indices recorded after sinceRevision.
+    /// Passing 0 returns every index this space has ever recorded, which is a superset of the currently
+    /// initialized bodies: indices of removed bodies stay in the log so consumers can drop their caches.
+    void CollectBodyIndicesChangedAfter(uint64_t sinceRevision, std::vector<int>& envBodyIndicesOut) const;
+
     inline CollisionObjectPtr GetLinkBV(const KinBody::Link &link) {
         return GetLinkBV(*link.GetParent(), link.GetIndex());
     }
@@ -284,6 +303,9 @@ private:
     /// \brief pass in info.GetBody() as a reference to avoid dereferencing the weak pointer in FCLKinBodyInfo
     void _Synchronize(FCLKinBodyInfo& info, const KinBody& body);
 
+    /// \brief record that the body at envBodyIndex changed, so cached consumers re-synchronize it
+    void _MarkBodyChanged(int envBodyIndex);
+
     /// \brief controls whether the kinbody info is removed during the destructor
     class FCLKinBodyInfoRemover
     {
@@ -313,6 +335,7 @@ private:
         FCLKinBodyInfoPtr pinfo = _pinfo.lock();
         if( !!pinfo ) {
             pinfo->nLinkUpdateStamp++;
+            _MarkBodyChanged(pinfo->nEnvBodyIndex);
         }
     }
 
@@ -320,6 +343,7 @@ private:
         FCLKinBodyInfoPtr pinfo = _pinfo.lock();
         if( !!pinfo ) {
             pinfo->nActiveDOFUpdateStamp++;
+            _MarkBodyChanged(pinfo->nEnvBodyIndex);
         }
     }
 
@@ -327,6 +351,7 @@ private:
         FCLKinBodyInfoPtr pinfo = _pinfo.lock();
         if( !!pinfo ) {
             pinfo->nAttachedBodiesUpdateStamp++;
+            _MarkBodyChanged(pinfo->nEnvBodyIndex);
         }
     }
 
@@ -344,6 +369,10 @@ private:
 
     std::vector<int> _vecAttachedEnvBodyIndicesCache; ///< cache
     std::vector<KinBodyPtr> _vecAttachedBodiesCache; ///< cache
+
+    uint64_t _nCurrentRevision = 0; ///< incremented every time any tracked body changes
+    std::vector<uint64_t> _vecBodyRevisions; ///< per environment body index, revision at which that body last changed. 0 means it has never been recorded
+    std::map<uint64_t, int> _mapChangedBodyIndices; ///< revision -> environment body index, one entry per recorded body. Ordered so that "changed after" queries only walk the tail
 
     bool _bIsSelfCollisionChecker; // Currently not used
 };

--- a/plugins/fclrave/fclspace.h
+++ b/plugins/fclrave/fclspace.h
@@ -2,9 +2,11 @@
 #ifndef OPENRAVE_FCL_SPACE
 #define OPENRAVE_FCL_SPACE
 
+#include <algorithm>
 #include <boost/shared_ptr.hpp>
 #include <map>
 #include <memory> // c++11
+#include <utility>
 #include <vector>
 
 namespace fclrave {
@@ -306,6 +308,14 @@ private:
     /// \brief record that the body at envBodyIndex changed, so cached consumers re-synchronize it
     void _MarkBodyChanged(int envBodyIndex);
 
+    /// \brief true if this entry is the body's latest, rather than one superseded by a later mark
+    inline bool _IsCurrentChangedBodyEntry(const std::pair<uint64_t, int>& entry) const {
+        return entry.second < (int)_vecBodyRevisions.size() && _vecBodyRevisions[entry.second] == entry.first;
+    }
+
+    /// \brief drop superseded entries from _vecChangedBodyIndices, keeping it sorted
+    void _CompactChangedBodyIndices();
+
     /// \brief controls whether the kinbody info is removed during the destructor
     class FCLKinBodyInfoRemover
     {
@@ -372,7 +382,8 @@ private:
 
     uint64_t _nCurrentRevision = 0; ///< incremented every time any tracked body changes
     std::vector<uint64_t> _vecBodyRevisions; ///< per environment body index, revision at which that body last changed. 0 means it has never been recorded
-    std::map<uint64_t, int> _mapChangedBodyIndices; ///< revision -> environment body index, one entry per recorded body. Ordered so that "changed after" queries only walk the tail
+    std::vector<std::pair<uint64_t, int> > _vecChangedBodyIndices; ///< (revision, environment body index) sorted by revision, so "changed after" queries binary search then walk the tail contiguously. Holds superseded entries, which _IsCurrentChangedBodyEntry skips
+    size_t _numCurrentChangedBodyEntries = 0; ///< number of bodies recorded at least once, i.e. how many entries of _vecChangedBodyIndices are not superseded
 
     bool _bIsSelfCollisionChecker; // Currently not used
 };


### PR DESCRIPTION
## Problem

`FCLCollisionChecker::_GetEnvManager` calls `FCLCollisionManagerInstance::EnsureBodies` and `Synchronize` on every environment-level `CheckCollision`, and both walked every cached body regardless of whether anything moved. The cost tracked environment size rather than amount of change: in a 200-body benchmark, moving **nothing** cost 6.9us per check and moving **all 200** cost 6.5us.

## Change

`FCLSpace` keeps a change log. `_MarkBodyChanged` records a body against a monotonic revision counter, `CollectBodyIndicesChangedAfter` returns the bodies recorded since a caller's last sync, and each manager keeps a cursor so it revisits only those.

The mark is set inside `FCLSpace::_Synchronize`, where an info is actually refreshed, rather than at the point of mutation. `KinBody::Link::SetTransform`, `KinBody::IncrementUpdateStamp` and `GetNonAdjacentLinks` bump the body update stamp without going through `_PostprocessChangedParameters`, so no change callback fires for them. Marking at the point of refresh covers those, and `FCLSpace::Synchronize` deliberately stays a full scan for the same reason -- its per-body cost is one integer compare.

Commit 2 stores the log in a vector sorted by revision rather than a `std::map`. Revisions only increase, so marking appends and a query binary searches once then walks contiguous memory; superseded entries are skipped on read and dropped by a compaction pass.

Commit 3 hardens the bookkeeping: marks are recorded before the mutation they describe, the manager cursor advances only after a whole `Synchronize` succeeded, teardown in `RemoveUserData`/`DestroyEnvironment` is indexed off the slot the body was initialized under, and attached bodies skipped because the space had not initialized them yet are retried.

Commit 4 fixes the active-DOF refresh caching a link BV it had just unregistered; the next refresh then unregistered (or `replaceObject`d) an object the broadphase manager does not hold.

Commit 5 applies the change log to `EnsureBodies` with its own cursor, separate from `Synchronize`'s so both consumers see the same marks. Recovery for a body the space stopped tracking is preserved: re-initializing it records a new mark in `InitKinBody`, which the cursor picks up. A valid cache entry holding a different body than the one now at that index is dropped and re-added instead of skipped.

## Results

Benchmark, 190 checks/cycle over 200 bodies: **~6.5us -> ~1.1us per check** (~2us after commits 1-2, ~1.1us after commit 5), and the cost now scales with how many bodies moved instead of being flat.

Commit 5 measured on its own, building the tree at commit 4 and at commit 5 and running the same benchmark:

| bodies moved | before commit 5 | after commit 5 | change |
|---|---|---|---|
| 0 | 1.86us | 1.07us | -42% |
| 1 | 1.61us | 1.20us | -25% |
| 10 | 1.58us | 1.10us | -30% |
| 50 | 1.86us | 1.18us | -37% |
| 100 | 1.61us | 1.06us | -34% |
| 200 | 2.03us | 1.13us | -44% |

Those are the minimum of several runs per configuration. The benchmark host is shared and noisy: individual runs of the same build vary by up to 2x, and the first run after a build is consistently slow from cold caches, so single numbers are not meaningful. The minimum is the honest estimator here because contention only ever adds time. What carries the conclusion is the floor rather than any single row: after commit 5 every row reached 1.06-1.20us in its best run, while before it never went below 1.58us on any row across three runs.

Profiled on a production fleet controller, share of the scheduling thread:

| | before | after commit 1 | after commit 2 |
|---|---|---|---|
| `FCLCollisionManagerInstance::Synchronize` | 46.5% | 15.4% | 11.2% |
| `CollectBodyIndicesChangedAfter` | - | 5.2% | 1.2% |

`EnsureBodies` was a further 8.2% of the same thread before commit 5.

## Testing

Re-run on the final tree unless noted:

- A randomized workload driving an articulated scene through `SetDOFValues`, `Link::SetTransform`, grab/release, active-DOF tracking, geometry group switches, link and body enabling, and adding and removing bodies mid-run. Each iteration answers the same query with the long-lived cached checker and with a checker created that instant; any disagreement is a stale cache. 17,598 comparisons, zero mismatches, and zero FCL `unregisterObject` warnings (commit 4 removes the 12 an earlier revision produced). An earlier revision that marked via a `Prop_LinkTransforms` callback fails it with 22 mismatches, so the check is sensitive to exactly this class of bug.
- A deterministic 20,000-iteration collision checksum: identical to an unpatched build.
- `test/test_collision.py` fcl suite: unchanged before and after.
- A downstream collision test suite of 578 tests: identical pass/fail sets before and after.
- Full integration run pinned to the first two commits: 1392 pass, 5 fail, all 5 reproduced on an unpatched baseline.

